### PR TITLE
Add the ability to read all configuration from environment is no .env file is provided in the backend.

### DIFF
--- a/apps/backend/src/config/config.service.spec.ts
+++ b/apps/backend/src/config/config.service.spec.ts
@@ -1,6 +1,9 @@
 import mock from 'mock-fs';
 import {ConfigService} from './config.service';
-import {ENV_MOCK_FILE} from '../../test/constants/env-test.constant';
+import {
+  ENV_MOCK_FILE,
+  SIMPLE_ENV_MOCK_FILE
+} from '../../test/constants/env-test.constant';
 
 /* If you run the test without --silent , you need to add console.log() before you mock out the
 file system in the beforeAll() or it'll throw an error (this is a documented bug which can be
@@ -32,7 +35,7 @@ describe('Config Service', () => {
         'Does the file exist and is it readable by the current user?'
       );
       expect(consoleSpy).toHaveBeenCalledWith(
-        'Falling back to default or undefined values!'
+        'Falling back to environment or undefined values!'
       );
     });
   });
@@ -57,6 +60,27 @@ describe('Config Service', () => {
       );
       expect(configService.get('JWT_SECRET')).toEqual('abc123');
       expect(configService.get('NODE_ENV')).toEqual('test');
+    });
+
+    it('should return undefined because env variable does not exist', () => {
+      const configService = new ConfigService();
+      expect(configService.get('INVALID_VARIABLE')).toBe(undefined);
+    });
+  });
+
+  describe('Tests the get function when environment file is sourced externally', () => {
+    beforeAll(() => {
+      // Mock .env file
+      mock({
+        '.env-loaded-externally': SIMPLE_ENV_MOCK_FILE
+      });
+      require('dotenv').config({path: '.env-loaded-externally'});
+    });
+
+    it('should return the correct database name', () => {
+      const configService = new ConfigService();
+      console.log(process.env);
+      expect(configService.get('HEIMDALL_SERVER_PORT')).toEqual('8001');
     });
 
     it('should return undefined because env variable does not exist', () => {

--- a/apps/backend/src/config/config.service.ts
+++ b/apps/backend/src/config/config.service.ts
@@ -16,7 +16,7 @@ export class ConfigService {
         console.log(
           'Does the file exist and is it readable by the current user?'
         );
-        console.log('Falling back to default or undefined values!');
+        console.log('Falling back to environment or undefined values!');
       } else {
         throw error;
       }
@@ -28,7 +28,7 @@ export class ConfigService {
       return this.envConfig[key];
     } catch (error) {
       if (error instanceof TypeError) {
-        return undefined;
+        return process.env[key];
       } else {
         throw error;
       }

--- a/apps/backend/test/constants/env-test.constant.ts
+++ b/apps/backend/test/constants/env-test.constant.ts
@@ -7,3 +7,5 @@ export const ENV_MOCK_FILE =
   'DATABASE_NAME=heimdallts_jest_testing_service_db\n' +
   'JWT_SECRET=abc123\n' +
   'NODE_ENV=test\n';
+
+export const SIMPLE_ENV_MOCK_FILE = 'HEIMDALL_SERVER_PORT=8001\n';

--- a/apps/frontend/vue.config.js
+++ b/apps/frontend/vue.config.js
@@ -18,8 +18,12 @@ module.exports = {
   publicPath: process.env.NODE_ENV === 'production' ? './' : '/',
   transpileDependencies: [/(\/|\\)vuetify(\/|\\)/],
   devServer: {
-    proxy: process.env.HEIMDALL_SERVER_PORT
-      ? 'http://127.0.0.1:' + process.env.HEIMDALL_SERVER_PORT
+    // JWT_SECRET is a required secret for the backend. If it is sourced
+    // then it is safe to assume the app is in server mode in development.
+    // HEIMDALL_SERVER_PORT is not required so use the default backend port value
+    // is used here if JWT_SECRET is applied but HEIMDALL_SERVER_PORT is undefined
+    proxy: process.env.JWT_SECRET
+      ? 'http://127.0.0.1:' + (process.env.HEIMDALL_SERVER_PORT || 3000)
       : ''
   },
   outputDir: '../../dist/frontend',


### PR DESCRIPTION
This adds a fallback method for configuring the environment, instead of only supporting a `.env` file, it will now fallback to reading any variables that are sourced in the environment.

The order goes as follows:

.env in `apps/backend/.env`
`process.env`
undefined