### PR TITLE
Evaluation Tags (CUD) via Evaluation API

### DIFF
--- a/apps/backend/src/database/database.service.spec.ts
+++ b/apps/backend/src/database/database.service.spec.ts
@@ -7,14 +7,12 @@ describe('DatabaseSerivce', () => {
 
   beforeAll(async () => {
     const module = await Test.createTestingModule({
-      imports: [
-        DatabaseModule
-      ],
+      imports: [DatabaseModule],
       providers: [DatabaseService]
     }).compile();
 
     databaseService = module.get<DatabaseService>(DatabaseService);
-  })
+  });
 
   afterAll(async () => {
     await databaseService.cleanAll();
@@ -36,7 +34,7 @@ describe('DatabaseSerivce', () => {
       const source = [{id: 1}, {id: 2}, {id: 3}];
       const updated = [{id: 1}, {id: 2}, {id: 3}, {id: 4}];
 
-      const delta = databaseService.getDelta(source, updated)
+      const delta = databaseService.getDelta(source, updated);
 
       expect(delta.added.length).toEqual(1);
       expect(delta.changed.length).toEqual(3);
@@ -47,7 +45,7 @@ describe('DatabaseSerivce', () => {
       const source = [{id: 1, prop: 1}];
       const updated = [{id: 1, prop: 2}];
 
-      const delta = databaseService.getDelta(source, updated)
+      const delta = databaseService.getDelta(source, updated);
 
       expect(delta.added.length).toEqual(0);
       expect(delta.changed.length).toEqual(1);
@@ -60,7 +58,7 @@ describe('DatabaseSerivce', () => {
       const source = [{id: 1}, {id: 2}, {id: 3}, {id: 4}];
       const updated = [{id: 1}, {id: 2}, {id: 4}];
 
-      const delta = databaseService.getDelta(source, updated)
+      const delta = databaseService.getDelta(source, updated);
 
       expect(delta.added.length).toEqual(0);
       expect(delta.changed.length).toEqual(3);
@@ -71,7 +69,7 @@ describe('DatabaseSerivce', () => {
       const source = [];
       const updated = [{id: 1}, {id: 2}, {id: 3}, {id: 4}];
 
-      const delta = databaseService.getDelta(source, updated)
+      const delta = databaseService.getDelta(source, updated);
 
       expect(delta.added.length).toEqual(4);
       expect(delta.changed.length).toEqual(0);
@@ -82,7 +80,7 @@ describe('DatabaseSerivce', () => {
       const source = [{id: 1}, {id: 2}, {id: 3}, {id: 4}];
       const updated = [{id: 1}, {id: 2}, {id: 3}, {id: 4}];
 
-      const delta = databaseService.getDelta(source, updated)
+      const delta = databaseService.getDelta(source, updated);
 
       expect(delta.added.length).toEqual(0);
       expect(delta.changed.length).toEqual(4);
@@ -93,7 +91,7 @@ describe('DatabaseSerivce', () => {
       const source = [{id: 1}, {id: 2}, {id: 3}, {id: 4}];
       const updated = [];
 
-      const delta = databaseService.getDelta(source, updated)
+      const delta = databaseService.getDelta(source, updated);
 
       expect(delta.added.length).toEqual(0);
       expect(delta.changed.length).toEqual(0);

--- a/apps/backend/src/database/database.service.spec.ts
+++ b/apps/backend/src/database/database.service.spec.ts
@@ -44,14 +44,16 @@ describe('DatabaseSerivce', () => {
     });
 
     it('returns the correct value when an item is changed', async () => {
-      const source = [{id: 1}];
-      const updated = [{id: 1}];
+      const source = [{id: 1, prop: 1}];
+      const updated = [{id: 1, prop: 2}];
 
       const delta = databaseService.getDelta(source, updated)
 
       expect(delta.added.length).toEqual(0);
       expect(delta.changed.length).toEqual(1);
       expect(delta.deleted.length).toEqual(0);
+
+      expect(delta.changed[0].prop).toEqual(updated[0].prop);
     });
 
     it('returns the correct value when an item is deleted', async () => {

--- a/apps/backend/src/database/database.service.spec.ts
+++ b/apps/backend/src/database/database.service.spec.ts
@@ -1,0 +1,101 @@
+import {DatabaseService} from './database.service';
+import {DatabaseModule} from './database.module';
+import {Test} from '@nestjs/testing';
+
+describe('DatabaseSerivce', () => {
+  let databaseService: DatabaseService;
+
+  beforeAll(async () => {
+    const module = await Test.createTestingModule({
+      imports: [
+        DatabaseModule
+      ],
+      providers: [DatabaseService]
+    }).compile();
+
+    databaseService = module.get<DatabaseService>(DatabaseService);
+  })
+
+  afterAll(async () => {
+    await databaseService.cleanAll();
+    await databaseService.closeConnection();
+  });
+
+  describe('getDelta', () => {
+    it('returns the correct value when no items are given', async () => {
+      const source = [];
+      const updated = [];
+
+      const delta = databaseService.getDelta(source, updated);
+      expect(delta.added.length).toEqual(0);
+      expect(delta.changed.length).toEqual(0);
+      expect(delta.deleted.length).toEqual(0);
+    });
+
+    it('returns the correct value when an item is added', async () => {
+      const source = [{id: 1}, {id: 2}, {id: 3}];
+      const updated = [{id: 1}, {id: 2}, {id: 3}, {id: 4}];
+
+      const delta = databaseService.getDelta(source, updated)
+
+      expect(delta.added.length).toEqual(1);
+      expect(delta.changed.length).toEqual(3);
+      expect(delta.deleted.length).toEqual(0);
+    });
+
+    it('returns the correct value when an item is changed', async () => {
+      const source = [{id: 1}];
+      const updated = [{id: 1}];
+
+      const delta = databaseService.getDelta(source, updated)
+
+      expect(delta.added.length).toEqual(0);
+      expect(delta.changed.length).toEqual(1);
+      expect(delta.deleted.length).toEqual(0);
+    });
+
+    it('returns the correct value when an item is deleted', async () => {
+      const source = [{id: 1}, {id: 2}, {id: 3}, {id: 4}];
+      const updated = [{id: 1}, {id: 2}, {id: 4}];
+
+      const delta = databaseService.getDelta(source, updated)
+
+      expect(delta.added.length).toEqual(0);
+      expect(delta.changed.length).toEqual(3);
+      expect(delta.deleted.length).toEqual(1);
+    });
+
+    it('returns the correct value when all items are added', async () => {
+      const source = [];
+      const updated = [{id: 1}, {id: 2}, {id: 3}, {id: 4}];
+
+      const delta = databaseService.getDelta(source, updated)
+
+      expect(delta.added.length).toEqual(4);
+      expect(delta.changed.length).toEqual(0);
+      expect(delta.deleted.length).toEqual(0);
+    });
+
+    it('returns the correct value when all items are changed', async () => {
+      const source = [{id: 1}, {id: 2}, {id: 3}, {id: 4}];
+      const updated = [{id: 1}, {id: 2}, {id: 3}, {id: 4}];
+
+      const delta = databaseService.getDelta(source, updated)
+
+      expect(delta.added.length).toEqual(0);
+      expect(delta.changed.length).toEqual(4);
+      expect(delta.deleted.length).toEqual(0);
+    });
+
+    it('returns the correct value when all items are deleted', async () => {
+      const source = [{id: 1}, {id: 2}, {id: 3}, {id: 4}];
+      const updated = [];
+
+      const delta = databaseService.getDelta(source, updated)
+
+      expect(delta.added.length).toEqual(0);
+      expect(delta.changed.length).toEqual(0);
+      expect(delta.deleted.length).toEqual(4);
+    });
+  });
+});

--- a/apps/backend/src/database/database.service.ts
+++ b/apps/backend/src/database/database.service.ts
@@ -1,5 +1,6 @@
 import {Injectable} from '@nestjs/common';
 import {Sequelize} from 'sequelize-typescript';
+import {DeltaArgs} from './interfaces/delta-args.interface';
 
 @Injectable()
 export class DatabaseService {
@@ -14,4 +15,25 @@ export class DatabaseService {
       model.destroy({where: {}});
     });
   }
+
+  getDelta<T extends DeltaArgs>(source: Array<T>, updated: Array<T> ) {
+    if(source === undefined || updated === undefined) {
+      return {
+        added: [],
+        changed: [],
+        deleted: []
+      }
+    }
+
+    let added = updated.filter(updatedItem => source.find(sourceItem => sourceItem.id === updatedItem.id) === undefined);
+    let changed = source.filter(sourceItem => updated.find(updatedItem => updatedItem.id === sourceItem.id) !== undefined);
+    let deleted = source.filter(sourceItem => updated.find(updatedItem => updatedItem.id === sourceItem.id) === undefined);
+
+    return {
+      added: added,
+      changed: changed,
+      deleted: deleted
+    };
+  }
 }
+

--- a/apps/backend/src/database/database.service.ts
+++ b/apps/backend/src/database/database.service.ts
@@ -16,7 +16,7 @@ export class DatabaseService {
     });
   }
 
-  getDelta<T extends DeltaArgs>(source: Array<T>, updated: Array<T> ) {
+  getDelta<T extends DeltaArgs>(source: Array<T>, updated: Array<T>) {
     if(source === undefined || updated === undefined) {
       return {
         added: [],
@@ -26,7 +26,7 @@ export class DatabaseService {
     }
 
     let added = updated.filter(updatedItem => source.find(sourceItem => sourceItem.id === updatedItem.id) === undefined);
-    let changed = source.filter(sourceItem => updated.find(updatedItem => updatedItem.id === sourceItem.id) !== undefined);
+    let changed = updated.filter(updatedItem => source.find(sourceItem => sourceItem.id === updatedItem.id) !== undefined);
     let deleted = source.filter(sourceItem => updated.find(updatedItem => updatedItem.id === sourceItem.id) === undefined);
 
     return {

--- a/apps/backend/src/database/database.service.ts
+++ b/apps/backend/src/database/database.service.ts
@@ -17,17 +17,29 @@ export class DatabaseService {
   }
 
   getDelta<T extends DeltaArgs>(source: Array<T>, updated: Array<T>) {
-    if(source === undefined || updated === undefined) {
+    if (source === undefined || updated === undefined) {
       return {
         added: [],
         changed: [],
         deleted: []
-      }
+      };
     }
 
-    let added = updated.filter(updatedItem => source.find(sourceItem => sourceItem.id === updatedItem.id) === undefined);
-    let changed = updated.filter(updatedItem => source.find(sourceItem => sourceItem.id === updatedItem.id) !== undefined);
-    let deleted = source.filter(sourceItem => updated.find(updatedItem => updatedItem.id === sourceItem.id) === undefined);
+    const added = updated.filter(
+      updatedItem =>
+        source.find(sourceItem => sourceItem.id === updatedItem.id) ===
+        undefined
+    );
+    const changed = updated.filter(
+      updatedItem =>
+        source.find(sourceItem => sourceItem.id === updatedItem.id) !==
+        undefined
+    );
+    const deleted = source.filter(
+      sourceItem =>
+        updated.find(updatedItem => updatedItem.id === sourceItem.id) ===
+        undefined
+    );
 
     return {
       added: added,
@@ -36,4 +48,3 @@ export class DatabaseService {
     };
   }
 }
-

--- a/apps/backend/src/database/interfaces/delta-args.interface.ts
+++ b/apps/backend/src/database/interfaces/delta-args.interface.ts
@@ -1,3 +1,3 @@
 export interface DeltaArgs {
-  id: number
+  id: number;
 }

--- a/apps/backend/src/database/interfaces/delta-args.interface.ts
+++ b/apps/backend/src/database/interfaces/delta-args.interface.ts
@@ -1,0 +1,3 @@
+export interface DeltaArgs {
+  id: number
+}

--- a/apps/backend/src/evaluation-tags/dto/create-evaluation-tag.dto.ts
+++ b/apps/backend/src/evaluation-tags/dto/create-evaluation-tag.dto.ts
@@ -1,10 +1,23 @@
-import {IsNotEmpty} from 'class-validator';
+import {IsNotEmpty, IsString, IsNumber, Min, Max} from 'class-validator';
 import {ICreateEvaluationTag} from '@heimdall/interfaces';
 
 export class CreateEvaluationTagDto implements ICreateEvaluationTag {
   @IsNotEmpty()
+  @IsNumber()
+  @Min(0)
+  @Max(0)
+  readonly id: number;
+
+  @IsNotEmpty()
+  @IsString()
   readonly key: string;
 
   @IsNotEmpty()
+  @IsString()
   readonly value: string;
+
+  constructor(dto) {
+    this.key = dto.key;
+    this.value = dto.value;
+  }
 }

--- a/apps/backend/src/evaluation-tags/dto/delete-evaluation-tag.dto.ts
+++ b/apps/backend/src/evaluation-tags/dto/delete-evaluation-tag.dto.ts
@@ -1,6 +1,7 @@
 import {IsNotEmpty} from 'class-validator';
+import {IDeleteEvaluationTag} from '@heimdall/interfaces';
 
-export class DeleteEvaluationTagDto {
+export class DeleteEvaluationTagDto implements IDeleteEvaluationTag {
   @IsNotEmpty()
   readonly id: number;
 }

--- a/apps/backend/src/evaluation-tags/dto/delete-evaluation-tag.dto.ts
+++ b/apps/backend/src/evaluation-tags/dto/delete-evaluation-tag.dto.ts
@@ -1,0 +1,6 @@
+import {IsNotEmpty} from 'class-validator';
+
+export class DeleteEvaluationTagDto {
+  @IsNotEmpty()
+  readonly id: number;
+}

--- a/apps/backend/src/evaluation-tags/dto/update-evaluation-tag.dto.ts
+++ b/apps/backend/src/evaluation-tags/dto/update-evaluation-tag.dto.ts
@@ -7,7 +7,7 @@ import {IUpdateEvaluationTag} from '@heimdall/interfaces';
 
 export class UpdateEvaluationTagDto implements IUpdateEvaluationTag {
   @IsNumber()
-  readonly id: number
+  readonly id: number;
 
   @IsOptional()
   @IsString()

--- a/apps/backend/src/evaluation-tags/dto/update-evaluation-tag.dto.ts
+++ b/apps/backend/src/evaluation-tags/dto/update-evaluation-tag.dto.ts
@@ -1,10 +1,25 @@
-import {IsOptional} from 'class-validator';
+import {
+  IsOptional,
+  IsString,
+  IsNumber
+} from 'class-validator';
 import {IUpdateEvaluationTag} from '@heimdall/interfaces';
 
 export class UpdateEvaluationTagDto implements IUpdateEvaluationTag {
+  @IsNumber()
+  readonly id: number
+
   @IsOptional()
+  @IsString()
   readonly key: string;
 
   @IsOptional()
+  @IsString()
   readonly value: string;
+
+  constructor(dto) {
+    this.id = dto.id;
+    this.key = dto.key;
+    this.value = dto.value;
+  }
 }

--- a/apps/backend/src/evaluation-tags/dto/update-evaluation-tag.dto.ts
+++ b/apps/backend/src/evaluation-tags/dto/update-evaluation-tag.dto.ts
@@ -1,8 +1,4 @@
-import {
-  IsOptional,
-  IsString,
-  IsNumber
-} from 'class-validator';
+import {IsOptional, IsString, IsNumber} from 'class-validator';
 import {IUpdateEvaluationTag} from '@heimdall/interfaces';
 
 export class UpdateEvaluationTagDto implements IUpdateEvaluationTag {

--- a/apps/backend/src/evaluation-tags/evaluation-tags.service.ts
+++ b/apps/backend/src/evaluation-tags/evaluation-tags.service.ts
@@ -35,11 +35,10 @@ export class EvaluationTagsService {
   async update(
     id: number,
     updateEvaluationTagDto: UpdateEvaluationTagDto
-  ): Promise<EvaluationTagDto> {
+  ): Promise<EvaluationTag> {
     const evaluationTag = await EvaluationTag.findByPk<EvaluationTag>(id);
     this.exists(evaluationTag);
-    evaluationTag.update(updateEvaluationTagDto);
-    return new EvaluationTagDto(evaluationTag);
+    return await evaluationTag.update(updateEvaluationTagDto);
   }
 
   async remove(id: number): Promise<EvaluationTagDto> {

--- a/apps/backend/src/evaluations/dto/update-evaluation.dto.ts
+++ b/apps/backend/src/evaluations/dto/update-evaluation.dto.ts
@@ -1,7 +1,7 @@
 import {IsOptional} from 'class-validator';
-import {UpdateEvaluationTagDto} from '../../evaluation-tags/dto/update-evaluation-tag.dto';
 import {
   IUpdateEvaluation,
+  IUpdateEvaluationTagDto,
   ICreateEvaluationTagDto,
   IDeleteEvaluationTagDto
 } from '@heimdall/interfaces';
@@ -14,5 +14,10 @@ export class UpdateEvaluationDto implements IUpdateEvaluation {
   readonly data: Record<string, any>;
 
   @IsOptional()
-  readonly evaluationTags: (UpdateEvaluationTagDto|ICreateEvaluationTagDto|IDeleteEvaluationTagDto)[];
+  readonly evaluationTags: (
+    | IUpdateEvaluationTagDto
+    | ICreateEvaluationTagDto
+    | IDeleteEvaluationTagDto
+  )[];
+
 }

--- a/apps/backend/src/evaluations/dto/update-evaluation.dto.ts
+++ b/apps/backend/src/evaluations/dto/update-evaluation.dto.ts
@@ -1,10 +1,8 @@
 import {IsOptional} from 'class-validator';
-import {
-  IUpdateEvaluation,
-  IUpdateEvaluationTagDto,
-  ICreateEvaluationTagDto,
-  IDeleteEvaluationTagDto
-} from '@heimdall/interfaces';
+import {IUpdateEvaluation} from '@heimdall/interfaces';
+import {UpdateEvaluationTagDto} from '../../evaluation-tags/dto/update-evaluation-tag.dto';
+import {CreateEvaluationTagDto} from '../../evaluation-tags/dto/create-evaluation-tag.dto';
+import {DeleteEvaluationTagDto} from '../../evaluation-tags/dto/delete-evaluation-tag.dto';
 
 export class UpdateEvaluationDto implements IUpdateEvaluation {
   @IsOptional()
@@ -15,9 +13,8 @@ export class UpdateEvaluationDto implements IUpdateEvaluation {
 
   @IsOptional()
   readonly evaluationTags: (
-    | IUpdateEvaluationTagDto
-    | ICreateEvaluationTagDto
-    | IDeleteEvaluationTagDto
+    | UpdateEvaluationTagDto
+    | CreateEvaluationTagDto
+    | DeleteEvaluationTagDto
   )[];
-
 }

--- a/apps/backend/src/evaluations/dto/update-evaluation.dto.ts
+++ b/apps/backend/src/evaluations/dto/update-evaluation.dto.ts
@@ -1,6 +1,10 @@
 import {IsOptional} from 'class-validator';
 import {UpdateEvaluationTagDto} from '../../evaluation-tags/dto/update-evaluation-tag.dto';
-import {IUpdateEvaluation} from '@heimdall/interfaces';
+import {
+  IUpdateEvaluation,
+  ICreateEvaluationTagDto,
+  IDeleteEvaluationTagDto
+} from '@heimdall/interfaces';
 
 export class UpdateEvaluationDto implements IUpdateEvaluation {
   @IsOptional()
@@ -10,5 +14,5 @@ export class UpdateEvaluationDto implements IUpdateEvaluation {
   readonly data: Record<string, any>;
 
   @IsOptional()
-  readonly evaluationTags: UpdateEvaluationTagDto[];
+  readonly evaluationTags: (UpdateEvaluationTagDto|ICreateEvaluationTagDto|IDeleteEvaluationTagDto)[];
 }

--- a/apps/backend/src/evaluations/evaluations.service.spec.ts
+++ b/apps/backend/src/evaluations/evaluations.service.spec.ts
@@ -175,7 +175,9 @@ describe('EvaluationsService', () => {
     });
 
     it('should add additional evaluation tags to an evaluation', async () => {
-      const evaluation = await evaluationsService.create(EVALUATION_WITH_TAGS_1);
+      const evaluation = await evaluationsService.create(
+        EVALUATION_WITH_TAGS_1
+      );
       const updatedEvaluation = await evaluationsService.update(
         evaluation.id,
         UPDATE_EVALUATION_ADD_TAGS_1
@@ -190,8 +192,10 @@ describe('EvaluationsService', () => {
       expect(updatedEvaluation.evaluationTags).not.toEqual(
         evaluation.evaluationTags
       );
-      expect(updatedEvaluation.evaluationTags.length).toBeGreaterThan(evaluation.evaluationTags.length);
-      updatedEvaluation.evaluationTags.forEach((tag) => {
+      expect(updatedEvaluation.evaluationTags.length).toBeGreaterThan(
+        evaluation.evaluationTags.length
+      );
+      updatedEvaluation.evaluationTags.forEach(tag => {
         expect(tag.id).toBeDefined();
         expect(tag.createdAt).toBeDefined();
         expect(tag.updatedAt).toBeDefined();
@@ -199,7 +203,9 @@ describe('EvaluationsService', () => {
     });
 
     it('should remove tags from an evaluation', async () => {
-      const evaluation = await evaluationsService.create(EVALUATION_WITH_TAGS_1);
+      const evaluation = await evaluationsService.create(
+        EVALUATION_WITH_TAGS_1
+      );
       const updatedEvaluation = await evaluationsService.update(
         evaluation.id,
         UPDATE_EVALUATION_REMOVE_TAGS_1
@@ -218,17 +224,19 @@ describe('EvaluationsService', () => {
     });
 
     it('should update existing evaluation tags', async () => {
-      const evaluation = await evaluationsService.create(EVALUATION_WITH_TAGS_1);
+      const evaluation = await evaluationsService.create(
+        EVALUATION_WITH_TAGS_1
+      );
       const updateEvaluationTagDto: UpdateEvaluationTagDto = {
         id: evaluation.evaluationTags[0].id,
         key: 'updated key',
         value: 'updated value'
-      }
+      };
       const updateEvaluationDto: UpdateEvaluationDto = {
         data: undefined,
         version: undefined,
         evaluationTags: [updateEvaluationTagDto]
-      }
+      };
       const updatedEvaluation = await evaluationsService.update(
         evaluation.id,
         updateEvaluationDto
@@ -240,7 +248,9 @@ describe('EvaluationsService', () => {
       expect(updatedEvaluation.data).toEqual(evaluation.data);
       expect(updatedEvaluation.version).toEqual(evaluation.version);
       // ---
-      expect(updatedEvaluation.evaluationTags).not.toEqual(evaluation.evaluationTags);
+      expect(updatedEvaluation.evaluationTags).not.toEqual(
+        evaluation.evaluationTags
+      );
       expect(updatedEvaluation.evaluationTags.length).toEqual(1);
       const originalTag = evaluation.evaluationTags[0];
       const updatedTag = updatedEvaluation.evaluationTags[0];

--- a/apps/backend/src/evaluations/evaluations.service.spec.ts
+++ b/apps/backend/src/evaluations/evaluations.service.spec.ts
@@ -15,8 +15,12 @@ import {
   CREATE_EVALUATION_DTO_WITHOUT_DATA,
   CREATE_EVALUATION_DTO_WITHOUT_VERSION,
   UPDATE_EVALUATION_VERSION_ONLY,
-  UPDATE_EVALUATION_DATA_ONLY
+  UPDATE_EVALUATION_DATA_ONLY,
+  UPDATE_EVALUATION_ADD_TAGS_1,
+  UPDATE_EVALUATION_REMOVE_TAGS_1
 } from '../../test/constants/evaluations-test.constant';
+import {UpdateEvaluationTagDto} from '../evaluation-tags/dto/update-evaluation-tag.dto';
+import {UpdateEvaluationDto} from './dto/update-evaluation.dto';
 
 describe('EvaluationsService', () => {
   let evaluationsService: EvaluationsService;
@@ -170,13 +174,82 @@ describe('EvaluationsService', () => {
       expect(updatedEvaluation.version).not.toEqual(evaluation.version);
     });
 
-    // To be implemented after changing the update method to update EvaluationTags
+    it('should add additional evaluation tags to an evaluation', async () => {
+      const evaluation = await evaluationsService.create(EVALUATION_WITH_TAGS_1);
+      const updatedEvaluation = await evaluationsService.update(
+        evaluation.id,
+        UPDATE_EVALUATION_ADD_TAGS_1
+      );
+      expect(updatedEvaluation.id).toEqual(evaluation.id);
+      expect(updatedEvaluation.createdAt).toEqual(evaluation.createdAt);
+      expect(updatedEvaluation.data).toEqual(evaluation.data);
+      expect(updatedEvaluation.version).toEqual(evaluation.version);
+      // Evaluation was not updated, only assoc was.
+      expect(updatedEvaluation.updatedAt).toEqual(evaluation.updatedAt);
+      // ---
+      expect(updatedEvaluation.evaluationTags).not.toEqual(
+        evaluation.evaluationTags
+      );
+      expect(updatedEvaluation.evaluationTags.length).toBeGreaterThan(evaluation.evaluationTags.length);
+      updatedEvaluation.evaluationTags.forEach((tag) => {
+        expect(tag.id).toBeDefined();
+        expect(tag.createdAt).toBeDefined();
+        expect(tag.updatedAt).toBeDefined();
+      });
+    });
 
-    // it('should add additional evaluation tags to an evaluation', async () => {});
+    it('should remove tags from an evaluation', async () => {
+      const evaluation = await evaluationsService.create(EVALUATION_WITH_TAGS_1);
+      const updatedEvaluation = await evaluationsService.update(
+        evaluation.id,
+        UPDATE_EVALUATION_REMOVE_TAGS_1
+      );
+      expect(updatedEvaluation.id).toEqual(evaluation.id);
+      expect(updatedEvaluation.createdAt).toEqual(evaluation.createdAt);
+      expect(updatedEvaluation.data).toEqual(evaluation.data);
+      expect(updatedEvaluation.version).toEqual(evaluation.version);
+      // Evaluation was not updated, only assoc was.
+      expect(updatedEvaluation.updatedAt).toEqual(evaluation.updatedAt);
+      // ---
+      expect(updatedEvaluation.evaluationTags).not.toEqual(
+        evaluation.evaluationTags
+      );
+      expect(updatedEvaluation.evaluationTags.length).toEqual(0);
+    });
 
-    // it('should remove tags from an evaluation', async () => {});
-
-    // it('should update existing evaluation tags', async () => {});
+    it('should update existing evaluation tags', async () => {
+      const evaluation = await evaluationsService.create(EVALUATION_WITH_TAGS_1);
+      const updateEvaluationTagDto: UpdateEvaluationTagDto = {
+        id: evaluation.evaluationTags[0].id,
+        key: 'updated key',
+        value: 'updated value'
+      }
+      const updateEvaluationDto: UpdateEvaluationDto = {
+        data: undefined,
+        version: undefined,
+        evaluationTags: [updateEvaluationTagDto]
+      }
+      const updatedEvaluation = await evaluationsService.update(
+        evaluation.id,
+        updateEvaluationDto
+      );
+      expect(updatedEvaluation.id).toEqual(evaluation.id);
+      expect(updatedEvaluation.createdAt).toEqual(evaluation.createdAt);
+      // Evaluation was not updated, only assoc was.
+      expect(updatedEvaluation.updatedAt).toEqual(evaluation.updatedAt);
+      expect(updatedEvaluation.data).toEqual(evaluation.data);
+      expect(updatedEvaluation.version).toEqual(evaluation.version);
+      // ---
+      expect(updatedEvaluation.evaluationTags).not.toEqual(evaluation.evaluationTags);
+      expect(updatedEvaluation.evaluationTags.length).toEqual(1);
+      const originalTag = evaluation.evaluationTags[0];
+      const updatedTag = updatedEvaluation.evaluationTags[0];
+      expect(updatedTag.createdAt).toEqual(originalTag.createdAt);
+      expect(updatedTag.updatedAt).not.toEqual(originalTag.updatedAt);
+      expect(updatedTag.createdAt).toEqual(originalTag.createdAt);
+      expect(updatedTag.key).toEqual(updateEvaluationTagDto.key);
+      expect(updatedTag.value).toEqual(updateEvaluationTagDto.value);
+    });
 
     it('should only update data if provided', async () => {
       const evaluation = await evaluationsService.create(

--- a/apps/backend/src/evaluations/evaluations.service.ts
+++ b/apps/backend/src/evaluations/evaluations.service.ts
@@ -7,6 +7,9 @@ import {UpdateEvaluationDto} from './dto/update-evaluation.dto';
 import {EvaluationTagsService} from '../evaluation-tags/evaluation-tags.service';
 import {EvaluationTag} from '../evaluation-tags/evaluation-tag.model';
 import {DatabaseService} from '../database/database.service';
+import {CreateEvaluationTagDto} from '../evaluation-tags/dto/create-evaluation-tag.dto';
+import {UpdateEvaluationTagDto} from '../evaluation-tags/dto/update-evaluation-tag.dto';
+import {EvaluationTagDto} from '../evaluation-tags/dto/evaluation-tag.dto'
 
 @Injectable()
 export class EvaluationsService {
@@ -58,12 +61,47 @@ export class EvaluationsService {
       include: [EvaluationTag]
     });
     this.exists(evaluation);
-    const evaluationTagDelta = this.databaseService.getDelta(evaluation.evaluationTags, updateEvaluationDto.evaluationTags);
 
+    if(updateEvaluationDto.data !== undefined) {
+      evaluation.set('data', updateEvaluationDto.data);
+    }
 
-    evaluation.update(updateEvaluationDto);
-    const evaluationData = await evaluation.save();
-    return new EvaluationDto(evaluationData);
+    if(updateEvaluationDto.version !== undefined) {
+      evaluation.set('version', updateEvaluationDto.version);
+    }
+
+    if(updateEvaluationDto.evaluationTags !== undefined) {
+      const evaluationTagsDelta = this.databaseService.getDelta(
+        evaluation.evaluationTags,
+        updateEvaluationDto.evaluationTags
+      );
+
+      const createTagPromises = evaluationTagsDelta.added.map(async evaluationTag => {
+        return await this.evaluationTagsService.create(
+          evaluation.id,
+          new CreateEvaluationTagDto(evaluationTag),
+        );
+      });
+
+      const updateTagPromises = evaluationTagsDelta.changed.map(async evaluationTag => {
+        return await this.evaluationTagsService.update(
+          evaluationTag.id,
+          new UpdateEvaluationTagDto(evaluationTag),
+        )
+      });
+
+      const deleteTagPromises = evaluationTagsDelta.deleted.map(async evaluationTag => {
+        return await this.evaluationTagsService.remove(
+          evaluationTag.id,
+        );
+      });
+
+      const createTags = await Promise.all(createTagPromises);
+      const updateTags = await Promise.all(updateTagPromises);
+      await Promise.all(deleteTagPromises);
+      evaluation.set('evaluationTags', [...createTags, ...updateTags], {raw: true});
+    }
+    return new EvaluationDto(await evaluation.save());
   }
 
   async remove(id: number): Promise<EvaluationDto> {

--- a/apps/backend/src/evaluations/evaluations.service.ts
+++ b/apps/backend/src/evaluations/evaluations.service.ts
@@ -58,6 +58,9 @@ export class EvaluationsService {
       include: [EvaluationTag]
     });
     this.exists(evaluation);
+    const evaluationTagDelta = this.databaseService.getDelta(evaluation.evaluationTags, updateEvaluationDto.evaluationTags);
+
+
     evaluation.update(updateEvaluationDto);
     const evaluationData = await evaluation.save();
     return new EvaluationDto(evaluationData);

--- a/apps/backend/src/evaluations/evaluations.service.ts
+++ b/apps/backend/src/evaluations/evaluations.service.ts
@@ -9,7 +9,6 @@ import {EvaluationTag} from '../evaluation-tags/evaluation-tag.model';
 import {DatabaseService} from '../database/database.service';
 import {CreateEvaluationTagDto} from '../evaluation-tags/dto/create-evaluation-tag.dto';
 import {UpdateEvaluationTagDto} from '../evaluation-tags/dto/update-evaluation-tag.dto';
-import {EvaluationTagDto} from '../evaluation-tags/dto/evaluation-tag.dto'
 
 @Injectable()
 export class EvaluationsService {
@@ -62,44 +61,50 @@ export class EvaluationsService {
     });
     this.exists(evaluation);
 
-    if(updateEvaluationDto.data !== undefined) {
+    if (updateEvaluationDto.data !== undefined) {
       evaluation.set('data', updateEvaluationDto.data);
     }
 
-    if(updateEvaluationDto.version !== undefined) {
+    if (updateEvaluationDto.version !== undefined) {
       evaluation.set('version', updateEvaluationDto.version);
     }
 
-    if(updateEvaluationDto.evaluationTags !== undefined) {
+    if (updateEvaluationDto.evaluationTags !== undefined) {
       const evaluationTagsDelta = this.databaseService.getDelta(
         evaluation.evaluationTags,
         updateEvaluationDto.evaluationTags
       );
 
-      const createTagPromises = evaluationTagsDelta.added.map(async evaluationTag => {
-        return await this.evaluationTagsService.create(
-          evaluation.id,
-          new CreateEvaluationTagDto(evaluationTag),
-        );
-      });
+      const createTagPromises = evaluationTagsDelta.added.map(
+        async evaluationTag => {
+          return await this.evaluationTagsService.create(
+            evaluation.id,
+            new CreateEvaluationTagDto(evaluationTag)
+          );
+        }
+      );
 
-      const updateTagPromises = evaluationTagsDelta.changed.map(async evaluationTag => {
-        return await this.evaluationTagsService.update(
-          evaluationTag.id,
-          new UpdateEvaluationTagDto(evaluationTag),
-        )
-      });
+      const updateTagPromises = evaluationTagsDelta.changed.map(
+        async evaluationTag => {
+          return await this.evaluationTagsService.update(
+            evaluationTag.id,
+            new UpdateEvaluationTagDto(evaluationTag)
+          );
+        }
+      );
 
-      const deleteTagPromises = evaluationTagsDelta.deleted.map(async evaluationTag => {
-        return await this.evaluationTagsService.remove(
-          evaluationTag.id,
-        );
-      });
+      const deleteTagPromises = evaluationTagsDelta.deleted.map(
+        async evaluationTag => {
+          return await this.evaluationTagsService.remove(evaluationTag.id);
+        }
+      );
 
       const createTags = await Promise.all(createTagPromises);
       const updateTags = await Promise.all(updateTagPromises);
       await Promise.all(deleteTagPromises);
-      evaluation.set('evaluationTags', [...createTags, ...updateTags], {raw: true});
+      evaluation.set('evaluationTags', [...createTags, ...updateTags], {
+        raw: true
+      });
     }
     return new EvaluationDto(await evaluation.save());
   }

--- a/apps/backend/test/constants/evaluation-tags-test.constant.ts
+++ b/apps/backend/test/constants/evaluation-tags-test.constant.ts
@@ -22,20 +22,24 @@ export const EVALUATION_TAG_DTO: EvaluationTagDto = {
 };
 
 export const CREATE_EVALUATION_TAG_DTO: CreateEvaluationTagDto = {
+  id: 0,
   key: 'key string',
   value: 'value string'
 };
 
 // @ts-ignore
 export const CREATE_EVALUATION_TAG_DTO_MISSING_KEY: CreateEvaluationTagDto = {
+  id: 0,
   value: 'value string'
 };
 
 // @ts-ignore
 export const CREATE_EVALUATION_TAG_DTO_MISSING_VALUE: CreateEvaluationTagDto = {
+  id: 0,
   key: 'key string'
 };
 
+// @ts-ignore
 export const UPDATE_EVALUATION_TAG_DTO: UpdateEvaluationTagDto = {
   key: 'new key string',
   value: 'new value string'

--- a/apps/backend/test/constants/evaluations-test.constant.ts
+++ b/apps/backend/test/constants/evaluations-test.constant.ts
@@ -66,12 +66,12 @@ export const UPDATE_EVALUATION_TAG_ONLY: UpdateEvaluationDto = {
 // @ts-ignore
 export const UPDATE_EVALUATION_ADD_TAGS_1: UpdateEvaluationDto = {
   evaluationTags: [UPDATE_EVALUATION_TAG_DTO, CREATE_EVALUATION_TAG_DTO]
-}
+};
 
 // @ts-ignore
 export const UPDATE_EVALUATION_REMOVE_TAGS_1: UpdateEvaluationDto = {
   evaluationTags: []
-}
+};
 
 export const EVALUATION_DTO: EvaluationDto = {
   id: 9999,

--- a/apps/backend/test/constants/evaluations-test.constant.ts
+++ b/apps/backend/test/constants/evaluations-test.constant.ts
@@ -63,6 +63,16 @@ export const UPDATE_EVALUATION_TAG_ONLY: UpdateEvaluationDto = {
   evaluationTags: [UPDATE_EVALUATION_TAG_DTO]
 };
 
+// @ts-ignore
+export const UPDATE_EVALUATION_ADD_TAGS_1: UpdateEvaluationDto = {
+  evaluationTags: [UPDATE_EVALUATION_TAG_DTO, CREATE_EVALUATION_TAG_DTO]
+}
+
+// @ts-ignore
+export const UPDATE_EVALUATION_REMOVE_TAGS_1: UpdateEvaluationDto = {
+  evaluationTags: []
+}
+
 export const EVALUATION_DTO: EvaluationDto = {
   id: 9999,
   data: {},

--- a/libs/interfaces/evaluation-tag/delete-evaluation-tag.interface.ts
+++ b/libs/interfaces/evaluation-tag/delete-evaluation-tag.interface.ts
@@ -1,0 +1,3 @@
+export interface IDeleteEvaluationTag {
+  readonly id: number;
+}

--- a/libs/interfaces/evaluation/update-evaluation.interface.ts
+++ b/libs/interfaces/evaluation/update-evaluation.interface.ts
@@ -1,7 +1,15 @@
-import {IUpdateEvaluationTag} from '..';
+import {
+  IUpdateEvaluationTag,
+  ICreateEvaluationTag,
+  IDeleteEvaluationTag
+} from '..';
 
 export interface IUpdateEvaluation {
   readonly version: string;
   readonly data: Record<string, any>;
-  readonly evaluationTags: IUpdateEvaluationTag[];
+  readonly evaluationTags: (
+    | IUpdateEvaluationTag
+    | ICreateEvaluationTag
+    | IDeleteEvaluationTag
+  )[];
 }

--- a/libs/interfaces/index.ts
+++ b/libs/interfaces/index.ts
@@ -1,5 +1,6 @@
 export * from './evaluation-tag/create-evaluation-tag.interface';
 export * from './evaluation-tag/update-evaluation-tag.interface';
+export * from './evaluation-tag/delete-evaluation-tag.interface';
 export * from './evaluation-tag/evaluation-tag.interface';
 export * from './evaluation/create-evaluation.interface';
 export * from './evaluation/update-evaluation.interface';


### PR DESCRIPTION
This PR adds functionality that lets evaluation tags be created, updated and deleted when updating an evaluation.

There is no associated issue for this, but it adds some expected behavior.