### PR TITLE
Fix styling on search bar when clicking on it in lite/dark mode

### DIFF
--- a/apps/frontend/src/views/Compare.vue
+++ b/apps/frontend/src/views/Compare.vue
@@ -6,7 +6,6 @@
         v-model="search_term"
         flat
         solo
-        solo-inverted
         hide-details
         prepend-inner-icon="mdi-magnify"
         label="Search"

--- a/apps/frontend/src/views/Results.vue
+++ b/apps/frontend/src/views/Results.vue
@@ -5,9 +5,8 @@
       <v-text-field
         v-model="search_term"
         flat
-        solo
-        solo-inverted
         hide-details
+        solo
         prepend-inner-icon="mdi-magnify"
         label="Search"
         clearable


### PR DESCRIPTION
New behavior:
![Screen Shot 2020-09-10 at 12 21 01](https://user-images.githubusercontent.com/3009651/92763544-a7c05b00-f361-11ea-8026-6ee8b2602e2e.png)
![Screen Shot 2020-09-10 at 12 21 12](https://user-images.githubusercontent.com/3009651/92763555-aa22b500-f361-11ea-8ed6-5a91b37e51f4.png)

Closes #110 
