### PR TITLE
Enable typescript strict compiler option for backend

### DIFF
--- a/apps/backend/src/authz/policy.model.ts
+++ b/apps/backend/src/authz/policy.model.ts
@@ -16,30 +16,30 @@ export class Policy extends Model<Policy> {
   @AutoIncrement
   @AllowNull(false)
   @Column(DataType.BIGINT)
-  id: number;
+  id!: number;
 
   @AllowNull(false)
   @Column
-  role: string;
+  role!: string;
 
   @AllowNull(false)
   @Column
-  actions: string;
+  actions!: string;
 
   @AllowNull(false)
   @Column
-  targets: string;
+  targets!: string;
 
   @Column(DataType.JSON)
-  attributes: any;
+  attributes!: any;
 
   @CreatedAt
   @AllowNull(false)
   @Column
-  createdAt: Date;
+  createdAt!: Date;
 
   @UpdatedAt
   @AllowNull(false)
   @Column
-  updatedAt: Date;
+  updatedAt!: Date;
 }

--- a/apps/backend/src/config/config.service.ts
+++ b/apps/backend/src/config/config.service.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import {StartupSettingsDto} from './dto/startup-settings.dto';
 
 export class ConfigService {
-  private envConfig: {[key: string]: string};
+  private envConfig: {[key: string]: string | undefined};
 
   constructor() {
     console.log('Attempting to read configuration file `.env`!');
@@ -35,12 +35,14 @@ export class ConfigService {
   }
 
   private parseDatabaseUrl(): boolean {
-    if (!this.get('DATABASE_URL')) {
+    const url = this.get('DATABASE_URL');
+    if (url === undefined) {
       return false;
     } else {
-      const url = this.get('DATABASE_URL');
       const pattern = /^(?:([^:\/?#\s]+):\/{2})?(?:([^@\/?#\s]+)@)?([^\/?#\s]+)?(?:\/([^?#\s]*))?(?:[?]([^#\s]+))?\S*$/;
       const matches = url.match(pattern);
+
+      if (matches === null) return false;
 
       this.set(
         'DATABASE_USERNAME',
@@ -66,7 +68,7 @@ export class ConfigService {
     }
   }
 
-  set(key: string, value: string) {
+  set(key: string, value: string | undefined) {
     this.envConfig[key] = value;
   }
 

--- a/apps/backend/src/config/config.service.ts
+++ b/apps/backend/src/config/config.service.ts
@@ -42,7 +42,9 @@ export class ConfigService {
       const pattern = /^(?:([^:\/?#\s]+):\/{2})?(?:([^@\/?#\s]+)@)?([^\/?#\s]+)?(?:\/([^?#\s]*))?(?:[?]([^#\s]+))?\S*$/;
       const matches = url.match(pattern);
 
-      if (matches === null) return false;
+      if (matches === null) {
+        return false;
+      }
 
       this.set(
         'DATABASE_USERNAME',

--- a/apps/backend/src/database/database.module.ts
+++ b/apps/backend/src/database/database.module.ts
@@ -5,30 +5,26 @@ import {ConfigModule} from '../config/config.module';
 import {ConfigService} from '../config/config.service';
 
 function getDatabaseName(configService: ConfigService): string {
-  if (
-    configService.get('DATABASE_NAME') === undefined &&
-    configService.get('NODE_ENV') === undefined
-  ) {
+  const databaseName = configService.get('DATABASE_NAME');
+  const nodeEnvironment = configService.get('NODE_ENV');
+
+  if (databaseName !== undefined) {
+    return databaseName;
+  } else if (nodeEnvironment !== undefined) {
+    return `heimdall-server-${nodeEnvironment.toLowerCase()}`;
+  } else {
     throw new TypeError(
       'NODE_ENV and DATABASE_NAME are undefined. Unable to set database or use the default based on environment.'
     );
-  } else if (
-    configService.get('DATABASE_NAME') === undefined &&
-    configService.get('NODE_ENV') !== undefined
-  ) {
-    return `heimdall-server-${configService.get('NODE_ENV').toLowerCase()}`;
-  } else {
-    return configService.get('DATABASE_NAME');
   }
 }
 
 function getSynchronize(configService: ConfigService): boolean {
-  if (configService.get('NODE_ENV') === undefined) {
+  const nodeEnvironment = configService.get('NODE_ENV');
+  if (nodeEnvironment === undefined) {
     throw new TypeError('NODE_ENV is not set and must be provided.');
   } else {
-    return configService.get('NODE_ENV').toLowerCase() === 'test'
-      ? false
-      : true;
+    return nodeEnvironment === 'test' ? false : true;
   }
 }
 

--- a/apps/backend/src/database/database.service.ts
+++ b/apps/backend/src/database/database.service.ts
@@ -1,6 +1,7 @@
 import {Injectable} from '@nestjs/common';
 import {Sequelize} from 'sequelize-typescript';
 import {DeltaArgs} from './interfaces/delta-args.interface';
+import {IDelta} from './interfaces/delta.interface';
 
 @Injectable()
 export class DatabaseService {
@@ -16,7 +17,10 @@ export class DatabaseService {
     });
   }
 
-  getDelta<T extends DeltaArgs>(source: Array<T>, updated: Array<T>) {
+  getDelta<T extends DeltaArgs>(
+    source: Array<T>,
+    updated: Array<T>
+  ): IDelta<T> {
     if (source === undefined || updated === undefined) {
       return {
         added: [],

--- a/apps/backend/src/database/interfaces/delta.interface.ts
+++ b/apps/backend/src/database/interfaces/delta.interface.ts
@@ -1,0 +1,5 @@
+export interface IDelta<T> {
+  added: Array<T>;
+  changed: Array<T>;
+  deleted: Array<T>;
+}

--- a/apps/backend/src/evaluation-tags/dto/create-evaluation-tag.dto.ts
+++ b/apps/backend/src/evaluation-tags/dto/create-evaluation-tag.dto.ts
@@ -6,15 +6,15 @@ export class CreateEvaluationTagDto implements ICreateEvaluationTag {
   @IsNumber()
   @Min(0)
   @Max(0)
-  readonly id: number;
+  readonly id!: number;
 
   @IsNotEmpty()
   @IsString()
-  readonly key: string;
+  readonly key!: string;
 
   @IsNotEmpty()
   @IsString()
-  readonly value: string;
+  readonly value!: string;
 
   constructor(dto: CreateEvaluationTagDto) {
     this.key = dto.key;

--- a/apps/backend/src/evaluation-tags/dto/create-evaluation-tag.dto.ts
+++ b/apps/backend/src/evaluation-tags/dto/create-evaluation-tag.dto.ts
@@ -1,13 +1,7 @@
-import {IsNotEmpty, IsString, IsNumber, Min, Max} from 'class-validator';
+import {IsNotEmpty, IsString} from 'class-validator';
 import {ICreateEvaluationTag} from '@heimdall/interfaces';
 
 export class CreateEvaluationTagDto implements ICreateEvaluationTag {
-  @IsNotEmpty()
-  @IsNumber()
-  @Min(0)
-  @Max(0)
-  readonly id!: number;
-
   @IsNotEmpty()
   @IsString()
   readonly key!: string;

--- a/apps/backend/src/evaluation-tags/dto/delete-evaluation-tag.dto.ts
+++ b/apps/backend/src/evaluation-tags/dto/delete-evaluation-tag.dto.ts
@@ -5,13 +5,13 @@ export class DeleteEvaluationTagDto implements IDeleteEvaluationTag {
   @IsNotEmpty()
   @IsNumber()
   @Min(1)
-  readonly id: number;
+  readonly id!: number;
 
   @IsNotEmpty()
   @IsString()
-  readonly key: string;
+  readonly key!: string;
 
   @IsNotEmpty()
   @IsString()
-  readonly value: string;
+  readonly value!: string;
 }

--- a/apps/backend/src/evaluation-tags/evaluation-tag.model.ts
+++ b/apps/backend/src/evaluation-tags/evaluation-tag.model.ts
@@ -17,28 +17,28 @@ export class EvaluationTag extends Model<EvaluationTag> {
   @AutoIncrement
   @AllowNull(false)
   @Column(DataType.BIGINT)
-  id: number;
+  id!: number;
 
   @AllowNull(false)
   @Column
-  key: string;
+  key!: string;
 
   @AllowNull(false)
   @Column
-  value: string;
+  value!: string;
 
   @AllowNull(false)
   @Column
-  createdAt: Date;
+  createdAt!: Date;
 
   @AllowNull(false)
   @Column
-  updatedAt: Date;
+  updatedAt!: Date;
 
   @ForeignKey(() => Evaluation)
   @Column(DataType.BIGINT)
-  evaluationId: number;
+  evaluationId!: number;
 
   @BelongsTo(() => Evaluation)
-  evaluation: Evaluation;
+  evaluation!: Evaluation;
 }

--- a/apps/backend/src/evaluation-tags/evaluation-tags.controller.ts
+++ b/apps/backend/src/evaluation-tags/evaluation-tags.controller.ts
@@ -1,14 +1,54 @@
-import {Controller, UseGuards, Get} from '@nestjs/common';
+import {
+  Controller,
+  UseGuards,
+  Get,
+  Body,
+  Post,
+  Param,
+  Put,
+  Delete
+} from '@nestjs/common';
 import {EvaluationTagsService} from './evaluation-tags.service';
 import {JwtAuthGuard} from '../guards/jwt-auth.guard';
 import {EvaluationTagDto} from './dto/evaluation-tag.dto';
+import {CreateEvaluationTagDto} from './dto/create-evaluation-tag.dto';
+import {UpdateEvaluationTagDto} from './dto/update-evaluation-tag.dto';
 
 @Controller('evaluation-tags')
+@UseGuards(JwtAuthGuard)
 export class EvaluationTagsController {
   constructor(private evaluationTagsService: EvaluationTagsService) {}
-  @UseGuards(JwtAuthGuard)
   @Get()
   async index(): Promise<EvaluationTagDto[]> {
     return this.evaluationTagsService.findAll();
+  }
+
+  @Get(':id')
+  async findById(@Param('id') id: number): Promise<EvaluationTagDto> {
+    return this.evaluationTagsService.findById(id);
+  }
+
+  @Post()
+  async create(
+    @Param('evaluationId') evaluationId: number,
+    @Body() createEvaluationTagDto: CreateEvaluationTagDto
+  ): Promise<EvaluationTagDto> {
+    return this.evaluationTagsService.create(
+      evaluationId,
+      createEvaluationTagDto
+    );
+  }
+
+  @Put(':id')
+  async update(
+    @Param('id') id: number,
+    @Body() updateEvaluationTagDto: UpdateEvaluationTagDto
+  ): Promise<EvaluationTagDto> {
+    return this.evaluationTagsService.update(id, updateEvaluationTagDto);
+  }
+
+  @Delete(':id')
+  async remove(@Param('id') id: number): Promise<EvaluationTagDto> {
+    return this.evaluationTagsService.remove(id);
   }
 }

--- a/apps/backend/src/evaluation-tags/evaluation-tags.service.spec.ts
+++ b/apps/backend/src/evaluation-tags/evaluation-tags.service.spec.ts
@@ -4,11 +4,10 @@ import {DatabaseService} from '../database/database.service';
 import {EvaluationTagsService} from './evaluation-tags.service';
 import {EvaluationTag} from './evaluation-tag.model';
 import {SequelizeModule} from '@nestjs/sequelize';
-import {NotFoundException} from '@nestjs/common';
+
 import {Evaluation} from '../evaluations/evaluation.model';
 import {EvaluationsService} from '../evaluations/evaluations.service';
 import {
-  EVALUATION_TAG_1,
   CREATE_EVALUATION_TAG_DTO,
   CREATE_EVALUATION_TAG_DTO_MISSING_KEY,
   CREATE_EVALUATION_TAG_DTO_MISSING_VALUE,
@@ -46,20 +45,6 @@ describe('EvaluationTagsService', () => {
 
   beforeEach(() => {
     return databaseService.cleanAll();
-  });
-
-  describe('exists', () => {
-    it('throws an error when null', () => {
-      expect(() => {
-        evaluationTagsService.exists(null);
-      }).toThrow(NotFoundException);
-    });
-
-    it('returns true when given an EvaluationTag', () => {
-      expect(() => {
-        evaluationTagsService.exists(EVALUATION_TAG_1);
-      }).toBeTruthy();
-    });
   });
 
   describe('Create', () => {

--- a/apps/backend/src/evaluation-tags/evaluation-tags.service.ts
+++ b/apps/backend/src/evaluation-tags/evaluation-tags.service.ts
@@ -36,16 +36,12 @@ export class EvaluationTagsService {
     id: number,
     updateEvaluationTagDto: UpdateEvaluationTagDto
   ): Promise<EvaluationTag> {
-    const evaluationTag = await EvaluationTag.findByPk<EvaluationTag>(id);
-    this.exists(evaluationTag);
+    const evaluationTag = await this.findByPkBang(id);
     return evaluationTag.update(updateEvaluationTagDto);
   }
 
   async remove(id: number): Promise<EvaluationTagDto> {
-    const evaluationTag = await this.evaluationTagModel.findByPk<EvaluationTag>(
-      id
-    );
-    this.exists(evaluationTag);
+    const evaluationTag = await this.findByPkBang(id);
     await evaluationTag.destroy();
     return new EvaluationTagDto(evaluationTag);
   }
@@ -54,11 +50,16 @@ export class EvaluationTagsService {
     return new EvaluationTag(createEvaluationTagDto);
   }
 
-  exists(evaluationTag: EvaluationTag): boolean {
-    if (!evaluationTag) {
+  async findByPkBang(
+    identifier: string | number | Buffer | undefined
+  ): Promise<EvaluationTag> {
+    const evaluationTag = await EvaluationTag.findByPk<EvaluationTag>(
+      identifier
+    );
+    if (evaluationTag === null) {
       throw new NotFoundException('EvaluationTag with given id not found');
     } else {
-      return true;
+      return evaluationTag;
     }
   }
 }

--- a/apps/backend/src/evaluation-tags/evaluation-tags.service.ts
+++ b/apps/backend/src/evaluation-tags/evaluation-tags.service.ts
@@ -21,6 +21,11 @@ export class EvaluationTagsService {
     );
   }
 
+  async findById(id: number): Promise<EvaluationTagDto> {
+    const evaluationTag = await this.findByPkBang(id);
+    return new EvaluationTagDto(evaluationTag);
+  }
+
   async create(
     evaluationId: number,
     createEvaluationTagDto: CreateEvaluationTagDto

--- a/apps/backend/src/evaluations/dto/create-evaluation.dto.ts
+++ b/apps/backend/src/evaluations/dto/create-evaluation.dto.ts
@@ -11,13 +11,13 @@ import {ICreateEvaluation} from '@heimdall/interfaces';
 export class CreateEvaluationDto implements ICreateEvaluation {
   @IsNotEmpty()
   @IsString()
-  readonly filename: string;
+  readonly filename!: string;
 
   @IsNotEmpty()
   @IsObject()
-  readonly data: Record<string, any>;
+  readonly data!: Record<string, any>;
 
   @IsOptional()
   @IsArray()
-  readonly evaluationTags: CreateEvaluationTagDto[];
+  readonly evaluationTags: CreateEvaluationTagDto[] | undefined;
 }

--- a/apps/backend/src/evaluations/dto/evaluation.dto.ts
+++ b/apps/backend/src/evaluations/dto/evaluation.dto.ts
@@ -6,7 +6,7 @@ export class EvaluationDto implements IEvaluation {
   id: number;
   readonly filename: string;
   readonly data: Record<string, any>;
-  readonly evaluationTags: EvaluationTagDto[];
+  readonly evaluationTags: EvaluationTagDto[] | null;
   readonly createdAt: Date;
   readonly updatedAt: Date;
 
@@ -14,9 +14,16 @@ export class EvaluationDto implements IEvaluation {
     this.id = evaluation.id;
     this.filename = evaluation.filename;
     this.data = evaluation.data;
-    this.evaluationTags = evaluation.evaluationTags.map(
-      (tag) => new EvaluationTagDto(tag)
-    );
+    if (
+      evaluation.evaluationTags === null ||
+      evaluation.evaluationTags === undefined
+    ) {
+      this.evaluationTags = null;
+    } else {
+      this.evaluationTags = evaluation.evaluationTags.map(
+        (tag) => new EvaluationTagDto(tag)
+      );
+    }
     this.createdAt = evaluation.createdAt;
     this.updatedAt = evaluation.updatedAt;
   }

--- a/apps/backend/src/evaluations/dto/update-evaluation.dto.ts
+++ b/apps/backend/src/evaluations/dto/update-evaluation.dto.ts
@@ -7,17 +7,19 @@ import {DeleteEvaluationTagDto} from '../../evaluation-tags/dto/delete-evaluatio
 export class UpdateEvaluationDto implements IUpdateEvaluation {
   @IsOptional()
   @IsString()
-  readonly filename: string;
+  readonly filename: string | undefined;
 
   @IsOptional()
   @IsObject()
-  readonly data: Record<string, any>;
+  readonly data: Record<string, any> | undefined;
 
   @IsOptional()
   @IsArray()
-  readonly evaluationTags: (
-    | UpdateEvaluationTagDto
-    | CreateEvaluationTagDto
-    | DeleteEvaluationTagDto
-  )[];
+  readonly evaluationTags:
+    | (
+        | UpdateEvaluationTagDto
+        | CreateEvaluationTagDto
+        | DeleteEvaluationTagDto
+      )[]
+    | undefined;
 }

--- a/apps/backend/src/evaluations/dto/update-evaluation.dto.ts
+++ b/apps/backend/src/evaluations/dto/update-evaluation.dto.ts
@@ -1,8 +1,5 @@
-import {IsOptional, IsArray, IsString, IsObject} from 'class-validator';
+import {IsOptional, IsString, IsObject} from 'class-validator';
 import {IUpdateEvaluation} from '@heimdall/interfaces';
-import {UpdateEvaluationTagDto} from '../../evaluation-tags/dto/update-evaluation-tag.dto';
-import {CreateEvaluationTagDto} from '../../evaluation-tags/dto/create-evaluation-tag.dto';
-import {DeleteEvaluationTagDto} from '../../evaluation-tags/dto/delete-evaluation-tag.dto';
 
 export class UpdateEvaluationDto implements IUpdateEvaluation {
   @IsOptional()
@@ -12,14 +9,4 @@ export class UpdateEvaluationDto implements IUpdateEvaluation {
   @IsOptional()
   @IsObject()
   readonly data: Record<string, any> | undefined;
-
-  @IsOptional()
-  @IsArray()
-  readonly evaluationTags:
-    | (
-        | UpdateEvaluationTagDto
-        | CreateEvaluationTagDto
-        | DeleteEvaluationTagDto
-      )[]
-    | undefined;
 }

--- a/apps/backend/src/evaluations/evaluation.model.ts
+++ b/apps/backend/src/evaluations/evaluation.model.ts
@@ -18,26 +18,26 @@ export class Evaluation extends Model<Evaluation> {
   @AutoIncrement
   @AllowNull(false)
   @Column(DataType.BIGINT)
-  id: number;
+  id!: number;
 
   @AllowNull(false)
   @Column
-  filename: string;
+  filename!: string;
 
   @AllowNull(false)
   @Column(DataType.JSON)
-  data: Record<string, any>;
+  data!: Record<string, any>;
 
   @CreatedAt
   @AllowNull(false)
   @Column
-  createdAt: Date;
+  createdAt!: Date;
 
   @UpdatedAt
   @AllowNull(false)
   @Column
-  updatedAt: Date;
+  updatedAt!: Date;
 
   @HasMany(() => EvaluationTag)
-  evaluationTags: EvaluationTag[];
+  evaluationTags!: EvaluationTag[];
 }

--- a/apps/backend/src/evaluations/evaluation.model.ts
+++ b/apps/backend/src/evaluations/evaluation.model.ts
@@ -39,5 +39,5 @@ export class Evaluation extends Model<Evaluation> {
   updatedAt!: Date;
 
   @HasMany(() => EvaluationTag)
-  evaluationTags!: EvaluationTag[];
+  evaluationTags!: EvaluationTag[] | null;
 }

--- a/apps/backend/src/evaluations/evaluations.controller.ts
+++ b/apps/backend/src/evaluations/evaluations.controller.ts
@@ -39,7 +39,7 @@ export class EvaluationsController {
   async update(
     @Param('id') id: number,
     @Body() updateEvaluationDto: UpdateEvaluationDto
-  ): Promise<UpdateEvaluationDto> {
+  ): Promise<EvaluationDto> {
     return this.evaluationsService.update(id, updateEvaluationDto);
   }
 

--- a/apps/backend/src/evaluations/evaluations.service.spec.ts
+++ b/apps/backend/src/evaluations/evaluations.service.spec.ts
@@ -14,12 +14,8 @@ import {
   CREATE_EVALUATION_DTO_WITHOUT_DATA,
   CREATE_EVALUATION_DTO_WITHOUT_FILENAME,
   UPDATE_EVALUATION_FILENAME_ONLY,
-  UPDATE_EVALUATION_DATA_ONLY,
-  UPDATE_EVALUATION_ADD_TAGS_1,
-  UPDATE_EVALUATION_REMOVE_TAGS_1
+  UPDATE_EVALUATION_DATA_ONLY
 } from '../../test/constants/evaluations-test.constant';
-import {UpdateEvaluationTagDto} from '../evaluation-tags/dto/update-evaluation-tag.dto';
-import {UpdateEvaluationDto} from './dto/update-evaluation.dto';
 
 describe('EvaluationsService', () => {
   let evaluationsService: EvaluationsService;
@@ -91,9 +87,9 @@ describe('EvaluationsService', () => {
       expect(evaluation.createdAt).toBeDefined();
       expect(evaluation.data).toEqual(EVALUATION_WITH_TAGS_1.data);
       expect(evaluation.filename).toEqual(EVALUATION_WITH_TAGS_1.filename);
-      expect(evaluation.evaluationTags[0].evaluationId).toBeDefined();
-      expect(evaluation.evaluationTags[0].updatedAt).toBeDefined();
-      expect(evaluation.evaluationTags[0].createdAt).toBeDefined();
+      expect(evaluation.evaluationTags?.[0].evaluationId).toBeDefined();
+      expect(evaluation.evaluationTags?.[0].updatedAt).toBeDefined();
+      expect(evaluation.evaluationTags?.[0].createdAt).toBeDefined();
 
       if (EVALUATION_WITH_TAGS_1.evaluationTags === undefined) {
         throw new TypeError(
@@ -101,10 +97,10 @@ describe('EvaluationsService', () => {
         );
       }
 
-      expect(evaluation.evaluationTags[0].value).toEqual(
+      expect(evaluation.evaluationTags?.[0].value).toEqual(
         EVALUATION_WITH_TAGS_1.evaluationTags[0].value
       );
-      expect(evaluation.evaluationTags[0].key).toEqual(
+      expect(evaluation.evaluationTags?.[0].key).toEqual(
         EVALUATION_WITH_TAGS_1.evaluationTags[0].key
       );
     });
@@ -120,7 +116,7 @@ describe('EvaluationsService', () => {
       expect(evaluation.filename).toEqual(
         CREATE_EVALUATION_DTO_WITHOUT_TAGS.filename
       );
-      expect(evaluation.evaluationTags.length).toBe(0);
+      expect(evaluation.evaluationTags).toBeNull();
       expect((await evaluationTagsService.findAll()).length).toBe(0);
     });
 
@@ -141,7 +137,6 @@ describe('EvaluationsService', () => {
     });
   });
 
-  // Current update implementation will not cascade to the evaluation tags
   describe('update', () => {
     it('should throw an error if an evaluation does not exist', async () => {
       expect.assertions(1);
@@ -166,93 +161,6 @@ describe('EvaluationsService', () => {
       );
       expect(updatedEvaluation.data).not.toEqual(evaluation.data);
       expect(updatedEvaluation.filename).not.toEqual(evaluation.filename);
-    });
-
-    it('should add additional evaluation tags to an evaluation', async () => {
-      const evaluation = await evaluationsService.create(
-        EVALUATION_WITH_TAGS_1
-      );
-      const updatedEvaluation = await evaluationsService.update(
-        evaluation.id,
-        UPDATE_EVALUATION_ADD_TAGS_1
-      );
-      expect(updatedEvaluation.id).toEqual(evaluation.id);
-      expect(updatedEvaluation.createdAt).toEqual(evaluation.createdAt);
-      expect(updatedEvaluation.data).toEqual(evaluation.data);
-      expect(updatedEvaluation.filename).toEqual(evaluation.filename);
-      // Evaluation was not updated, only assoc was.
-      expect(updatedEvaluation.updatedAt).toEqual(evaluation.updatedAt);
-      // ---
-      expect(updatedEvaluation.evaluationTags).not.toEqual(
-        evaluation.evaluationTags
-      );
-      expect(updatedEvaluation.evaluationTags.length).toBeGreaterThan(
-        evaluation.evaluationTags.length
-      );
-      updatedEvaluation.evaluationTags.forEach((tag) => {
-        expect(tag.id).toBeDefined();
-        expect(tag.createdAt).toBeDefined();
-        expect(tag.updatedAt).toBeDefined();
-      });
-    });
-
-    it('should remove tags from an evaluation', async () => {
-      const evaluation = await evaluationsService.create(
-        EVALUATION_WITH_TAGS_1
-      );
-      const updatedEvaluation = await evaluationsService.update(
-        evaluation.id,
-        UPDATE_EVALUATION_REMOVE_TAGS_1
-      );
-      expect(updatedEvaluation.id).toEqual(evaluation.id);
-      expect(updatedEvaluation.createdAt).toEqual(evaluation.createdAt);
-      expect(updatedEvaluation.data).toEqual(evaluation.data);
-      expect(updatedEvaluation.filename).toEqual(evaluation.filename);
-      // Evaluation was not updated, only assoc was.
-      expect(updatedEvaluation.updatedAt).toEqual(evaluation.updatedAt);
-      // ---
-      expect(updatedEvaluation.evaluationTags).not.toEqual(
-        evaluation.evaluationTags
-      );
-      expect(updatedEvaluation.evaluationTags.length).toEqual(0);
-    });
-
-    it('should update existing evaluation tags', async () => {
-      const evaluation = await evaluationsService.create(
-        EVALUATION_WITH_TAGS_1
-      );
-      const updateEvaluationTagDto: UpdateEvaluationTagDto = {
-        id: evaluation.evaluationTags[0].id,
-        key: 'updated key',
-        value: 'updated value'
-      };
-      const updateEvaluationDto: UpdateEvaluationDto = {
-        data: undefined,
-        filename: undefined,
-        evaluationTags: [updateEvaluationTagDto]
-      };
-      const updatedEvaluation = await evaluationsService.update(
-        evaluation.id,
-        updateEvaluationDto
-      );
-      expect(updatedEvaluation.id).toEqual(evaluation.id);
-      expect(updatedEvaluation.createdAt).toEqual(evaluation.createdAt);
-      // Evaluation was not updated, only assoc was.
-      expect(updatedEvaluation.updatedAt).toEqual(evaluation.updatedAt);
-      expect(updatedEvaluation.data).toEqual(evaluation.data);
-      expect(updatedEvaluation.filename).toEqual(evaluation.filename);
-      // ---
-      expect(updatedEvaluation.evaluationTags).not.toEqual(
-        evaluation.evaluationTags
-      );
-      expect(updatedEvaluation.evaluationTags.length).toEqual(1);
-      const originalTag = evaluation.evaluationTags[0];
-      const updatedTag = updatedEvaluation.evaluationTags[0];
-      expect(updatedTag.createdAt).toEqual(originalTag.createdAt);
-      expect(updatedTag.updatedAt).not.toEqual(originalTag.updatedAt);
-      expect(updatedTag.createdAt).toEqual(originalTag.createdAt);
-      expect(updatedTag.key).toEqual(updateEvaluationTagDto.key);
-      expect(updatedTag.value).toEqual(updateEvaluationTagDto.value);
     });
 
     it('should only update data if provided', async () => {

--- a/apps/backend/src/evaluations/evaluations.service.spec.ts
+++ b/apps/backend/src/evaluations/evaluations.service.spec.ts
@@ -156,9 +156,6 @@ describe('EvaluationsService', () => {
       expect(updatedEvaluation.id).toEqual(evaluation.id);
       expect(updatedEvaluation.createdAt).toEqual(evaluation.createdAt);
       expect(updatedEvaluation.updatedAt).not.toEqual(evaluation.updatedAt);
-      expect(updatedEvaluation.evaluationTags).not.toEqual(
-        evaluation.evaluationTags
-      );
       expect(updatedEvaluation.data).not.toEqual(evaluation.data);
       expect(updatedEvaluation.filename).not.toEqual(evaluation.filename);
     });

--- a/apps/backend/src/evaluations/evaluations.service.spec.ts
+++ b/apps/backend/src/evaluations/evaluations.service.spec.ts
@@ -8,7 +8,6 @@ import {SequelizeModule} from '@nestjs/sequelize';
 import {Test} from '@nestjs/testing';
 import {NotFoundException} from '@nestjs/common';
 import {
-  EVALUATION,
   UPDATE_EVALUATION,
   EVALUATION_WITH_TAGS_1,
   CREATE_EVALUATION_DTO_WITHOUT_TAGS,
@@ -46,20 +45,6 @@ describe('EvaluationsService', () => {
 
   beforeEach(() => {
     return databaseService.cleanAll();
-  });
-
-  describe('exists', () => {
-    it('throws an error when null', async () => {
-      expect(() => {
-        evaluationsService.exists(null);
-      }).toThrow(NotFoundException);
-    });
-
-    it('returns true when given an evaluation', async () => {
-      expect(() => {
-        evaluationsService.exists(EVALUATION);
-      }).toBeTruthy();
-    });
   });
 
   describe('findAll', () => {
@@ -109,6 +94,13 @@ describe('EvaluationsService', () => {
       expect(evaluation.evaluationTags[0].evaluationId).toBeDefined();
       expect(evaluation.evaluationTags[0].updatedAt).toBeDefined();
       expect(evaluation.evaluationTags[0].createdAt).toBeDefined();
+
+      if (EVALUATION_WITH_TAGS_1.evaluationTags === undefined) {
+        throw new TypeError(
+          'Evaluation fixture does not have any assocaited tags.'
+        );
+      }
+
       expect(evaluation.evaluationTags[0].value).toEqual(
         EVALUATION_WITH_TAGS_1.evaluationTags[0].value
       );

--- a/apps/backend/src/evaluations/evaluations.service.ts
+++ b/apps/backend/src/evaluations/evaluations.service.ts
@@ -113,7 +113,7 @@ export class EvaluationsService {
     const evaluation = await this.findByPkBang(id, {
       include: [EvaluationTag]
     });
-    await this.databaseService.sequelize.transaction(async transaction => {
+    await this.databaseService.sequelize.transaction(async (transaction) => {
       await Promise.all([
         evaluation.evaluationTags.map(async (evaluationTag) => {
           await evaluationTag.destroy({transaction});

--- a/apps/backend/src/users/dto/create-user.dto.ts
+++ b/apps/backend/src/users/dto/create-user.dto.ts
@@ -4,34 +4,34 @@ import {ICreateUser} from '@heimdall/interfaces';
 export class CreateUserDto implements ICreateUser {
   @IsEmail()
   @IsNotEmpty()
-  readonly email: string;
+  readonly email!: string;
 
   @IsNotEmpty()
   @IsString()
-  readonly password: string;
+  readonly password!: string;
 
   @IsNotEmpty()
   @IsString()
-  readonly passwordConfirmation: string;
+  readonly passwordConfirmation!: string;
 
   @IsOptional()
   @IsString()
-  readonly firstName: string;
+  readonly firstName: string | undefined;
 
   @IsOptional()
   @IsString()
-  readonly lastName: string;
+  readonly lastName: string | undefined;
 
   @IsOptional()
   @IsString()
-  readonly organization: string;
+  readonly organization: string | undefined;
 
   @IsOptional()
   @IsString()
-  readonly title: string;
+  readonly title: string | undefined;
 
   @IsNotEmpty()
   @IsString()
   @IsIn(['user'])
-  readonly role: string;
+  readonly role!: string;
 }

--- a/apps/backend/src/users/dto/delete-user.dto.ts
+++ b/apps/backend/src/users/dto/delete-user.dto.ts
@@ -5,5 +5,5 @@ export class DeleteUserDto implements IDeleteUser {
   @IsNotEmpty()
   @IsString()
   @MinLength(15)
-  readonly password: string;
+  readonly password!: string;
 }

--- a/apps/backend/src/users/dto/update-user.dto.ts
+++ b/apps/backend/src/users/dto/update-user.dto.ts
@@ -11,42 +11,42 @@ import {IUpdateUser} from '@heimdall/interfaces';
 export class UpdateUserDto implements IUpdateUser {
   @IsEmail()
   @IsOptional()
-  readonly email: string;
+  readonly email: string | undefined;
 
   @IsOptional()
   @IsString()
-  readonly firstName: string;
+  readonly firstName!: string | undefined;
 
   @IsOptional()
   @IsString()
-  readonly lastName: string;
+  readonly lastName!: string | undefined;
 
   @IsOptional()
   @IsString()
-  readonly organization: string;
+  readonly organization!: string | undefined;
 
   @IsOptional()
   @IsString()
-  readonly title: string;
+  readonly title!: string | undefined;
 
   @IsOptional()
   @IsString()
   @IsIn(['user'])
-  readonly role: string;
+  readonly role: string | undefined;
 
   @IsOptional()
   @IsString()
-  readonly password: string;
+  readonly password: string | undefined;
 
   @IsOptional()
   @IsString()
-  readonly passwordConfirmation: string;
+  readonly passwordConfirmation: string | undefined;
 
   @IsOptional()
   @IsBoolean()
-  readonly forcePasswordChange: boolean;
+  readonly forcePasswordChange: boolean | undefined;
 
   @IsNotEmpty()
   @IsString()
-  readonly currentPassword: string;
+  readonly currentPassword!: string;
 }

--- a/apps/backend/src/users/dto/user.dto.ts
+++ b/apps/backend/src/users/dto/user.dto.ts
@@ -4,13 +4,13 @@ import {IUser} from '@heimdall/interfaces';
 export class UserDto implements IUser {
   id: number;
   readonly email: string;
-  readonly firstName: string;
-  readonly lastName: string;
-  readonly title: string;
+  readonly firstName: string | null;
+  readonly lastName: string | null;
+  readonly title: string | null;
   readonly role: string;
-  readonly organization: string;
+  readonly organization: string | null;
   readonly loginCount: number;
-  readonly lastLogin: Date;
+  readonly lastLogin: Date | null;
   readonly createdAt: Date;
   readonly updatedAt: Date;
 

--- a/apps/backend/src/users/user.model.ts
+++ b/apps/backend/src/users/user.model.ts
@@ -24,58 +24,58 @@ export class User extends Model<User> {
   @Unique
   @IsEmail
   @AllowNull(false)
-  @Column
+  @Column(DataType.STRING)
   email!: string;
 
   @AllowNull(true)
-  @Column
+  @Column(DataType.STRING)
   firstName!: string | null;
 
   @AllowNull(true)
-  @Column
+  @Column(DataType.STRING)
   lastName!: string | null;
 
   @AllowNull(true)
-  @Column
+  @Column(DataType.STRING)
   organization!: string | null;
 
   @AllowNull(true)
-  @Column
+  @Column(DataType.STRING)
   title!: string | null;
 
   @AllowNull(false)
-  @Column
+  @Column(DataType.STRING)
   encryptedPassword!: string;
 
   @AllowNull(true)
-  @Column
+  @Column(DataType.BOOLEAN)
   forcePasswordChange!: boolean | null;
 
   @AllowNull(true)
-  @Column
+  @Column(DataType.DATE)
   lastLogin!: Date | null;
 
   @AllowNull(false)
   @Default(0)
-  @Column
+  @Column(DataType.BIGINT)
   loginCount!: number;
 
   @AllowNull(true)
-  @Column
+  @Column(DataType.DATE)
   passwordChangedAt!: Date | null;
 
   @AllowNull(false)
   @Default('user')
-  @Column
+  @Column(DataType.STRING)
   role!: string;
 
   @CreatedAt
   @AllowNull(false)
-  @Column
+  @Column(DataType.DATE)
   createdAt!: Date;
 
   @UpdatedAt
   @AllowNull(false)
-  @Column
+  @Column(DataType.DATE)
   updatedAt!: Date;
 }

--- a/apps/backend/src/users/user.model.ts
+++ b/apps/backend/src/users/user.model.ts
@@ -19,63 +19,63 @@ export class User extends Model<User> {
   @AutoIncrement
   @AllowNull(false)
   @Column(DataType.BIGINT)
-  id: number;
+  id!: number;
 
   @Unique
   @IsEmail
   @AllowNull(false)
   @Column
-  email: string;
+  email!: string;
 
   @AllowNull(true)
   @Column
-  firstName: string;
+  firstName!: string | null;
 
   @AllowNull(true)
   @Column
-  lastName: string;
+  lastName!: string | null;
 
   @AllowNull(true)
   @Column
-  organization: string;
+  organization!: string | null;
 
   @AllowNull(true)
   @Column
-  title: string;
+  title!: string | null;
 
   @AllowNull(false)
   @Column
-  encryptedPassword: string;
+  encryptedPassword!: string;
 
   @AllowNull(true)
   @Column
-  forcePasswordChange: boolean;
+  forcePasswordChange!: boolean | null;
 
   @AllowNull(true)
   @Column
-  lastLogin: Date;
+  lastLogin!: Date | null;
 
   @AllowNull(false)
   @Default(0)
   @Column
-  loginCount: number;
+  loginCount!: number;
 
   @AllowNull(true)
   @Column
-  passwordChangedAt: Date;
+  passwordChangedAt!: Date | null;
 
   @AllowNull(false)
   @Default('user')
   @Column
-  role: string;
+  role!: string;
 
   @CreatedAt
   @AllowNull(false)
   @Column
-  createdAt: Date;
+  createdAt!: Date;
 
   @UpdatedAt
   @AllowNull(false)
   @Column
-  updatedAt: Date;
+  updatedAt!: Date;
 }

--- a/apps/backend/src/users/users.service.spec.ts
+++ b/apps/backend/src/users/users.service.spec.ts
@@ -196,6 +196,13 @@ describe('UsersService', () => {
     it('should update a user', async () => {
       const user = await usersService.create(CREATE_USER_DTO_TEST_OBJ);
       const beforeUpdate = await User.findByPk<User>(user.id);
+
+      if (beforeUpdate === null) {
+        throw new TypeError(
+          'User that was just created was not returned from the database. Create method may have failed silently.'
+        );
+      }
+
       const updatedUser = await usersService.update(
         user.id,
         UPDATE_USER_DTO_TEST_OBJ,
@@ -223,7 +230,7 @@ describe('UsersService', () => {
       // This will not change currently because there is only a 'user' role that can be updated via API.
       expect(updatedUser.role).toEqual(user.role);
       expect(beforeUpdate.forcePasswordChange).not.toEqual(
-        afterUpdate.forcePasswordChange
+        afterUpdate?.forcePasswordChange
       );
     });
 
@@ -327,6 +334,11 @@ describe('UsersService', () => {
     it('should update a user without updating password', async () => {
       const user = await usersService.create(CREATE_USER_DTO_TEST_OBJ);
       const beforeUpdate = await User.findByPk<User>(user.id);
+      if (beforeUpdate === null) {
+        throw new TypeError(
+          'User that was just created was not returned from the database. Create method may have failed silently.'
+        );
+      }
       await usersService.update(
         user.id,
         UPDATE_USER_DTO_WITHOUT_PASSWORD_FIELDS,
@@ -334,28 +346,28 @@ describe('UsersService', () => {
       );
       const updatedUser = await User.findByPk<User>(user.id);
 
-      expect(updatedUser.email).toEqual(
+      expect(updatedUser?.email).toEqual(
         UPDATE_USER_DTO_WITHOUT_PASSWORD_FIELDS.email
       );
-      expect(updatedUser.firstName).toEqual(
+      expect(updatedUser?.firstName).toEqual(
         UPDATE_USER_DTO_WITHOUT_PASSWORD_FIELDS.firstName
       );
-      expect(updatedUser.lastName).toEqual(
+      expect(updatedUser?.lastName).toEqual(
         UPDATE_USER_DTO_WITHOUT_PASSWORD_FIELDS.lastName
       );
-      expect(updatedUser.organization).toEqual(
+      expect(updatedUser?.organization).toEqual(
         UPDATE_USER_DTO_WITHOUT_PASSWORD_FIELDS.organization
       );
-      expect(updatedUser.title).toEqual(
+      expect(updatedUser?.title).toEqual(
         UPDATE_USER_DTO_WITHOUT_PASSWORD_FIELDS.title
       );
-      expect(updatedUser.role).toEqual(
+      expect(updatedUser?.role).toEqual(
         UPDATE_USER_DTO_WITHOUT_PASSWORD_FIELDS.role
       );
-      expect(updatedUser.encryptedPassword).toEqual(
+      expect(updatedUser?.encryptedPassword).toEqual(
         beforeUpdate.encryptedPassword
       );
-      expect(updatedUser.updatedAt.valueOf()).not.toEqual(
+      expect(updatedUser?.updatedAt.valueOf()).not.toEqual(
         user.updatedAt.valueOf()
       );
     });
@@ -421,17 +433,16 @@ describe('UsersService', () => {
       const lastLogin = user.lastLogin;
       const createdUser = await User.findByPk<User>(user.id);
 
+      if (createdUser === null) {
+        throw new TypeError(
+          'User that was just created was not returned from the database. Create method may have failed silently.'
+        );
+      }
+
       await usersService.updateLoginMetadata(createdUser);
 
       expect(createdUser.loginCount).toBe(1);
       expect(createdUser.lastLogin).not.toBe(lastLogin);
-    });
-
-    it('should fail because user passed is null', async () => {
-      expect.assertions(1);
-      await expect(usersService.updateLoginMetadata(null)).rejects.toThrow(
-        NotFoundException
-      );
     });
   });
 

--- a/apps/backend/src/users/users.service.spec.ts
+++ b/apps/backend/src/users/users.service.spec.ts
@@ -9,7 +9,6 @@ import {
 import {SequelizeModule} from '@nestjs/sequelize';
 import {User} from './user.model';
 import {
-  TEST_USER,
   USER_ONE_DTO,
   CREATE_USER_DTO_TEST_OBJ,
   DELETE_USER_DTO_TEST_OBJ,
@@ -51,20 +50,6 @@ describe('UsersService', () => {
 
   beforeEach(() => {
     return databaseService.cleanAll();
-  });
-
-  describe('exists', () => {
-    it('throws an error when null', async () => {
-      expect(() => {
-        usersService.exists(null);
-      }).toThrow(NotFoundException);
-    });
-
-    it('returns true when given a User', async () => {
-      expect(() => {
-        usersService.exists(TEST_USER);
-      }).toBeTruthy();
-    });
   });
 
   describe('Create', () => {

--- a/apps/backend/src/users/users.service.spec.ts
+++ b/apps/backend/src/users/users.service.spec.ts
@@ -37,6 +37,8 @@ import {DatabaseService} from '../database/database.service';
 describe('UsersService', () => {
   let usersService: UsersService;
   let databaseService: DatabaseService;
+  const errorString =
+    'User that was just created was not returned from the database. Create method may have failed silently.';
 
   beforeAll(async () => {
     const module = await Test.createTestingModule({
@@ -183,9 +185,7 @@ describe('UsersService', () => {
       const beforeUpdate = await User.findByPk<User>(user.id);
 
       if (beforeUpdate === null) {
-        throw new TypeError(
-          'User that was just created was not returned from the database. Create method may have failed silently.'
-        );
+        throw new TypeError(errorString);
       }
 
       const updatedUser = await usersService.update(
@@ -320,9 +320,7 @@ describe('UsersService', () => {
       const user = await usersService.create(CREATE_USER_DTO_TEST_OBJ);
       const beforeUpdate = await User.findByPk<User>(user.id);
       if (beforeUpdate === null) {
-        throw new TypeError(
-          'User that was just created was not returned from the database. Create method may have failed silently.'
-        );
+        throw new TypeError(errorString);
       }
       await usersService.update(
         user.id,
@@ -419,9 +417,7 @@ describe('UsersService', () => {
       const createdUser = await User.findByPk<User>(user.id);
 
       if (createdUser === null) {
-        throw new TypeError(
-          'User that was just created was not returned from the database. Create method may have failed silently.'
-        );
+        throw new TypeError(errorString);
       }
 
       await usersService.updateLoginMetadata(createdUser);

--- a/apps/backend/src/users/users.service.ts
+++ b/apps/backend/src/users/users.service.ts
@@ -40,12 +40,11 @@ export class UsersService {
   }
 
   async findModelByEmail(email: string): Promise<User> {
-    const user = await this.findOneBang({
+    return this.findOneBang({
       where: {
         email
       }
     });
-    return user;
   }
 
   async create(createUserDto: CreateUserDto) {

--- a/apps/backend/src/users/users.service.ts
+++ b/apps/backend/src/users/users.service.ts
@@ -11,6 +11,7 @@ import {CreateUserDto} from './dto/create-user.dto';
 import {UpdateUserDto} from './dto/update-user.dto';
 import {DeleteUserDto} from './dto/delete-user.dto';
 import {hash, compare} from 'bcrypt';
+import {FindOptions} from 'sequelize/types';
 
 @Injectable()
 export class UsersService {
@@ -25,38 +26,35 @@ export class UsersService {
   }
 
   async findById(id: number): Promise<UserDto> {
-    const user = await this.userModel.findByPk<User>(id);
-    this.exists(user);
+    const user = await this.findByPkBang(id);
     return new UserDto(user);
   }
 
   async findByEmail(email: string): Promise<UserDto> {
-    const user = await this.userModel.findOne<User>({
+    const user = await this.findOneBang({
       where: {
         email
       }
     });
-    this.exists(user);
     return new UserDto(user);
   }
 
   async findModelByEmail(email: string): Promise<User> {
-    const user = await this.userModel.findOne<User>({
+    const user = await this.findOneBang({
       where: {
         email
       }
     });
-    this.exists(user);
     return user;
   }
 
   async create(createUserDto: CreateUserDto) {
     const user = new User();
     user.email = createUserDto.email;
-    user.firstName = createUserDto.firstName;
-    user.lastName = createUserDto.lastName;
-    user.title = createUserDto.title;
-    user.organization = createUserDto.organization;
+    user.firstName = createUserDto.firstName || null;
+    user.lastName = createUserDto.lastName || null;
+    user.title = createUserDto.title || null;
+    user.organization = createUserDto.organization || null;
     user.role = createUserDto.role;
     try {
       user.encryptedPassword = await hash(createUserDto.password, 14);
@@ -68,8 +66,7 @@ export class UsersService {
   }
 
   async update(id: number, updateUserDto: UpdateUserDto, isAdmin: boolean) {
-    const user = await this.userModel.findByPk<User>(id);
-    this.exists(user);
+    const user = await this.findByPkBang(id);
     if (!isAdmin) {
       await this.testPassword(updateUserDto, user);
     }
@@ -93,7 +90,6 @@ export class UsersService {
   }
 
   async updateLoginMetadata(user: User) {
-    this.exists(user);
     const id = user.id;
     user.lastLogin = new Date();
     user.loginCount++;
@@ -105,8 +101,7 @@ export class UsersService {
   }
 
   async remove(id: number, deleteUserDto: DeleteUserDto) {
-    const user = await this.userModel.findByPk<User>(id);
-    this.exists(user);
+    const user = await this.findByPkBang(id);
     try {
       if (!(await compare(deleteUserDto.password, user.encryptedPassword))) {
         throw new UnauthorizedException();
@@ -118,11 +113,23 @@ export class UsersService {
     return new UserDto(user);
   }
 
-  exists(user: User): boolean {
-    if (!user) {
+  async findByPkBang(
+    identifier: string | number | Buffer | undefined
+  ): Promise<User> {
+    const user = await this.userModel.findByPk<User>(identifier);
+    if (user === null) {
       throw new NotFoundException('User with given id not found');
     } else {
-      return true;
+      return user;
+    }
+  }
+
+  async findOneBang(options: FindOptions | undefined): Promise<User> {
+    const user = await this.userModel.findOne<User>(options);
+    if (user === null) {
+      throw new NotFoundException('User with given id not found');
+    } else {
+      return user;
     }
   }
 

--- a/apps/backend/test/constants/evaluation-tags-test.constant.ts
+++ b/apps/backend/test/constants/evaluation-tags-test.constant.ts
@@ -22,20 +22,17 @@ export const EVALUATION_TAG_DTO: EvaluationTagDto = {
 };
 
 export const CREATE_EVALUATION_TAG_DTO: CreateEvaluationTagDto = {
-  id: 0,
   key: 'key string',
   value: 'value string'
 };
 
 // @ts-ignore
 export const CREATE_EVALUATION_TAG_DTO_MISSING_KEY: CreateEvaluationTagDto = {
-  id: 0,
   value: 'value string'
 };
 
 // @ts-ignore
 export const CREATE_EVALUATION_TAG_DTO_MISSING_VALUE: CreateEvaluationTagDto = {
-  id: 0,
   key: 'key string'
 };
 

--- a/apps/backend/test/constants/evaluations-test.constant.ts
+++ b/apps/backend/test/constants/evaluations-test.constant.ts
@@ -1,10 +1,7 @@
 import {CreateEvaluationDto} from '../../src/evaluations/dto/create-evaluation.dto';
 import {UpdateEvaluationDto} from '../../src/evaluations/dto/update-evaluation.dto';
 import {EvaluationDto} from '../../src/evaluations/dto/evaluation.dto';
-import {
-  CREATE_EVALUATION_TAG_DTO,
-  UPDATE_EVALUATION_TAG_DTO
-} from './evaluation-tags-test.constant';
+import {CREATE_EVALUATION_TAG_DTO} from './evaluation-tags-test.constant';
 import {Evaluation} from '../../src/evaluations/evaluation.model';
 /* eslint-disable @typescript-eslint/ban-ts-ignore */
 
@@ -44,8 +41,7 @@ export const UPDATE_EVALUATION: UpdateEvaluationDto = {
   data: {
     filename: DEFAULT_FILE_NAME
   },
-  filename: 'example-result-new.json',
-  evaluationTags: []
+  filename: 'example-result-new.json'
 };
 
 // @ts-ignore
@@ -58,21 +54,6 @@ export const UPDATE_EVALUATION_DATA_ONLY: UpdateEvaluationDto = {
   data: {
     filename: DEFAULT_FILE_NAME
   }
-};
-
-// @ts-ignore
-export const UPDATE_EVALUATION_TAG_ONLY: UpdateEvaluationDto = {
-  evaluationTags: [UPDATE_EVALUATION_TAG_DTO]
-};
-
-// @ts-ignore
-export const UPDATE_EVALUATION_ADD_TAGS_1: UpdateEvaluationDto = {
-  evaluationTags: [UPDATE_EVALUATION_TAG_DTO, CREATE_EVALUATION_TAG_DTO]
-};
-
-// @ts-ignore
-export const UPDATE_EVALUATION_REMOVE_TAGS_1: UpdateEvaluationDto = {
-  evaluationTags: []
 };
 
 export const EVALUATION_DTO: EvaluationDto = {

--- a/apps/backend/test/constants/users-test.constant.ts
+++ b/apps/backend/test/constants/users-test.constant.ts
@@ -170,8 +170,6 @@ export const TEST_USER_WITH_INVALID_ROLE: User = {
   updatedAt: new Date()
 };
 
-export const NULL_USER: User = null;
-
 // @ts-ignore
 export const USER_ARRAY: User[] = [
   // @ts-ignore

--- a/apps/backend/test/evaluations.e2e-spec.ts
+++ b/apps/backend/test/evaluations.e2e-spec.ts
@@ -143,16 +143,22 @@ describe('/evaluations', () => {
             // 1 minute in ms
             expect(createdDelta).toBeLessThanOrEqual(60000);
             expect(updatedDelta).toBeLessThanOrEqual(60000);
-            expect(response.body.evaluationTags[0].key).toEqual(
-              EVALUATION_WITH_TAGS_1.evaluationTags[0].key
-            );
-            expect(response.body.evaluationTags[0].value).toEqual(
-              EVALUATION_WITH_TAGS_1.evaluationTags[0].value
-            );
-            expect(response.body.evaluationTags[0].id).toBeDefined();
-            expect(response.body.id).toEqual(
-              response.body.evaluationTags[0].evaluationId
-            );
+            if (EVALUATION_WITH_TAGS_1.evaluationTags === undefined) {
+              throw TypeError(
+                'Test fixture for Evaluation is set up improperly and has an undefined value for Evaluation Tags'
+              );
+            } else {
+              expect(response.body.evaluationTags[0].key).toEqual(
+                EVALUATION_WITH_TAGS_1.evaluationTags[0].key
+              );
+              expect(response.body.evaluationTags[0].value).toEqual(
+                EVALUATION_WITH_TAGS_1.evaluationTags[0].value
+              );
+              expect(response.body.evaluationTags[0].id).toBeDefined();
+              expect(response.body.id).toEqual(
+                response.body.evaluationTags[0].evaluationId
+              );
+            }
           });
       });
     });

--- a/apps/backend/test/users.e2e-spec.ts
+++ b/apps/backend/test/users.e2e-spec.ts
@@ -459,9 +459,12 @@ describe('/users', () => {
       });
 
       it('should return 200 status after user is deleted by admin', async () => {
+        function EmptyJWTError(): string {
+          return 'Token does not conform to the expected format for a zip code';
+        }
         const admin = await usersService.create(CREATE_ADMIN_DTO);
 
-        let adminJWTToken: string;
+        let adminJWTToken = '';
         await request(app.getHttpServer())
           .post('/authn/login')
           .set('Content-Type', 'application/json')
@@ -470,6 +473,10 @@ describe('/users', () => {
           .then((response) => {
             adminJWTToken = response.body.accessToken;
           });
+
+        if (adminJWTToken === '') {
+          throw EmptyJWTError();
+        }
 
         await request(app.getHttpServer())
           .delete('/users/' + admin.id)

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -8,6 +8,7 @@
     "outDir": "../../dist/server",
     "baseUrl": "./",
     "incremental": true,
+    "strict": true,
     "lib": [
       "es2020"
     ],

--- a/libs/interfaces/evaluation/create-evaluation.interface.ts
+++ b/libs/interfaces/evaluation/create-evaluation.interface.ts
@@ -3,5 +3,5 @@ import {ICreateEvaluationTag} from '..';
 export interface ICreateEvaluation {
   readonly filename: string;
   readonly data: Record<string, any>;
-  readonly evaluationTags: ICreateEvaluationTag[];
+  readonly evaluationTags: ICreateEvaluationTag[] | undefined;
 }

--- a/libs/interfaces/evaluation/evaluation.interface.ts
+++ b/libs/interfaces/evaluation/evaluation.interface.ts
@@ -4,7 +4,7 @@ export interface IEvaluation {
   id: number;
   readonly filename: string;
   readonly data: Record<string, any>;
-  readonly evaluationTags: IEvaluationTag[];
+  readonly evaluationTags: IEvaluationTag[] | null;
   readonly createdAt: Date;
   readonly updatedAt: Date;
 }

--- a/libs/interfaces/evaluation/update-evaluation.interface.ts
+++ b/libs/interfaces/evaluation/update-evaluation.interface.ts
@@ -1,13 +1,4 @@
-import {
-  IUpdateEvaluationTag,
-  ICreateEvaluationTag,
-  IDeleteEvaluationTag
-} from '..';
-
 export interface IUpdateEvaluation {
   readonly filename: string | undefined;
   readonly data: Record<string, any> | undefined;
-  readonly evaluationTags:
-    | (IUpdateEvaluationTag | ICreateEvaluationTag | IDeleteEvaluationTag)[]
-    | undefined;
 }

--- a/libs/interfaces/evaluation/update-evaluation.interface.ts
+++ b/libs/interfaces/evaluation/update-evaluation.interface.ts
@@ -7,9 +7,7 @@ import {
 export interface IUpdateEvaluation {
   readonly filename: string | undefined;
   readonly data: Record<string, any> | undefined;
-  readonly evaluationTags: (
-    | IUpdateEvaluationTag
-    | ICreateEvaluationTag
-    | IDeleteEvaluationTag
-  )[] | undefined;
+  readonly evaluationTags:
+    | (IUpdateEvaluationTag | ICreateEvaluationTag | IDeleteEvaluationTag)[]
+    | undefined;
 }

--- a/libs/interfaces/evaluation/update-evaluation.interface.ts
+++ b/libs/interfaces/evaluation/update-evaluation.interface.ts
@@ -5,11 +5,11 @@ import {
 } from '..';
 
 export interface IUpdateEvaluation {
-  readonly filename: string;
-  readonly data: Record<string, any>;
+  readonly filename: string | undefined;
+  readonly data: Record<string, any> | undefined;
   readonly evaluationTags: (
     | IUpdateEvaluationTag
     | ICreateEvaluationTag
     | IDeleteEvaluationTag
-  )[];
+  )[] | undefined;
 }

--- a/libs/interfaces/user/create-user.interface.ts
+++ b/libs/interfaces/user/create-user.interface.ts
@@ -2,9 +2,9 @@ export interface ICreateUser {
   readonly email: string;
   readonly password: string;
   readonly passwordConfirmation: string;
-  readonly firstName: string;
-  readonly lastName: string;
-  readonly organization: string;
-  readonly title: string;
+  readonly firstName: string | undefined;
+  readonly lastName: string | undefined;
+  readonly organization: string | undefined;
+  readonly title: string | undefined;
   readonly role: string;
 }

--- a/libs/interfaces/user/update-user.interface.ts
+++ b/libs/interfaces/user/update-user.interface.ts
@@ -1,12 +1,12 @@
 export interface IUpdateUser {
-  readonly email: string;
-  readonly firstName: string;
-  readonly lastName: string;
-  readonly organization: string;
-  readonly title: string;
-  readonly role: string;
-  readonly password: string;
-  readonly passwordConfirmation: string;
-  readonly forcePasswordChange: boolean;
+  readonly email: string | undefined;
+  readonly firstName: string | undefined;
+  readonly lastName: string | undefined;
+  readonly organization: string | undefined;
+  readonly title: string | undefined;
+  readonly role: string | undefined;
+  readonly password: string | undefined;
+  readonly passwordConfirmation: string | undefined;
+  readonly forcePasswordChange: boolean | undefined;
   readonly currentPassword: string;
 }

--- a/libs/interfaces/user/user.interface.ts
+++ b/libs/interfaces/user/user.interface.ts
@@ -1,13 +1,13 @@
 export interface IUser {
   id: number;
   readonly email: string;
-  readonly firstName: string;
-  readonly lastName: string;
-  readonly title: string;
+  readonly firstName: string | null;
+  readonly lastName: string | null;
+  readonly title: string | null;
   readonly role: string;
-  readonly organization: string;
+  readonly organization: string | null;
   readonly loginCount: number;
-  readonly lastLogin: Date;
+  readonly lastLogin: Date | null;
   readonly createdAt: Date;
   readonly updatedAt: Date;
 }

--- a/package.json
+++ b/package.json
@@ -16,14 +16,6 @@
       "libs/*"
     ]
   },
-  "gitHooks": {
-    "pre-commit": "lint-staged"
-  },
-  "lint-staged": {
-    "*.{js,vue,ts}": [
-      "yarn run lint -- --"
-    ]
-  },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^2.34.0",
     "@typescript-eslint/parser": "^2.34.0",
@@ -33,7 +25,6 @@
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-unused-imports": "^0.1.3",
     "lerna": "^3.22.1",
-    "lint-staged": "^10.4.0",
     "prettier": "^2.1.2",
     "typescript": "^3.9.7"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4639,11 +4639,6 @@ ansi-colors@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.4.tgz#e3a3da4bfbae6c86a9c285625de124a234026fbf"
   integrity sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==
 
-ansi-colors@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
-  integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
-
 ansi-escapes@^3.0.0, ansi-escapes@^3.1.0, ansi-escapes@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
@@ -5374,11 +5369,6 @@ astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
   integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
-
-astral-regex@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
-  integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
 async-each@^1.0.1:
   version "1.0.3"
@@ -6700,14 +6690,6 @@ cli-truncate@^0.2.1:
     slice-ansi "0.0.4"
     string-width "^1.0.1"
 
-cli-truncate@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-2.1.0.tgz#c39e28bf05edcde5be3b98992a22deed5a2b93c7"
-  integrity sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==
-  dependencies:
-    slice-ansi "^3.0.0"
-    string-width "^4.2.0"
-
 cli-ux@5.4.10:
   version "5.4.10"
   resolved "https://registry.yarnpkg.com/cli-ux/-/cli-ux-5.4.10.tgz#b4d5ed438a3fd6956c3f74f07d18f7dae02643d9"
@@ -7027,11 +7009,6 @@ commander@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/commander/-/commander-3.0.2.tgz#6837c3fb677ad9933d1cfba42dd14d5117d6b39e"
   integrity sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==
-
-commander@^6.0.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-6.1.0.tgz#f8d722b78103141006b66f4c7ba1e97315ba75bc"
-  integrity sha512-wl7PNrYWd2y5mp1OK/LhTlv8Ff4kQJQRXXAvF+uU/TPNiVJUxZLRYGj/B0y/lPGAVcSbJqH2Za/cvHmrPMC8mA==
 
 commander@~2.14.1:
   version "2.14.1"
@@ -7399,17 +7376,6 @@ cosmiconfig@^6.0.0:
     parse-json "^5.0.0"
     path-type "^4.0.0"
     yaml "^1.7.2"
-
-cosmiconfig@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.0.tgz#ef9b44d773959cae63ddecd122de23853b60f8d3"
-  integrity sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==
-  dependencies:
-    "@types/parse-json" "^4.0.0"
-    import-fresh "^3.2.1"
-    parse-json "^5.0.0"
-    path-type "^4.0.0"
-    yaml "^1.10.0"
 
 crc-32@~1.2.0:
   version "1.2.0"
@@ -8771,13 +8737,6 @@ enhanced-resolve@^4.0.0, enhanced-resolve@^4.3.0:
     memory-fs "^0.5.0"
     tapable "^1.0.0"
 
-enquirer@^2.3.6:
-  version "2.3.6"
-  resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
-  integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
-  dependencies:
-    ansi-colors "^4.1.1"
-
 entities@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
@@ -9324,7 +9283,7 @@ execa@^3.2.0, execa@^3.3.0:
     signal-exit "^3.0.2"
     strip-final-newline "^2.0.0"
 
-execa@^4.0.0, execa@^4.0.3:
+execa@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/execa/-/execa-4.0.3.tgz#0a34dabbad6d66100bd6f2c576c8669403f317f2"
   integrity sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==
@@ -9670,7 +9629,7 @@ figures@^2.0.0:
   dependencies:
     escape-string-regexp "^1.0.5"
 
-figures@^3.0.0, figures@^3.2.0:
+figures@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
   integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
@@ -10206,11 +10165,6 @@ get-func-name@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
   integrity sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=
-
-get-own-enumerable-property-symbols@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz#b5fde77f22cbe35f390b4e089922c50bce6ef664"
-  integrity sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==
 
 get-package-type@^0.1.0:
   version "0.1.0"
@@ -11272,7 +11226,7 @@ import-fresh@^2.0.0:
     caller-path "^2.0.0"
     resolve-from "^3.0.0"
 
-import-fresh@^3.0.0, import-fresh@^3.1.0, import-fresh@^3.2.1:
+import-fresh@^3.0.0, import-fresh@^3.1.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.1.tgz#633ff618506e793af5ac91bf48b72677e15cbe66"
   integrity sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==
@@ -11760,7 +11714,7 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
-is-obj@^1.0.0, is-obj@^1.0.1:
+is-obj@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
   integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
@@ -11851,11 +11805,6 @@ is-regex@^1.0.4, is-regex@^1.1.0, is-regex@^1.1.1:
   integrity sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==
   dependencies:
     has-symbols "^1.0.1"
-
-is-regexp@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
-  integrity sha1-/S2INUXEa6xaYz57mgnof6LLUGk=
 
 is-resolvable@^1.0.0:
   version "1.1.0"
@@ -13390,27 +13339,6 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-lint-staged@^10.4.0:
-  version "10.4.0"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-10.4.0.tgz#d18628f737328e0bbbf87d183f4020930e9a984e"
-  integrity sha512-uaiX4U5yERUSiIEQc329vhCTDDwUcSvKdRLsNomkYLRzijk3v8V9GWm2Nz0RMVB87VcuzLvtgy6OsjoH++QHIg==
-  dependencies:
-    chalk "^4.1.0"
-    cli-truncate "^2.1.0"
-    commander "^6.0.0"
-    cosmiconfig "^7.0.0"
-    debug "^4.1.1"
-    dedent "^0.7.0"
-    enquirer "^2.3.6"
-    execa "^4.0.3"
-    listr2 "^2.6.0"
-    log-symbols "^4.0.0"
-    micromatch "^4.0.2"
-    normalize-path "^3.0.0"
-    please-upgrade-node "^3.2.0"
-    string-argv "0.3.1"
-    stringify-object "^3.3.0"
-
 listr-silent-renderer@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz#924b5a3757153770bf1a8e3fbf74b8bbf3f9242e"
@@ -13439,20 +13367,6 @@ listr-verbose-renderer@^0.5.0:
     cli-cursor "^2.1.0"
     date-fns "^1.27.2"
     figures "^2.0.0"
-
-listr2@^2.6.0:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/listr2/-/listr2-2.6.2.tgz#4912eb01e1e2dd72ec37f3895a56bf2622d6f36a"
-  integrity sha512-6x6pKEMs8DSIpA/tixiYY2m/GcbgMplMVmhQAaLFxEtNSKLeWTGjtmU57xvv6QCm2XcqzyNXL/cTSVf4IChCRA==
-  dependencies:
-    chalk "^4.1.0"
-    cli-truncate "^2.1.0"
-    figures "^3.2.0"
-    indent-string "^4.0.0"
-    log-update "^4.0.0"
-    p-map "^4.0.0"
-    rxjs "^6.6.2"
-    through "^2.3.8"
 
 listr@0.14.3:
   version "0.14.3"
@@ -13761,16 +13675,6 @@ log-update@^2.3.0:
     ansi-escapes "^3.0.0"
     cli-cursor "^2.0.0"
     wrap-ansi "^3.0.1"
-
-log-update@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/log-update/-/log-update-4.0.0.tgz#589ecd352471f2a1c0c570287543a64dfd20e0a1"
-  integrity sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==
-  dependencies:
-    ansi-escapes "^4.3.0"
-    cli-cursor "^3.1.0"
-    slice-ansi "^4.0.0"
-    wrap-ansi "^6.2.0"
 
 loglevel@^1.6.7, loglevel@^1.6.8:
   version "1.7.0"
@@ -15366,13 +15270,6 @@ p-map@^3.0.0:
   dependencies:
     aggregate-error "^3.0.0"
 
-p-map@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/p-map/-/p-map-4.0.0.tgz#bb2f95a5eda2ec168ec9274e06a747c3e2904d2b"
-  integrity sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==
-  dependencies:
-    aggregate-error "^3.0.0"
-
 p-pipe@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/p-pipe/-/p-pipe-1.2.0.tgz#4b1a11399a11520a67790ee5a0c1d5881d6befe9"
@@ -15881,13 +15778,6 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
-
-please-upgrade-node@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"
-  integrity sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==
-  dependencies:
-    semver-compare "^1.0.0"
 
 pluralize@8.0.0, pluralize@^8.0.0:
   version "8.0.0"
@@ -17333,7 +17223,7 @@ rxjs@6.5.5:
   dependencies:
     tslib "^1.9.0"
 
-rxjs@^6.3.3, rxjs@^6.4.0, rxjs@^6.5.3, rxjs@^6.5.4, rxjs@^6.6.0, rxjs@^6.6.2:
+rxjs@^6.3.3, rxjs@^6.4.0, rxjs@^6.5.3, rxjs@^6.5.4, rxjs@^6.6.0:
   version "6.6.3"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.3.tgz#8ca84635c4daa900c0d3967a6ee7ac60271ee552"
   integrity sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==
@@ -17501,11 +17391,6 @@ selfsigned@^1.10.7:
   integrity sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==
   dependencies:
     node-forge "0.9.0"
-
-semver-compare@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
-  integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
 
 semver-diff@^2.0.0:
   version "2.1.0"
@@ -17838,24 +17723,6 @@ slice-ansi@^2.1.0:
     ansi-styles "^3.2.0"
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
-
-slice-ansi@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-3.0.0.tgz#31ddc10930a1b7e0b67b08c96c2f49b77a789787"
-  integrity sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==
-  dependencies:
-    ansi-styles "^4.0.0"
-    astral-regex "^2.0.0"
-    is-fullwidth-code-point "^3.0.0"
-
-slice-ansi@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-4.0.0.tgz#500e8dd0fd55b05815086255b3195adf2a45fe6b"
-  integrity sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==
-  dependencies:
-    ansi-styles "^4.0.0"
-    astral-regex "^2.0.0"
-    is-fullwidth-code-point "^3.0.0"
 
 slide@^1.1.6:
   version "1.1.6"
@@ -18237,11 +18104,6 @@ strict-uri-encode@^1.0.0:
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
 
-string-argv@0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
-  integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
-
 string-hash@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/string-hash/-/string-hash-1.1.3.tgz#e8aafc0ac1855b4666929ed7dd1275df5d6c811b"
@@ -18340,15 +18202,6 @@ string_decoder@~1.1.1:
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
-
-stringify-object@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/stringify-object/-/stringify-object-3.3.0.tgz#703065aefca19300d3ce88af4f5b3956d7556629"
-  integrity sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==
-  dependencies:
-    get-own-enumerable-property-symbols "^3.0.0"
-    is-obj "^1.0.1"
-    is-regexp "^1.0.0"
 
 strip-ansi@5.2.0, strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   version "5.2.0"
@@ -20681,7 +20534,7 @@ yaml-front-matter@^3.4.1:
     commander "1.0.0"
     js-yaml "^3.5.2"
 
-yaml@^1.10.0, yaml@^1.7.2:
+yaml@^1.7.2:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"
   integrity sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==


### PR DESCRIPTION
Closes #239 

This got a little out of hand because this PR also:
* Removes functionality of updating `EvaluationTag` through `Evaluation`
* Adds CRUD methods to the `EvaluationTag` controller.
* Removes `pre-commit` since it does not work in monorepos.