### PR TITLE
Require developers to install lerna globally

### DIFF
--- a/.github/workflows/e2e-backend-tests.yml
+++ b/.github/workflows/e2e-backend-tests.yml
@@ -38,22 +38,19 @@ jobs:
        with:
         node-version: '12.x'
 
-     - name: Install lerna and dev dependencies
-       run: npm install
+     - name: Install lerna
+       run: npm install -g lerna
 
      - name: Install project dependencies
-       run: npx lerna bootstrap --hoist
-
-     - name: Run lint
-       run: npx lerna run lint:ci
+       run: lerna bootstrap --hoist
 
      - name: Copy .env-ci to .env
        run: cp apps/backend/test/.env-ci apps/backend/.env
 
      - name: Create/migrate db
        run: |
-        npx lerna exec "npx sequelize-cli db:create" --scope heimdall-server
-        npx lerna exec "npx sequelize-cli db:migrate" --scope heimdall-server
+        lerna exec "npx sequelize-cli db:create" --scope heimdall-server
+        lerna exec "npx sequelize-cli db:migrate" --scope heimdall-server
 
      - name: Run e2e tests
-       run: npx lerna run test:e2e --stream
+       run: lerna run test:e2e --stream

--- a/.github/workflows/e2e-ui-tests.yml
+++ b/.github/workflows/e2e-ui-tests.yml
@@ -38,23 +38,23 @@ jobs:
        with:
         node-version: '12.x'
 
-     - name: Install lerna and dev dependencies
-       run: npm install
+     - name: Install lerna
+       run: npm install -g lerna
 
      - name: Install project dependencies
-       run: npx lerna bootstrap --hoist
+       run: lerna bootstrap --hoist
 
      - name: Copy .env-ci to .env
        run: cp apps/backend/test/.env-ci apps/backend/.env
 
      - name: Create/migrate db
        run: |
-        npx lerna exec "npx sequelize-cli db:create" --scope heimdall-server
-        npx lerna exec "npx sequelize-cli db:migrate" --scope heimdall-server
+        lerna exec "npx sequelize-cli db:create" --scope heimdall-server
+        lerna exec "npx sequelize-cli db:migrate" --scope heimdall-server
 
      - name: Build frontend and server for E2E UI tests
        run: |
-        npx lerna run build
+        lerna run build
 
      - name: Run e2e UI tests
-       run: npx lerna run test:ui --stream
+       run: lerna run test:ui --stream

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -38,11 +38,11 @@ jobs:
        with:
         node-version: '12.x'
 
-     - name: Install lerna and dev dependencies
-       run: npm install
+     - name: Install lerna
+       run: npm install -g lerna
 
      - name: Install project dependencies
-       run: npx lerna bootstrap --hoist
+       run: lerna bootstrap --hoist
 
      - name: Run frontend tests
-       run: npx lerna run test --scope heimdall-lite --stream
+       run: lerna run test --scope heimdall-lite --stream

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -38,11 +38,11 @@ jobs:
        with:
         node-version: '12.x'
 
-     - name: Install lerna and dev dependencies
-       run: npm install
+     - name: Install lerna
+       run: npm install -g lerna
 
      - name: Install project dependencies
-       run: npx lerna bootstrap --hoist
+       run: lerna bootstrap --hoist
 
      - name: Run lint
-       run: npx lerna run lint:ci
+       run: lerna run lint:ci

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains the source code for the Heimdall 2 Backend and Frontend
 
 This project uses [Lerna](https://lerna.js.org/) (multi-project manager) to manage dependencies and run the applications. Installing dependencies can be done by running
 
-    npm install
+    npm install -g lerna
     npx lerna bootstrap --hoist
 
 ## How to Run

--- a/apps/frontend/vue.config.js
+++ b/apps/frontend/vue.config.js
@@ -18,7 +18,9 @@ module.exports = {
   publicPath: process.env.NODE_ENV === 'production' ? './' : '/',
   transpileDependencies: [/(\/|\\)vuetify(\/|\\)/],
   devServer: {
-    proxy: process.env.VUE_APP_API_URL
+    proxy: process.env.HEIMDALL_SERVER_PORT
+      ? 'http://127.0.0.1:' + process.env.HEIMDALL_SERVER_PORT
+      : ''
   },
   outputDir: '../../dist/frontend',
   configureWebpack: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16686,6 +16686,61 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
       "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
     },
+    "dotenv-cli": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv-cli/-/dotenv-cli-3.2.0.tgz",
+      "integrity": "sha512-zg/dfXISo7ntL3JKC+oj7eXEMg8LbOsARWTeypfVsmYtazDYOptmKLqA9u3LTee9x/sIPiLqmI6wskRP+89ohQ==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1",
+        "dotenv": "^8.1.0",
+        "dotenv-expand": "^5.1.0",
+        "minimist": "^1.1.3"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "dotenv-expand": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -2,20 +2,21 @@
   "name": "root",
   "private": true,
   "scripts": {
-    "start:dev": "VUE_APP_API_URL=http://localhost:3000 lerna exec 'npm run start:dev'",
-    "lite:dev": "lerna exec 'npm run start:dev' --scope heimdall-lite"
+    "start:dev": "dotenv -e apps/backend/.env lerna exec npm run start:dev",
+    "lite:dev": "lerna exec npm run start:dev --scope heimdall-lite"
   },
   "devDependencies": {
     "@types/jest": "^26.0.7",
     "@types/node": "^13.13.6",
+    "@typescript-eslint/eslint-plugin": "^2.34.0",
+    "@typescript-eslint/parser": "^2.34.0",
+    "dotenv-cli": "^3.2.0",
     "eslint": "^6.8.0",
     "eslint-plugin-prettier": "^3.1.4",
     "jest": "^26.4.2",
     "lerna": "^3.22.1",
     "prettier": "^1.19.1",
     "ts-jest": "^26.1.3",
-    "typescript": "^3.9.7",
-    "@typescript-eslint/eslint-plugin": "^2.34.0",
-    "@typescript-eslint/parser": "^2.34.0"
+    "typescript": "^3.9.7"
   }
 }


### PR DESCRIPTION
Using npm install to install lerna was bad practice since it was overwriting the 'package-lock.json' at the root of the repository. Developers now will need to directly install lerna and then use lerna to bootstrap dependencies.

This also fixes a few small problems causing difficulty developing the application on Windows.