### PR TITLE
Change single-expand and mutliple-expand to be reactive

### DIFF
--- a/apps/frontend/src/components/cards/controltable/ControlTable.vue
+++ b/apps/frontend/src/components/cards/controltable/ControlTable.vue
@@ -5,7 +5,7 @@
       <v-col cols="12">
         <v-switch
           v-model="single_expand"
-          label="Single expand"
+          :label="single_expand ? 'Single Expand' : 'Multiple Expand'"
           class="mt-2 "
         ></v-switch>
       </v-col>


### PR DESCRIPTION
This changes the the single-expand vs multi-expand switch to be reactive to the currently selected state.
![Screen Shot 2020-09-02 at 4 30 42 PM](https://user-images.githubusercontent.com/66680985/92033455-b2fc0100-ed39-11ea-935d-aeb110845920.png)
![Screen Shot 2020-09-02 at 4 31 15 PM](https://user-images.githubusercontent.com/66680985/92033501-c27b4a00-ed39-11ea-8d04-5b31451a89d1.png)
