### PR TITLE
Auto approve Dependabot PRs

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,12 @@
+name: Auto approve Dependabot PRs
+on: pull_request
+
+jobs:
+  approve:
+    name: Auto-approve dependabot PRs
+    if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: hmarr/auto-approve-action@v2.0.0
+      with:
+        github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This allows most PRs to require 1 review before merging, and will still require the tests to pass before the PR is automatically merged.