### PR TITLE
Convert all Vue components to use vue-property-decorator declarations

### DIFF
--- a/apps/frontend/src/App.vue
+++ b/apps/frontend/src/App.vue
@@ -16,15 +16,11 @@ import Component from 'vue-class-component';
 import Footer from '@/components/global/Footer.vue';
 import Snackbar from '@/components/global/Snackbar.vue';
 
-// We declare the props separately
-// to make props types inferable.
-const AppProps = Vue.extend({});
-
 @Component({
   components: {
     Footer,
     Snackbar
   }
 })
-export default class App extends AppProps {}
+export default class App extends Vue {}
 </script>

--- a/apps/frontend/src/components/cards/ComplianceChart.vue
+++ b/apps/frontend/src/components/cards/ComplianceChart.vue
@@ -19,21 +19,17 @@ import {ColorHackModule} from '@/store/color_hack';
 import {ApexOptions} from 'apexcharts';
 
 import {StatusCountModule} from '@/store/status_counts';
-
-// We declare the props separately
-// to make props types inferrable.
-const ComplianceChartProps = Vue.extend({
-  props: {
-    filter: Object // Of type Filer from filteredData
-  }
-});
+import {Prop} from 'vue-property-decorator';
+import {Filter} from '@/store/data_filters';
 
 @Component({
   components: {
     VueApexCharts
   }
 })
-export default class ComplianceChart extends ComplianceChartProps {
+export default class ComplianceChart extends Vue {
+  @Prop({type: Object, required: true}) readonly filter!: Filter;
+
   get chartOptions(): ApexOptions {
     // Produce our options
     let result: ApexOptions = {

--- a/apps/frontend/src/components/cards/EvaluationInfo.vue
+++ b/apps/frontend/src/components/cards/EvaluationInfo.vue
@@ -18,9 +18,7 @@ import {FileID, EvaluationFile} from '@/store/report_intake';
 
 import {Prop} from 'vue-property-decorator';
 
-@Component({
-  components: {}
-})
+@Component
 export default class EvaluationInfo extends Vue {
   @Prop({required: true}) readonly file_filter!: FileID;
 
@@ -38,7 +36,7 @@ export default class EvaluationInfo extends Vue {
     let file = InspecDataModule.allFiles.find(
       (f) => f.unique_id === this.file_filter
     );
-    if (file) {
+    if (file && file.hasOwnProperty('evaluation')) {
       let eva = file as EvaluationFile;
       this.version = eva.evaluation.data.version;
       this.platform_name = eva.evaluation.data.platform.name;
@@ -76,7 +74,7 @@ export default class EvaluationInfo extends Vue {
     let file = InspecDataModule.allFiles.find(
       (f) => f.unique_id === this.file_filter
     );
-    if (file) {
+    if (file && file.hasOwnProperty('evaluation')) {
       let eva = file as EvaluationFile;
       this.version = eva.evaluation.data.version;
       this.platform_name = eva.evaluation.data.platform.name;

--- a/apps/frontend/src/components/cards/ProfileData.vue
+++ b/apps/frontend/src/components/cards/ProfileData.vue
@@ -82,9 +82,10 @@ import Component from 'vue-class-component';
 import {InspecDataModule, isFromProfileFile} from '@/store/data_store';
 import {SourcedContextualizedEvaluation} from '@/store/report_intake';
 
-import {profile_unique_key} from '../../utilities/format_util';
+import {profile_unique_key} from '@/utilities/format_util';
 import {InspecFile, ProfileFile} from '@/store/report_intake';
 import {context} from 'inspecjs';
+import {Prop} from 'vue-property-decorator';
 
 /**
  * Makes a ContextualizedProfile work as a TreeView item
@@ -107,18 +108,11 @@ class TreeItem {
   }
 }
 
-// We declare the props separately
-// to make props types inferrable.
-const Props = Vue.extend({
-  props: {
-    selected_prof: {type: Object, required: true}
-  }
-});
+@Component
+export default class ProfileData extends Vue {
+  @Prop({type: Object, required: true})
+  readonly selected_prof!: context.ContextualizedProfile;
 
-@Component({
-  components: {}
-})
-export default class ProfileData extends Props {
   //auto select the root prof
   mounted() {
     this.active = [profile_unique_key(this.selected_prof)];

--- a/apps/frontend/src/components/cards/SeverityChart.vue
+++ b/apps/frontend/src/components/cards/SeverityChart.vue
@@ -12,14 +12,8 @@ import Component from 'vue-class-component';
 import ApexPieChart, {Category} from '@/components/generic/ApexPieChart.vue';
 import {Severity} from 'inspecjs';
 import {SeverityCountModule} from '@/store/severity_counts';
-
-// We declare the props separately to make props types inferable.
-const SeverityChartProps = Vue.extend({
-  props: {
-    value: String, // The currently selected severity, or null
-    filter: Object // Of type Filer from filteredData
-  }
-});
+import {Filter} from '@/store/data_filters';
+import {Prop} from 'vue-property-decorator';
 
 /**
  * Categories property must be of type Category
@@ -30,7 +24,10 @@ const SeverityChartProps = Vue.extend({
     ApexPieChart
   }
 })
-export default class SeverityChart extends SeverityChartProps {
+export default class SeverityChart extends Vue {
+  @Prop({type: String}) readonly value!: string | null;
+  @Prop({type: Object, required: true}) readonly filter!: Filter;
+
   categories: Category<Severity>[] = [
     // { label: "Low", value: "low", icon: "SquareIcon", color: "var(--v-success-base)" },
     {label: 'Low', value: 'low', color: 'severityLow'},

--- a/apps/frontend/src/components/cards/StatusCardRow.vue
+++ b/apps/frontend/src/components/cards/StatusCardRow.vue
@@ -46,6 +46,8 @@
 import Vue from 'vue';
 import Component from 'vue-class-component';
 import {StatusCountModule} from '@/store/status_counts';
+import {Filter} from '@/store/data_filters';
+import {Prop} from 'vue-property-decorator';
 
 interface CardProps {
   icon: string;
@@ -55,17 +57,10 @@ interface CardProps {
   color: string;
 }
 
-// We declare the props separately to make props types inferable.
-const StatusCardRowProps = Vue.extend({
-  props: {
-    filter: Object // Of type Filter
-  }
-});
+@Component
+export default class StatusCardRow extends Vue {
+  @Prop({type: Object, required: true}) readonly filter!: Filter;
 
-@Component({
-  components: {}
-})
-export default class StatusCardRow extends StatusCardRowProps {
   // Cards
   get standardCardProps(): CardProps[] {
     return [

--- a/apps/frontend/src/components/cards/StatusChart.vue
+++ b/apps/frontend/src/components/cards/StatusChart.vue
@@ -14,16 +14,8 @@ import Component from 'vue-class-component';
 import ApexPieChart, {Category} from '@/components/generic/ApexPieChart.vue';
 import {StatusCountModule} from '@/store/status_counts';
 import {ControlStatus} from 'inspecjs';
-
-// We declare the props separately to make props types inferable.
-const StatusChartProps = Vue.extend({
-  props: {
-    value: String, // The currently selected status, or null
-    filter: Object, // Of type Filer from filteredData
-    show_compliance: Boolean
-    //supress: Boolean // Supress status selection
-  }
-});
+import {Prop} from 'vue-property-decorator';
+import {Filter} from '@/store/data_filters';
 
 /**
  * Categories property must be of type Category
@@ -34,7 +26,11 @@ const StatusChartProps = Vue.extend({
     ApexPieChart
   }
 })
-export default class StatusChart extends StatusChartProps {
+export default class StatusChart extends Vue {
+  @Prop({type: String}) readonly value!: string | null;
+  @Prop({type: Object, required: true}) readonly filter!: Filter;
+  @Prop({type: Boolean, default: false}) show_compliance!: boolean;
+
   categories: Category<ControlStatus>[] = [
     {
       label: 'Passed',

--- a/apps/frontend/src/components/cards/UtilColorGenerator.vue
+++ b/apps/frontend/src/components/cards/UtilColorGenerator.vue
@@ -11,19 +11,12 @@ import Component from 'vue-class-component';
 import {ColorHack, ColorHackModule} from '@/store/color_hack';
 import {Color} from 'vuetify/lib/util/colors';
 
-// We declare the props separately to make props types inferable.
-const Props = Vue.extend({
-  props: {}
-});
-
 /**
  * Categories property must be of type Category
  * Model is of type Severity | null - reflects selected severity
  */
-@Component({
-  components: {}
-})
-export default class UtilColorGenerator extends Props {
+@Component
+export default class UtilColorGenerator extends Vue {
   color: string = 'background';
 
   get body(): string {

--- a/apps/frontend/src/components/cards/comparison/ChangeItem.vue
+++ b/apps/frontend/src/components/cards/comparison/ChangeItem.vue
@@ -20,20 +20,18 @@
 </template>
 
 <script lang="ts">
+import {ControlChange} from '@/utilities/delta_util';
 import Vue from 'vue';
 import Component from 'vue-class-component';
-
-const Props = Vue.extend({
-  props: {
-    change: Object,
-    shift: Number
-  }
-});
+import {Prop} from 'vue-property-decorator';
 
 @Component({
   components: {}
 })
-export default class ChangeItem extends Props {
+export default class ChangeItem extends Vue {
+  @Prop({type: Object, required: true}) readonly change!: ControlChange;
+  @Prop({type: Number, required: true}) readonly shift!: number;
+
   color(status: string): string {
     if (this.change.name.toLowerCase() == 'status') {
       return `status${status.replace(' ', '')}`;

--- a/apps/frontend/src/components/cards/comparison/CompareRow.vue
+++ b/apps/frontend/src/components/cards/comparison/CompareRow.vue
@@ -84,16 +84,8 @@ import {HDFControl} from 'inspecjs';
 import {ControlDelta} from '@/utilities/delta_util';
 import DeltaView from '@/components/cards/comparison/DeltaView.vue';
 import ControlRowDetails from '@/components/cards/controltable/ControlRowDetails.vue';
-import {FilteredDataModule} from '../../../store/data_filters';
-
-// We declare the props separately to make props types inferable.
-const Props = Vue.extend({
-  props: {
-    controls: Array, // Of type Array<ContextualizedControl>
-    shown_files: Number,
-    shift: Number
-  }
-});
+import {FilteredDataModule} from '@/store/data_filters';
+import {Prop} from 'vue-property-decorator';
 
 @Component({
   components: {
@@ -101,7 +93,12 @@ const Props = Vue.extend({
     ControlRowDetails
   }
 })
-export default class CompareRow extends Props {
+export default class CompareRow extends Vue {
+  @Prop({type: Array, required: true})
+  readonly controls!: context.ContextualizedControl[];
+  @Prop({type: Number, required: true}) readonly shown_files!: number;
+  @Prop({type: Number, required: true}) readonly shift!: number;
+
   /** Models the currently selected chips. If it's a number */
   selection: boolean[] = [];
   tab: string = 'tab-test';
@@ -109,13 +106,13 @@ export default class CompareRow extends Props {
   /** Initialize our selection */
   mounted() {
     // Pick the first and last control, or as close as we can get to that
-    if (this._controls.length === 0) {
+    if (this.controls.length === 0) {
       this.selection.splice(0);
-    } else if (this._controls.length === 1) {
+    } else if (this.controls.length === 1) {
       this.selection.push(false);
     } else {
       this.selection = [];
-      this._controls.forEach(() => {
+      this.controls.forEach(() => {
         this.selection.push(false);
       });
     }
@@ -137,20 +134,15 @@ export default class CompareRow extends Props {
     var i;
     for (i = 0; i < this.selection.length; i++) {
       if (this.selection[i]) {
-        selected.push(this._controls[i]);
+        selected.push(this.controls[i]);
       }
     }
     return selected;
   }
 
-  /** Typed getter on controls */
-  get _controls(): context.ContextualizedControl[] {
-    return this.controls as context.ContextualizedControl[];
-  }
-
   /** Just maps controls to hdf. Makes our template a bit less verbose */
   get hdf_controls(): Array<HDFControl | null> {
-    return this._controls.map((c) => {
+    return this.controls.map((c) => {
       if (c == null) {
         return null;
       }

--- a/apps/frontend/src/components/cards/comparison/DeltaView.vue
+++ b/apps/frontend/src/components/cards/comparison/DeltaView.vue
@@ -29,7 +29,6 @@ import {
 
 import ChangeItem from '@/components/cards/comparison/ChangeItem.vue';
 import TruncatedText from '@/components/generic/TruncatedText.vue';
-import ControlRowCol from '@/components/cards/controltable/ControlRowCol.vue';
 
 //TODO: add line numbers
 import 'prismjs';
@@ -37,31 +36,19 @@ import 'prismjs/components/prism-makefile.js';
 import 'prismjs/components/prism-ruby.js';
 //@ts-ignore
 import Prism from 'vue-prism-component';
+import {Prop} from 'vue-property-decorator';
 Vue.component('Prism', Prism);
-
-import 'prismjs/components/prism-ruby.js';
-
-// Define our props
-const Props = Vue.extend({
-  props: {
-    delta: Object, // Of type ControlDelta
-    shift: Number
-  }
-});
 
 @Component({
   components: {
     ChangeItem,
     TruncatedText,
-    Prism,
-    ControlRowCol
+    Prism
   }
 })
-export default class DeltaView extends Props {
-  /** Typed prop getter */
-  get _delta(): ControlDelta {
-    return this.delta as ControlDelta;
-  }
+export default class DeltaView extends Vue {
+  @Prop({required: true}) readonly delta!: ControlDelta;
+  @Prop({required: true}) readonly shift!: number;
 
   get head_changes(): boolean {
     for (let change of this.header_changes.changes) {
@@ -78,7 +65,7 @@ export default class DeltaView extends Props {
    * Wrapped getters to utilize vue caching, and also just make things easier in the template.
    */
   get header_changes(): ControlChangeGroup {
-    return this._delta.header_changes;
+    return this.delta.header_changes;
   }
 }
 </script>

--- a/apps/frontend/src/components/cards/comparison/ProfileRow.vue
+++ b/apps/frontend/src/components/cards/comparison/ProfileRow.vue
@@ -10,14 +10,13 @@
 
 <script lang="ts">
 import Vue from 'vue';
-const Props = Vue.extend({
-  props: {
-    name: String,
-    start_time: String,
-    index: Number,
-    show_index: Boolean
-  }
-});
+import {Component, Prop} from 'vue-property-decorator';
 
-export default class DeltaView extends Props {}
+@Component
+export default class ProfileRow extends Vue {
+  @Prop({type: String, required: true}) readonly name!: string;
+  @Prop({type: String}) readonly start_time!: string;
+  @Prop({type: Number}) readonly index!: number;
+  @Prop({type: Boolean, default: false}) readonly show_index!: boolean;
+}
 </script>

--- a/apps/frontend/src/components/cards/controltable/ControlRowCol.vue
+++ b/apps/frontend/src/components/cards/controltable/ControlRowCol.vue
@@ -82,32 +82,23 @@ import Component from 'vue-class-component';
 
 //@ts-ignore
 import VClamp from 'vue-clamp/dist/vue-clamp.js';
+import {Prop} from 'vue-property-decorator';
+import {HDFControlSegment} from 'inspecjs';
 
 interface CollapsableElement extends Element {
   offsetHeight: Number;
   offsetWidth: Number;
 }
 
-// We declare the props separately to make props types inferable.
-const ControlRowColProps = Vue.extend({
-  props: {
-    statusCode: {
-      type: String,
-      required: true
-    },
-    result: {
-      type: Object,
-      required: true
-    }
-  }
-});
-
 @Component({
   components: {
     VClamp
   }
 })
-export default class ControlRowCol extends ControlRowColProps {
+export default class ControlRowCol extends Vue {
+  @Prop({type: String, required: true}) readonly statusCode!: string;
+  @Prop({type: Object, required: true}) readonly result!: HDFControlSegment;
+
   expanded: boolean = false;
   clamp: boolean = false;
 

--- a/apps/frontend/src/components/cards/controltable/ControlRowDetails.vue
+++ b/apps/frontend/src/components/cards/controltable/ControlRowDetails.vue
@@ -103,29 +103,14 @@ import Prism from 'vue-prism-component';
 import 'prismjs/themes/prism-tomorrow.css';
 Vue.component('Prism', Prism);
 
-import 'prismjs/components/prism-ruby.js';
 import {context} from 'inspecjs';
+import {Prop} from 'vue-property-decorator';
 
 interface Detail {
   name: string;
   value: string;
   class?: string;
 }
-
-// We declare the props separately to make props types inferable.
-const ControlRowDetailsProps = Vue.extend({
-  props: {
-    tab: {
-      type: String,
-      required: false,
-      default: null
-    },
-    control: {
-      type: Object, // Of type context.ContextualizedControl
-      required: true
-    }
-  }
-});
 
 interface CollapsableElement extends Element {
   offsetHeight: Number;
@@ -139,18 +124,17 @@ interface CollapsableElement extends Element {
     Prism
   }
 })
-export default class ControlRowDetails extends ControlRowDetailsProps {
+export default class ControlRowDetails extends Vue {
+  @Prop({type: String}) readonly tab!: string;
+  @Prop({type: Object, required: true})
+  readonly control!: context.ContextualizedControl;
+
   clamped: boolean = false;
   expanded: boolean = false;
   local_tab: string = 'tab-test';
 
-  /** Typed getter aroun control prop */
-  get _control(): context.ContextualizedControl {
-    return this.control;
-  }
-
   get cciControlString(): string | null {
-    let cci = this._control.hdf.wraps.tags.cci;
+    let cci = this.control.hdf.wraps.tags.cci;
     if (!cci) {
       return null;
     } else if (Array.isArray(cci)) {
@@ -161,8 +145,8 @@ export default class ControlRowDetails extends ControlRowDetailsProps {
   }
 
   get main_desc(): string {
-    if (this._control.data.desc) {
-      return this._control.data.desc.trim();
+    if (this.control.data.desc) {
+      return this.control.data.desc.trim();
     } else {
       return 'No description';
     }
@@ -200,7 +184,7 @@ export default class ControlRowDetails extends ControlRowDetailsProps {
 
   /** Shown above the description */
   get header(): string {
-    let msg_split = this._control.root.hdf.finding_details.split(':');
+    let msg_split = this.control.root.hdf.finding_details.split(':');
     if (msg_split.length === 1) {
       return msg_split[0] + '.';
     } else {
@@ -209,7 +193,7 @@ export default class ControlRowDetails extends ControlRowDetailsProps {
   }
 
   get details(): Detail[] {
-    let c = this._control;
+    let c = this.control;
     return [
       {
         name: 'Control',

--- a/apps/frontend/src/components/cards/controltable/ControlTable.vue
+++ b/apps/frontend/src/components/cards/controltable/ControlTable.vue
@@ -76,9 +76,10 @@ import ControlRowDetails from '@/components/cards/controltable/ControlRowDetails
 import ColumnHeader, {Sort} from '@/components/generic/ColumnHeader.vue';
 import ResponsiveRowSwitch from '@/components/cards/controltable/ResponsiveRowSwitch.vue';
 
-import {FilteredDataModule} from '@/store/data_filters';
+import {Filter, FilteredDataModule} from '@/store/data_filters';
 import {control_unique_key} from '@/utilities/format_util';
 import {context} from 'inspecjs';
+import {Prop} from 'vue-property-decorator';
 
 // Tracks the visibility of an HDF control
 interface ListElt {
@@ -92,16 +93,6 @@ interface ListElt {
   control: context.ContextualizedControl;
 }
 
-// We declare the props separately to make props types inferable.
-const ControlTableProps = Vue.extend({
-  props: {
-    filter: {
-      type: Object, // Of type filter
-      required: true
-    }
-  }
-});
-
 @Component({
   components: {
     ControlRowHeader,
@@ -110,7 +101,8 @@ const ControlTableProps = Vue.extend({
     ResponsiveRowSwitch
   }
 })
-export default class ControlTable extends ControlTableProps {
+export default class ControlTable extends Vue {
+  @Prop({type: Object, required: true}) readonly filter!: Filter;
   // Whether to allow multiple expansions
   single_expand: boolean = false;
 

--- a/apps/frontend/src/components/cards/controltable/ResponsiveRowLarge.vue
+++ b/apps/frontend/src/components/cards/controltable/ResponsiveRowLarge.vue
@@ -34,13 +34,8 @@
 import Vue from 'vue';
 import Component from 'vue-class-component';
 
-const Props = Vue.extend({
-  props: {
-    statusColor: String
-  }
-});
 @Component
-export default class Row extends Props {}
+export default class Row extends Vue {}
 </script>
 
 <style scoped>

--- a/apps/frontend/src/components/cards/controltable/ResponsiveRowMedium.vue
+++ b/apps/frontend/src/components/cards/controltable/ResponsiveRowMedium.vue
@@ -28,13 +28,8 @@
 import Vue from 'vue';
 import Component from 'vue-class-component';
 
-const Props = Vue.extend({
-  props: {
-    statusColor: String
-  }
-});
 @Component
-export default class Row extends Props {}
+export default class Row extends Vue {}
 </script>
 
 <style scoped>

--- a/apps/frontend/src/components/cards/controltable/ResponsiveRowSmall.vue
+++ b/apps/frontend/src/components/cards/controltable/ResponsiveRowSmall.vue
@@ -24,13 +24,8 @@
 import Vue from 'vue';
 import Component from 'vue-class-component';
 
-const Props = Vue.extend({
-  props: {
-    statusColor: String
-  }
-});
 @Component
-export default class Row extends Props {}
+export default class Row extends Vue {}
 </script>
 
 <style scoped>

--- a/apps/frontend/src/components/cards/controltable/ResponsiveRowSwitch.vue
+++ b/apps/frontend/src/components/cards/controltable/ResponsiveRowSwitch.vue
@@ -71,11 +71,6 @@ import ResponsiveRowLarge from '@/components/cards/controltable/ResponsiveRowLar
 import ResponsiveRowMedium from '@/components/cards/controltable/ResponsiveRowMedium.vue';
 import ResponsiveRowSmall from '@/components/cards/controltable/ResponsiveRowSmall.vue';
 
-const Props = Vue.extend({
-  props: {
-    statusColor: String
-  }
-});
 @Component({
   components: {
     ResponsiveRowLarge,
@@ -83,5 +78,5 @@ const Props = Vue.extend({
     ResponsiveRowSmall
   }
 })
-export default class ControlRowHeader extends Props {}
+export default class ControlRowHeader extends Vue {}
 </script>

--- a/apps/frontend/src/components/cards/treemap/Treemap.vue
+++ b/apps/frontend/src/components/cards/treemap/Treemap.vue
@@ -37,7 +37,7 @@ import Vue from 'vue';
 import Component from 'vue-class-component';
 
 import * as d3 from 'd3';
-import {FilteredDataModule, TreeMapState} from '@/store/data_filters';
+import {Filter, FilteredDataModule, TreeMapState} from '@/store/data_filters';
 import {
   TreemapNode,
   build_nist_tree_map,
@@ -48,33 +48,9 @@ import {HierarchyRectangularNode} from 'd3';
 import Cell, {XYScale} from '@/components/cards/treemap/Cell.vue';
 //@ts-ignore
 import resize from 'vue-resize-directive';
-import {ColorHackModule} from '../../../store/color_hack';
+import {ColorHackModule} from '@/store/color_hack';
 import {compare_arrays} from '@/utilities/helper_util';
-
-// We declare the props separately to make props types inferable.
-const TreemapProps = Vue.extend({
-  props: {
-    value: {
-      type: Array, // Of type Array<TreeMapNode>, representing current descent path
-      required: true
-    },
-    /*
-    path: {
-      type: Array, // Of type TreeMapState, representing current descent path
-      required: true
-    },
-    */
-    selected_control: {
-      // Represents control id
-      type: String,
-      required: false
-    },
-    filter: {
-      type: Object, // Of type Filter
-      required: true
-    }
-  }
-});
+import {Prop, PropSync} from 'vue-property-decorator';
 
 // Respects a v-model of type TreeMapState
 @Component({
@@ -85,15 +61,16 @@ const TreemapProps = Vue.extend({
     resize
   }
 })
-export default class Treemap extends TreemapProps {
+export default class Treemap extends Vue {
+  @Prop({type: Array, required: true}) readonly value!: TreeMapState;
+  @Prop({type: Object, required: true}) readonly filter!: Filter;
+  @PropSync('selected_control', {type: String}) synced_selected_control!:
+    | string
+    | null;
+
   /** The svg internal coordinate space */
   width: number = 1600;
   height: number = 530;
-
-  /** Typed getter on current spec path */
-  get _state(): TreeMapState {
-    return this.value as TreeMapState;
-  }
 
   /** The currently selected treemap node. Wrapped to avoid initialization woes */
   get selected_node(): d3.HierarchyRectangularNode<TreemapNode> {
@@ -103,14 +80,14 @@ export default class Treemap extends TreemapProps {
     let depth = 0;
 
     try {
-      for (; depth < this._state.length; depth++) {
+      for (; depth < this.value.length; depth++) {
         // If the current has no children, then just bail here
         if (curr.children === undefined) {
           throw Error('no children to go into');
         }
 
         // Fetch the next path spec
-        let next_specifiers = this._state.slice(0, depth + 1);
+        let next_specifiers = this.value.slice(0, depth + 1);
 
         let new_curr = curr.children.find((child) => {
           if (is_parent(child.data)) {
@@ -136,7 +113,7 @@ export default class Treemap extends TreemapProps {
       }
     } catch (some_traversal_error) {
       // Slice to last successful depth. Slice is non inclusive so this works
-      this.set_path(this._state.slice(0, depth));
+      this.set_path(this.value.slice(0, depth));
     }
 
     // Return as deep as we travelled
@@ -183,10 +160,10 @@ export default class Treemap extends TreemapProps {
     // If it is a leaf, then select it
     if (is_leaf(n.data)) {
       let id = n.data.control.data.id;
-      if (id !== this.selected_control) {
-        this.$emit('update:selected_control', id);
+      if (id !== this.synced_selected_control) {
+        this.synced_selected_control = id;
       } else {
-        this.$emit('update:selected_control', null);
+        this.synced_selected_control = null;
       }
     } else {
       // Otherwise, dive away. Set course for the leading title
@@ -199,12 +176,12 @@ export default class Treemap extends TreemapProps {
 
   /** Submits an event to go up one node */
   up(): void {
-    if (this._state.length) {
+    if (this.value.length) {
       // Slice and dice, baybee
-      this.set_path(this._state.slice(0, this._state.length - 1));
+      this.set_path(this.value.slice(0, this.value.length - 1));
 
       // Also clear selected
-      this.$emit('update:selected_control', null);
+      this.synced_selected_control = null;
     }
   }
 
@@ -215,7 +192,7 @@ export default class Treemap extends TreemapProps {
 
   /** Controls whether we should allow up */
   get allow_up(): boolean {
-    return this._state.length > 0;
+    return this.value.length > 0;
   }
 
   /** Called on resize */

--- a/apps/frontend/src/components/generic/ApexLineChart.vue
+++ b/apps/frontend/src/components/generic/ApexLineChart.vue
@@ -10,32 +10,12 @@
 </template>
 
 <script lang="ts">
-import Vue, {PropType} from 'vue';
+import Vue from 'vue';
 import Component from 'vue-class-component';
 import VueApexCharts from 'vue-apexcharts';
 import {ApexOptions} from 'apexcharts';
-
-// We declare the props separately to make props types inferable.
-const ApexLineChartProps = Vue.extend({
-  props: {
-    categories: {
-      type: Array as PropType<string[]>,
-      validator: (value) => {
-        return value.every((element) => typeof element === 'string');
-      }
-    }, // Should be of type string[]
-    series: {
-      type: Array as PropType<SeriesItem[]>,
-      validator: (value) => {
-        return value.every((element) => typeof element === 'object');
-      }
-    }, // Should be of type object[]
-    upper_range: Number, //upper bound of y axis
-    sev_chart: Boolean, //identifies chart as severity chart
-    title: String,
-    y_title: String
-  }
-});
+import {Category} from './ApexPieChart.vue';
+import {Prop} from 'vue-property-decorator';
 
 let id_counter = 0;
 function next_id(): number {
@@ -56,7 +36,14 @@ export interface SeriesItem {
     VueApexCharts
   }
 })
-export default class ApexLineChart extends ApexLineChartProps {
+export default class ApexLineChart extends Vue {
+  @Prop({required: true, type: Array}) readonly categories!: Category<string>[];
+  @Prop({required: true, type: Array}) readonly series!: number[];
+  @Prop({type: Number}) readonly upper_range!: number; //upper bound of y axis
+  @Prop({type: Boolean}) readonly sev_chart!: boolean; //identifies chart as severity chart
+  @Prop({type: String}) readonly title!: string;
+  @Prop({type: String}) readonly y_title!: string;
+
   chart_id: string = `line_chart_${next_id}`;
 
   get label_colors(): string[] {

--- a/apps/frontend/src/components/generic/ColumnHeader.vue
+++ b/apps/frontend/src/components/generic/ColumnHeader.vue
@@ -11,25 +11,14 @@
 <script lang="ts">
 import Vue from 'vue';
 import Component from 'vue-class-component';
+import {Prop} from 'vue-property-decorator';
 
 export type Sort = 'ascending' | 'descending' | 'none' | 'disabled';
 
-// We declare the props separately to make props types inferable.
-const Props = Vue.extend({
-  props: {
-    text: {
-      type: String,
-      required: true
-    },
-    sort: {
-      type: String, // Of type Sort
-      required: true
-    }
-  }
-});
-
 @Component
-export default class ColumnHeader extends Props {
+export default class ColumnHeader extends Vue {
+  @Prop({type: String, required: true}) readonly text!: string;
+  @Prop({type: String, required: true}) readonly sort!: Sort;
   /**
    * Simple boolean deciding whether or not to actually show/allow sorting
    */
@@ -44,7 +33,7 @@ export default class ColumnHeader extends Props {
    */
   toggle_sort(): void {
     let new_sort: string;
-    switch (this.sort as Sort) {
+    switch (this.sort) {
       default: // Shouldn't happen but whatever
       case 'none':
         new_sort = 'descending';
@@ -63,7 +52,7 @@ export default class ColumnHeader extends Props {
    * Computes the material theme getter to use for the sort icon
    */
   get icon(): string {
-    switch (this.sort as Sort) {
+    switch (this.sort) {
       default:
       case 'none':
         return 'mdi-sort-variant';

--- a/apps/frontend/src/components/generic/TruncatedText.vue
+++ b/apps/frontend/src/components/generic/TruncatedText.vue
@@ -17,6 +17,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import Component from 'vue-class-component';
+import {Prop} from 'vue-property-decorator';
 
 // https://stackoverflow.com/questions/143815/determine-if-an-html-elements-content-overflows
 // Determines if the passed element is overflowing its bounds,
@@ -42,26 +43,12 @@ function check_overflow(el: HTMLElement): boolean {
   return is_overflowing;
 }
 
-// Define our props
-const Props = Vue.extend({
-  props: {
-    text: {
-      type: String,
-      required: true
-    },
-    span_class: {
-      type: Array, // Array<string>
-      default: () => []
-    },
-    span_style: {
-      type: String,
-      default: ''
-    }
-  }
-});
-
 @Component
-export default class TruncatedText extends Props {
+export default class TruncatedText extends Vue {
+  @Prop({type: String, required: true}) readonly text!: string;
+  @Prop({type: Array, default: () => []}) readonly span_class!: string[];
+  @Prop({type: String, default: ''}) readonly span_style!: string;
+
   get is_truncated(): boolean {
     if (this.$refs['text'] !== undefined) {
       return check_overflow(this.$refs['text'] as HTMLElement);

--- a/apps/frontend/src/components/global/AboutModal.vue
+++ b/apps/frontend/src/components/global/AboutModal.vue
@@ -57,30 +57,30 @@ import Component from 'vue-class-component';
 
 import {AppInfoModule} from '@/store/app_info';
 
-// We declare the props separately to make props types inferable.
-const Props = Vue.extend({
-  props: {}
-});
-@Component({
-  components: {}
-})
-export default class HelpModal extends Props {
+@Component
+export default class HelpModal extends Vue {
   dialog: boolean = false;
+
   get version(): string {
     return AppInfoModule.version;
   }
+
   get changelog(): string {
     return AppInfoModule.changelog;
   }
+
   get repository(): string {
     return AppInfoModule.repository;
   }
+
   get branch(): string {
     return AppInfoModule.branch;
   }
+
   get issues(): string {
     return AppInfoModule.issues;
   }
+
   get passedClickable(): boolean | undefined {
     return this.$slots.clickable ? true : false;
   }

--- a/apps/frontend/src/components/global/ExportCaat.vue
+++ b/apps/frontend/src/components/global/ExportCaat.vue
@@ -21,28 +21,18 @@ import XLSX from 'xlsx';
 import {saveAs} from 'file-saver';
 import {HDFControl} from 'inspecjs';
 import LinkItem from '@/components/global/sidebaritems/IconLinkItem.vue';
+import {Prop} from 'vue-property-decorator';
 
 const MAX_CELL_SIZE = 32000; // Rounding a bit here.
 type CAATRow = string[];
-type CAAT = CAATRow[];
-
-// We declare the props separately
-// to make props types inferrable.
-const Props = Vue.extend({
-  props: {
-    filter: {
-      type: Object, // Of type Filter
-      required: true
-    }
-  }
-});
 
 @Component({
   components: {
     LinkItem
   }
 })
-export default class ExportCaat extends Props {
+export default class ExportCaat extends Vue {
+  @Prop({type: Object, required: true}) readonly filter!: Filter;
   /** Turns a control into a CAAT row.
    *  Checks vuln_list first to see if this gid is already included
    */
@@ -144,10 +134,10 @@ export default class ExportCaat extends Props {
 
   export_caat() {
     // Get our data
-    let controls = FilteredDataModule.controls(this.filter as Filter);
+    let controls = FilteredDataModule.controls(this.filter);
 
     // Initialize our data structures
-    let caat: CAAT = [this.header()];
+    let caat: CAATRow[] = [this.header()];
 
     // Turn controls into rows
     let non_deduped_rows: Array<CAATRow> = [];

--- a/apps/frontend/src/components/global/ExportJson.vue
+++ b/apps/frontend/src/components/global/ExportJson.vue
@@ -24,12 +24,6 @@ import {FilteredDataModule} from '@/store/data_filters';
 import {ZipFile} from 'yazl';
 import concat from 'concat-stream';
 
-// We declare the props separately
-// to make props types inferrable.
-const Props = Vue.extend({
-  props: {}
-});
-
 type FileData = {
   name: string;
   contents: string;
@@ -40,7 +34,7 @@ type FileData = {
     LinkItem
   }
 })
-export default class ExportJSON extends Props {
+export default class ExportJSON extends Vue {
   populate_files(): FileData[] {
     let ids = FilteredDataModule.selected_file_ids;
     let fileData = new Array<FileData>();

--- a/apps/frontend/src/components/global/ExportNist.vue
+++ b/apps/frontend/src/components/global/ExportNist.vue
@@ -24,6 +24,7 @@ import LinkItem from '@/components/global/sidebaritems/IconLinkItem.vue';
 import {NistControl} from 'inspecjs/dist/nist';
 import {FileID} from '@/store/report_intake';
 import {InspecDataModule} from '@/store/data_store';
+import {Prop} from 'vue-property-decorator';
 
 const MAX_SHEET_NAME_SIZE = 31;
 export type NISTRow = [string];
@@ -34,23 +35,14 @@ export interface Sheet {
   data: NISTList;
 }
 
-// We declare the props separately
-// to make props types inferrable.
-const Props = Vue.extend({
-  props: {
-    filter: {
-      type: Object, // Of type Filter
-      required: true
-    }
-  }
-});
-
 @Component({
   components: {
     LinkItem
   }
 })
-export default class ExportNIST extends Props {
+export default class ExportNIST extends Vue {
+  @Prop({type: Object, required: true}) readonly filter!: Filter;
+
   /** Formats a tag into a well-structured nist string */
   format_tag(control: NistControl): string | null {
     // For now just do raw text. Once Mo's nist work is done we can make sure these are well formed
@@ -81,7 +73,7 @@ export default class ExportNIST extends Props {
     }
 
     // Get our data
-    let base_filter = this.filter as Filter;
+    let base_filter = this.filter;
     let modified_filter: Filter = {...base_filter, fromFile: id};
     let controls = FilteredDataModule.controls(modified_filter);
 

--- a/apps/frontend/src/components/global/Footer.vue
+++ b/apps/frontend/src/components/global/Footer.vue
@@ -10,13 +10,8 @@
 import Vue from 'vue';
 import Component from 'vue-class-component';
 
-// We declare the props separately to make props types inferable.
-const FooterProps = Vue.extend({
-  props: {}
-});
-
 @Component({
   components: {}
 })
-export default class Footer extends FooterProps {}
+export default class Footer extends Vue {}
 </script>

--- a/apps/frontend/src/components/global/HelpAboutDropdown.vue
+++ b/apps/frontend/src/components/global/HelpAboutDropdown.vue
@@ -35,17 +35,21 @@
 </template>
 
 <script lang="ts">
+import Vue from 'vue';
+
 import LinkItem from '@/components/global/sidebaritems/IconLinkItem.vue';
 import AboutModal from '@/components/global/AboutModal.vue';
 import HelpModal from '@/components/global/HelpModal.vue';
+import Component from 'vue-class-component';
 
-export default {
+@Component({
   components: {
     HelpModal,
     AboutModal,
     LinkItem
   }
-};
+})
+export default class HelpAboutDropdown extends Vue {}
 </script>
 
 <style scoped>

--- a/apps/frontend/src/components/global/HelpModal.vue
+++ b/apps/frontend/src/components/global/HelpModal.vue
@@ -74,14 +74,8 @@ import Component from 'vue-class-component';
 
 import {AppInfoModule} from '@/store/app_info';
 
-// We declare the props separately to make props types inferable.
-const Props = Vue.extend({
-  props: {}
-});
-@Component({
-  components: {}
-})
-export default class HelpModal extends Props {
+@Component
+export default class HelpModal extends Vue {
   dialog: boolean = false;
   get version(): string {
     return AppInfoModule.version;

--- a/apps/frontend/src/components/global/Modal.vue
+++ b/apps/frontend/src/components/global/Modal.vue
@@ -22,7 +22,7 @@ import {Prop} from 'vue-property-decorator';
   components: {}
 })
 export default class Modal extends Vue {
-  @Prop({default: true}) readonly visible!: Boolean;
-  @Prop({default: false}) readonly persistent!: Boolean;
+  @Prop({default: true}) readonly visible!: boolean;
+  @Prop({default: false}) readonly persistent!: boolean;
 }
 </script>

--- a/apps/frontend/src/components/global/Sidebar.vue
+++ b/apps/frontend/src/components/global/Sidebar.vue
@@ -35,7 +35,6 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
 import Component, {mixins} from 'vue-class-component';
 import {EvaluationFile, ProfileFile} from '@/store/report_intake';
 import {InspecDataModule} from '@/store/data_store';
@@ -43,20 +42,16 @@ import {FilteredDataModule} from '@/store/data_filters';
 import RouteMixin from '@/mixins/RouteMixin';
 
 import DropdownContent from '@/components/global/sidebaritems/DropdownContent.vue';
-
-// We declare the props separately to make props types inferable.
-const SidebarProps = Vue.extend({
-  props: {
-    value: Boolean // Whether or not this item should make itself visible
-  }
-});
+import {Prop} from 'vue-property-decorator';
 
 @Component({
   components: {
     DropdownContent
   }
 })
-export default class Sidebar extends mixins(SidebarProps, RouteMixin) {
+export default class Sidebar extends mixins(RouteMixin) {
+  @Prop({type: Boolean}) readonly value!: boolean;
+
   // open the appropriate v-expansion-panel based on current route
   get active_path() {
     if (this.current_route === '/profiles') return 1;

--- a/apps/frontend/src/components/global/Snackbar.vue
+++ b/apps/frontend/src/components/global/Snackbar.vue
@@ -26,18 +26,22 @@ import {SnackbarModule} from '@/store/snackbar';
 import Component from 'vue-class-component';
 import Vue from 'vue';
 
-@Component({})
+@Component
 export default class Snackbar extends Vue {
   messageContent: string = '';
+
   get show(): boolean {
     return SnackbarModule.show;
   }
+
   set show(visibility) {
     SnackbarModule.visibility(visibility);
   }
+
   get error(): boolean {
     return SnackbarModule.error;
   }
+
   get message(): string {
     this.messageContent = SnackbarModule.message;
     if (this.error) {

--- a/apps/frontend/src/components/global/Toolbar.vue
+++ b/apps/frontend/src/components/global/Toolbar.vue
@@ -23,13 +23,8 @@
 import Vue from 'vue';
 import Component from 'vue-class-component';
 
-// We declare the props separately to make props types inferable.
-const ToolbarProps = Vue.extend({
-  props: {}
-});
-
 @Component({
   components: {}
 })
-export default class Toolbar extends ToolbarProps {}
+export default class Toolbar extends Vue {}
 </script>

--- a/apps/frontend/src/components/global/Topbar.vue
+++ b/apps/frontend/src/components/global/Topbar.vue
@@ -50,7 +50,7 @@ import {Prop} from 'vue-property-decorator';
   }
 })
 export default class Topbar extends mixins(ServerMixin) {
-  @Prop({required: true}) readonly title!: String;
+  @Prop({type: String, required: true}) readonly title!: string;
 
   showModal: boolean = false;
 

--- a/apps/frontend/src/components/global/UploadNexus.vue
+++ b/apps/frontend/src/components/global/UploadNexus.vue
@@ -97,8 +97,8 @@ const local_tab = new LocalStorageVal<string>('nexus_curr_tab');
   }
 })
 export default class UploadNexus extends mixins(ServerMixin, RouteMixin) {
-  @Prop({default: true}) readonly visible!: Boolean;
-  @Prop({default: false}) readonly persistent!: Boolean;
+  @Prop({default: true}) readonly visible!: boolean;
+  @Prop({default: false}) readonly persistent!: boolean;
 
   active_tab: string = local_tab.get_default('uploadtab-local');
 
@@ -125,7 +125,10 @@ export default class UploadNexus extends mixins(ServerMixin, RouteMixin) {
     ).length;
 
     if (numEvaluations > numProfiles) {
-      this.navigateUnlessActive('/results');
+      // Only navigate the user to the results page if they are not
+      // already on the compare page.
+      if ('/compare' !== this.current_route)
+        this.navigateUnlessActive('/results');
     } else {
       this.navigateUnlessActive('/profiles');
     }

--- a/apps/frontend/src/components/global/sidebaritems/IconLinkItem.vue
+++ b/apps/frontend/src/components/global/sidebaritems/IconLinkItem.vue
@@ -13,36 +13,12 @@
 <script lang="ts">
 import Vue from 'vue';
 import Component from 'vue-class-component';
+import {Prop} from 'vue-property-decorator';
 
-// We declare the props separately to make props types inferable.
-const LinkItemProps = Vue.extend({
-  props: {
-    text: {
-      type: String,
-      required: true
-    },
-    icon: {
-      type: String,
-      required: false
-    },
-    link: {
-      type: String,
-      required: false
-    },
-    action: {
-      type: Object, // Of type linkaction
-      required: false
-    }
-  }
-});
-
-/** If provided, will be called whenever clicked. */
-export interface LinkAction {
-  callback: () => void;
+@Component
+export default class LinkItem extends Vue {
+  @Prop({type: String, required: true}) readonly text!: string;
+  @Prop({type: String}) readonly icon!: string;
+  @Prop({type: String}) readonly link!: string;
 }
-
-@Component({
-  components: {}
-})
-export default class LinkItem extends LinkItemProps {}
 </script>

--- a/apps/frontend/src/components/global/sidebaritems/SidebarFileList.vue
+++ b/apps/frontend/src/components/global/sidebaritems/SidebarFileList.vue
@@ -27,28 +27,21 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
 import Component, {mixins} from 'vue-class-component';
 import axios from 'axios';
 import {ICreateEvaluation} from '@heimdall/interfaces';
 import {InspecDataModule} from '@/store/data_store';
 import {FilteredDataModule} from '@/store/data_filters';
-import {EvaluationFile} from '@/store/report_intake';
+import {EvaluationFile, ProfileFile} from '@/store/report_intake';
 import {SnackbarModule} from '@/store/snackbar';
 
 import ServerMixin from '@/mixins/ServerMixin';
+import {Prop} from 'vue-property-decorator';
 
-// We declare the props separately to make props types inferable.
-const FileItemProps = Vue.extend({
-  props: {
-    file: Object // Of type EvaluationFile or ProfileFile
-  }
-});
+@Component
+export default class FileItem extends mixins(ServerMixin) {
+  @Prop({type: Object}) readonly file!: EvaluationFile | ProfileFile;
 
-@Component({
-  components: {}
-})
-export default class FileItem extends mixins(FileItemProps, ServerMixin) {
   select_file() {
     if (this.file.hasOwnProperty('evaluation')) {
       FilteredDataModule.toggle_evaluation(this.file.unique_id);
@@ -106,7 +99,7 @@ export default class FileItem extends mixins(FileItemProps, ServerMixin) {
 
   //gives different icons for a file if it is just a profile
   get icon(): string {
-    if (this.file.profile !== undefined) {
+    if (this.file.hasOwnProperty('profile')) {
       return 'mdi-note';
     } else {
       return 'mdi-google-analytics';

--- a/apps/frontend/src/components/global/upload_tabs/FileReader.vue
+++ b/apps/frontend/src/components/global/upload_tabs/FileReader.vue
@@ -66,7 +66,7 @@ Vue.use(vueFileAgent);
  * Uploads data to the store with unique IDs asynchronously as soon as data is entered.
  * Emits "got-files" with a list of the unique_ids of the loaded files.
  */
-@Component({})
+@Component
 export default class FileReader extends mixins(ServerMixin) {
   fileRecords = new Array();
   loading = false;

--- a/apps/frontend/src/components/global/upload_tabs/HelpFooter.vue
+++ b/apps/frontend/src/components/global/upload_tabs/HelpFooter.vue
@@ -41,10 +41,6 @@ import Component from 'vue-class-component';
 import HelpModal from '@/components/global/HelpModal.vue';
 import AboutModal from '@/components/global/AboutModal.vue';
 import {AppInfoModule} from '@/store/app_info';
-// We declare the props separately to make props types inferable.
-const Props = Vue.extend({
-  props: {}
-});
 
 @Component({
   components: {
@@ -52,7 +48,7 @@ const Props = Vue.extend({
     HelpModal
   }
 })
-export default class HelpFooter extends Props {
+export default class HelpFooter extends Vue {
   get version(): string {
     return AppInfoModule.version;
   }

--- a/apps/frontend/src/components/global/upload_tabs/LoadFileList.vue
+++ b/apps/frontend/src/components/global/upload_tabs/LoadFileList.vue
@@ -42,9 +42,10 @@ import {Samples} from 'aws-sdk/clients/devicefarm';
 })
 export default class LoadFileList extends Vue {
   @Prop({required: true}) readonly headers!: Object[];
-  @Prop({default: false}) readonly loading!: boolean;
-  @Prop({default: 'id'}) readonly fileKey!: string;
-  @Prop({default: false}) readonly files!: IEvaluation[] | Samples[];
+  @Prop({type: Boolean, default: false}) readonly loading!: boolean;
+  @Prop({type: String, default: 'id'}) readonly fileKey!: string;
+  @Prop({required: true}) readonly files!: IEvaluation[] | Samples[];
+
   selectedFiles: IEvaluation[] | Samples[] = [];
 
   load_results(evaluations: IEvaluation[]) {

--- a/apps/frontend/src/components/global/upload_tabs/SampleList.vue
+++ b/apps/frontend/src/components/global/upload_tabs/SampleList.vue
@@ -8,7 +8,7 @@
       :headers="headers"
       :files="samples"
       file-key="filename"
-      loading="false"
+      :loading="false"
       @load-results="load_samples($event)"
     />
   </v-card>
@@ -23,17 +23,12 @@ import {SnackbarModule} from '@/store/snackbar';
 
 import {samples, Sample} from '@/utilities/sample_util';
 
-// We declare the props separately to make props types inferable.
-const Props = Vue.extend({
-  props: {}
-});
-
 @Component({
   components: {
     LoadFileList
   }
 })
-export default class SampleList extends Props {
+export default class SampleList extends Vue {
   samples: Sample[] = samples;
   headers: Object[] = [
     {

--- a/apps/frontend/src/components/global/upload_tabs/aws/AuthStepBasic.vue
+++ b/apps/frontend/src/components/global/upload_tabs/aws/AuthStepBasic.vue
@@ -39,17 +39,10 @@
 import Vue from 'vue';
 import Component from 'vue-class-component';
 
-import {LocalStorageVal} from '../../../../utilities/helper_util';
+import {LocalStorageVal} from '@/utilities/helper_util';
 
 import FileList from '@/components/global/upload_tabs/aws/FileList.vue';
-
-// We declare the props separately to make props types inferable.
-const Props = Vue.extend({
-  props: {
-    access_token: String,
-    secret_token: String
-  }
-});
+import {Prop} from 'vue-property-decorator';
 
 /** Localstorage keys */
 const local_access_token = new LocalStorageVal<string>('aws_s3_access_token');
@@ -65,7 +58,10 @@ const local_secret_token = new LocalStorageVal<string>('aws_s3_secret_token');
     FileList
   }
 })
-export default class S3Reader extends Props {
+export default class S3Reader extends Vue {
+  @Prop({type: String}) readonly access_token!: string;
+  @Prop({type: String}) readonly secret_token!: string;
+
   /** Models if currently displayed form is valid.
    * Shouldn't be used to interpret literally anything else as valid - just checks fields filled
    */

--- a/apps/frontend/src/components/global/upload_tabs/aws/AuthStepMFA.vue
+++ b/apps/frontend/src/components/global/upload_tabs/aws/AuthStepMFA.vue
@@ -31,16 +31,9 @@
 <script lang="ts">
 import Vue from 'vue';
 import Component from 'vue-class-component';
+import {PropSync} from 'vue-property-decorator';
 
-import {LocalStorageVal} from '../../../../utilities/helper_util';
-
-// We declare the props separately to make props types inferable.
-const Props = Vue.extend({
-  props: {
-    mfa_serial: String,
-    mfa_token: String
-  }
-});
+import {LocalStorageVal} from '@/utilities/helper_util';
 
 /** Localstorage keys */
 const local_mfa_serial = new LocalStorageVal<string>('aws_s3_mfa_serial');
@@ -50,8 +43,10 @@ const local_mfa_serial = new LocalStorageVal<string>('aws_s3_mfa_serial');
  * Uploads data to the store with unique IDs asynchronously as soon as data is entered.
  * Emits "got-files" with a list of the unique_ids of the loaded files.
  */
-@Component({})
-export default class S3Reader extends Props {
+@Component
+export default class S3Reader extends Vue {
+  @PropSync('mfa_token', {type: String}) token!: string;
+  @PropSync('mfa_serial', {type: String}) serial!: string;
   /** Models if currently displayed form is valid.
    * Shouldn't be used to interpret literally anything else as valid - just checks fields filled
    */
@@ -71,13 +66,13 @@ export default class S3Reader extends Props {
 
   /** Handles changes to mfa serial */
   change_mfa_token(new_value: string) {
-    this.$emit('update:mfa_token', new_value);
+    this.token = new_value;
   }
 
   /** Handles changes to mfa token */
   change_mfa_serial(new_value: string) {
     local_mfa_serial.set(new_value);
-    this.$emit('update:mfa_serial', new_value);
+    this.serial = new_value;
   }
 
   /** When button is pressed or enter is pressed */

--- a/apps/frontend/src/components/global/upload_tabs/aws/FileList.vue
+++ b/apps/frontend/src/components/global/upload_tabs/aws/FileList.vue
@@ -51,40 +51,22 @@ import Component from 'vue-class-component';
 import S3 from 'aws-sdk/clients/s3';
 import {InspecIntakeModule} from '@/store/report_intake';
 
-import {Auth, fetch_s3_file} from '../../../../utilities/aws_util';
-import {LocalStorageVal} from '../../../../utilities/helper_util';
+import {Auth, fetch_s3_file} from '@/utilities/aws_util';
+import {LocalStorageVal} from '@/utilities/helper_util';
+import {Prop} from 'vue-property-decorator';
 
 // Caches the bucket name
 const local_bucket_name = new LocalStorageVal<string>('aws_bucket_name');
 
-// We declare the props separately to make props types inferable.
-const Props = Vue.extend({
-  props: {
-    auth: Object, // Can be null, but shouldn't be!
-    files: Array, // List of S3 objects of current files
-    error: String
-  }
-});
-
 @Component({
   components: {}
 })
-export default class FileList extends Props {
+export default class FileList extends Vue {
+  @Prop({type: Object}) readonly auth!: Auth;
+  @Prop({type: Array}) readonly files!: S3.Object[];
+
   /** The name written in the form */
   form_bucket_name: string = '';
-
-  /** Currently visible files */
-  get _files(): S3.Object[] {
-    return this.files as S3.Object[];
-  }
-
-  /** Typed getter for auth */
-  get _auth(): Auth {
-    if (this.auth === null) {
-      throw new Error("We aren't auth'd");
-    }
-    return this.auth as Auth;
-  }
 
   /** On mount, try to look up stored auth info */
   /** Callback for when user selects a file.
@@ -92,19 +74,17 @@ export default class FileList extends Props {
    */
   async load_file(index: number): Promise<void> {
     // Get it out of the list
-    let file = this._files[index];
+    let file = this.files[index];
 
     // Fetch it from s3, and promise to submit it to be loaded afterwards
-    await fetch_s3_file(
-      this._auth.creds,
-      file.Key!,
-      this.form_bucket_name
-    ).then((content) => {
-      InspecIntakeModule.loadText({
-        text: content,
-        filename: file.Key!
-      }).then((unique_id) => this.$emit('got-files', [unique_id]));
-    });
+    await fetch_s3_file(this.auth.creds, file.Key!, this.form_bucket_name).then(
+      (content) => {
+        InspecIntakeModule.loadText({
+          text: content,
+          filename: file.Key!
+        }).then((unique_id) => this.$emit('got-files', [unique_id]));
+      }
+    );
   }
 
   /** Recalls the last entered bucket name.  */

--- a/apps/frontend/src/components/global/upload_tabs/aws/S3Reader.vue
+++ b/apps/frontend/src/components/global/upload_tabs/aws/S3Reader.vue
@@ -42,7 +42,7 @@ import Vue from 'vue';
 import Component from 'vue-class-component';
 import S3 from 'aws-sdk/clients/s3';
 import {AWSError} from 'aws-sdk/lib/error';
-import {LocalStorageVal} from '../../../../utilities/helper_util';
+import {LocalStorageVal} from '@/utilities/helper_util';
 import {SnackbarModule} from '@/store/snackbar';
 import FileList from '@/components/global/upload_tabs/aws/FileList.vue';
 import AuthStepMFA from '@/components/global/upload_tabs/aws/AuthStepMFA.vue';
@@ -53,13 +53,8 @@ import {
   get_session_token,
   MFA_Info,
   AUTH_DURATION
-} from '../../../../utilities/aws_util';
+} from '@/utilities/aws_util';
 import {FileID} from '@/store/report_intake';
-
-// We declare the props separately to make props types inferable.
-const Props = Vue.extend({
-  props: {}
-});
 
 /** The cached session info */
 const local_session_information = new LocalStorageVal<Auth | null>(
@@ -77,7 +72,7 @@ const local_session_information = new LocalStorageVal<Auth | null>(
     FileList
   }
 })
-export default class S3Reader extends Props {
+export default class S3Reader extends Vue {
   /** Form required field rules. Maybe eventually expand to other stuff */
   req_rule = (v: string | null | undefined) =>
     (v || '').trim().length > 0 || 'Field is Required';

--- a/apps/frontend/src/components/global/upload_tabs/splunk/AuthStep.vue
+++ b/apps/frontend/src/components/global/upload_tabs/splunk/AuthStep.vue
@@ -37,18 +37,15 @@
 <script lang="ts">
 import Vue from 'vue';
 import Component from 'vue-class-component';
-import {LocalStorageVal} from '../../../../utilities/helper_util';
+import {LocalStorageVal} from '@/utilities/helper_util';
 
 import FileList from '@/components/global/upload_tabs/aws/FileList.vue';
-import {SplunkEndpoint} from '../../../../utilities/splunk_util';
+import {SplunkEndpoint} from '@/utilities/splunk_util';
 
 // Our saved fields
 const local_username = new LocalStorageVal<string>('splunk_username');
 const local_password = new LocalStorageVal<string>('splunk_password');
 const local_hostname = new LocalStorageVal<string>('splunk_hostname');
-
-// We declare the props separately to make props types inferable.
-const Props = Vue.extend({});
 
 /**
  *
@@ -58,7 +55,7 @@ const Props = Vue.extend({});
     FileList
   }
 })
-export default class SplunkAuth extends Props {
+export default class SplunkAuth extends Vue {
   /** Models if currently displayed form is valid.
    * Shouldn't be used to interpret literally anything else as valid - just checks fields filled
    */

--- a/apps/frontend/src/components/global/upload_tabs/splunk/FileList.vue
+++ b/apps/frontend/src/components/global/upload_tabs/splunk/FileList.vue
@@ -46,19 +46,15 @@ import {v4 as uuid} from 'uuid';
 import {SplunkEndpoint, ExecutionMetaInfo} from '@/utilities/splunk_util';
 import {InspecDataModule} from '@/store/data_store';
 import {contextualizeEvaluation} from 'inspecjs/dist/context';
+import {Prop} from 'vue-property-decorator';
 
 const SEARCH_INTERVAL = 10000;
-
-const Props = Vue.extend({
-  props: {
-    endpoint: Object // Of type SplunkEndpoint. Can be null, but shouldn't be!
-  }
-});
 
 @Component({
   components: {}
 })
-export default class FileList extends Props {
+export default class FileList extends Vue {
+  @Prop({type: Object}) readonly endpoint!: SplunkEndpoint;
   /** The name written in the form */
   search: string = '';
 
@@ -84,14 +80,6 @@ export default class FileList extends Props {
   /** Currently fetch'd executions */
   items: ExecutionMetaInfo[] = [];
 
-  /** Typed getter for endpoint */
-  get _endpoint(): SplunkEndpoint | null {
-    if (this.endpoint == null) {
-      return null;
-    }
-    return this.endpoint as SplunkEndpoint;
-  }
-
   /** Callback for when user selects a file.
    * Loads it into our system.
    * We assume we're auth'd if this is called
@@ -101,7 +89,8 @@ export default class FileList extends Props {
     //let event = (null as unknown) as ExecutionMetaInfo;
 
     // Get its full event list and reconstruct
-    return this._endpoint!.get_execution(event.guid)
+    return this.endpoint
+      .get_execution(event.guid)
       .then((exec) => {
         let unique_id = uuid();
         let file = {
@@ -135,7 +124,7 @@ export default class FileList extends Props {
 
   /** Updates search results, if it is appropriate to do so */
   search_poller() {
-    if (!this._endpoint) {
+    if (!this.endpoint) {
       return;
     }
 
@@ -146,7 +135,7 @@ export default class FileList extends Props {
 
       // Then do the search
       this.already_searching = true;
-      this._endpoint
+      this.endpoint
         .fetch_execution_list()
         .then((l) => {
           // On success, save the items

--- a/apps/frontend/src/components/global/upload_tabs/splunk/SplunkReader.vue
+++ b/apps/frontend/src/components/global/upload_tabs/splunk/SplunkReader.vue
@@ -57,15 +57,7 @@ import {FileID} from '@/store/report_intake';
 import {SnackbarModule} from '@/store/snackbar';
 import AuthStep from './AuthStep.vue';
 import FileList from './FileList.vue';
-import {
-  SplunkEndpoint,
-  SplunkErrorCode
-} from '../../../../utilities/splunk_util';
-
-// We declare the props separately to make props types inferable.
-const Props = Vue.extend({
-  props: {}
-});
+import {SplunkEndpoint, SplunkErrorCode} from '@/utilities/splunk_util';
 
 /**
  * File reader component for taking in inspec JSON data.
@@ -78,7 +70,7 @@ const Props = Vue.extend({
     FileList
   }
 })
-export default class SplunkReader extends Props {
+export default class SplunkReader extends Vue {
   /** Our session information, saved iff valid */
   splunk_state: SplunkEndpoint | null = null;
 

--- a/apps/frontend/src/views/BaseView.vue
+++ b/apps/frontend/src/views/BaseView.vue
@@ -34,17 +34,7 @@ import Vue from 'vue';
 import Component from 'vue-class-component';
 import Sidebar from '@/components/global/Sidebar.vue';
 import Topbar from '@/components/global/Topbar.vue';
-
-// We declare the props separately
-// to make props types inferable.
-const BaseProps = Vue.extend({
-  props: {
-    title: {
-      type: String,
-      default: 'Heimdall Lite'
-    }
-  }
-});
+import {Prop} from 'vue-property-decorator';
 
 @Component({
   components: {
@@ -52,7 +42,8 @@ const BaseProps = Vue.extend({
     Topbar
   }
 })
-export default class Base extends BaseProps {
+export default class Base extends Vue {
+  @Prop({default: 'Heimdall'}) readonly title!: string;
   /** Models if the drawer is open */
   drawer: boolean = true;
 }

--- a/apps/frontend/src/views/Compare.vue
+++ b/apps/frontend/src/views/Compare.vue
@@ -19,7 +19,7 @@
         <v-row>
           <v-col cols="12">
             <div style="position: relative; top: 14px">
-              <h1>Results Comparisons</h1>
+              <h1>Results Comparison</h1>
             </div>
           </v-col>
         </v-row>
@@ -229,12 +229,6 @@ import ApexLineChart, {
 import resize from 'vue-resize-directive';
 import {get_eval_start_time} from '@/utilities/delta_util';
 
-// We declare the props separately
-// to make props types inferrable.
-const Props = Vue.extend({
-  props: {}
-});
-
 @Component({
   components: {
     BaseView,
@@ -248,7 +242,7 @@ const Props = Vue.extend({
     resize
   }
 })
-export default class Compare extends Props {
+export default class Compare extends Vue {
   categories: Category<ControlStatus>[] = [
     {
       label: 'Passed',

--- a/apps/frontend/src/views/Landing.vue
+++ b/apps/frontend/src/views/Landing.vue
@@ -2,30 +2,21 @@
   <v-container>
     <v-row>
       <v-col center xl="8" md="8" sm="12" xs="12">
-        <UploadNexus :persistent="true" @got-files="on_got_files" />
+        <UploadNexus :persistent="true" />
       </v-col>
     </v-row>
   </v-container>
 </template>
 
 <script lang="ts">
+import Vue from 'vue';
 import {Component} from 'vue-property-decorator';
 import UploadNexus from '@/components/global/UploadNexus.vue';
-
-import ServerMixin from '@/mixins/ServerMixin';
-import {mixins} from 'vue-class-component';
 
 @Component({
   components: {
     UploadNexus
   }
 })
-export default class Landing extends mixins(ServerMixin) {
-  /**
-   * Invoked when file(s) are loaded.
-   */
-  on_got_files() {
-    this.$router.push(`/results`);
-  }
-}
+export default class Landing extends Vue {}
 </script>

--- a/apps/frontend/src/views/Results.vue
+++ b/apps/frontend/src/views/Results.vue
@@ -64,7 +64,7 @@
                 </v-card>
               </v-slide-item>
             </v-slide-group>
-            <ProfData
+            <ProfileData
               v-if="eval_info != null"
               class="my-4 mx-10"
               :selected_prof="
@@ -85,7 +85,7 @@
               </v-card-subtitle>
             </v-card>
           </v-col>
-          <ProfData
+          <ProfileData
             v-if="eval_info != null && file_filter.length <= 3"
             class="my-4 mx-10"
             :selected_prof="
@@ -213,17 +213,11 @@ import {ControlStatus, Severity} from 'inspecjs';
 import {FileID, SourcedContextualizedEvaluation} from '@/store/report_intake';
 import {InspecDataModule, isFromProfileFile} from '@/store/data_store';
 
-import ProfData from '@/components/cards/ProfData.vue';
+import ProfileData from '@/components/cards/ProfileData.vue';
 import {context} from 'inspecjs';
 
 import {ServerModule} from '@/store/server';
 import {capitalize} from 'lodash';
-
-// We declare the props separately
-// to make props types inferrable.
-const ResultsProps = Vue.extend({
-  props: {}
-});
 
 @Component({
   components: {
@@ -238,10 +232,10 @@ const ResultsProps = Vue.extend({
     ExportNist,
     ExportJson,
     EvaluationInfo,
-    ProfData
+    ProfileData
   }
 })
-export default class Results extends ResultsProps {
+export default class Results extends Vue {
   /**
    * The currently selected severity, as modeled by the severity chart
    */

--- a/apps/frontend/tests/unit/Compare.spec.ts
+++ b/apps/frontend/tests/unit/Compare.spec.ts
@@ -5,7 +5,7 @@ import {shallowMount, Wrapper} from '@vue/test-utils';
 import Compare from '@/views/Compare.vue';
 import {FilteredDataModule} from '@/store/data_filters';
 import {StatusCountModule} from '@/store/status_counts';
-import {ComparisonContext} from '../../src/utilities/delta_util';
+import {ComparisonContext} from '@/utilities/delta_util';
 
 import {removeAllFiles, loadSample, fileCompliance} from '../util/testingUtils';
 

--- a/apps/frontend/tests/unit/Results.spec.ts
+++ b/apps/frontend/tests/unit/Results.spec.ts
@@ -11,10 +11,10 @@ import {
   expectedCount
 } from '../util/testingUtils';
 import Results from '@/views/Results.vue';
-import ProfData from '@/components/cards/ProfData.vue';
-import {profile_unique_key} from '../../src/utilities/format_util';
+import ProfData from '@/components/cards/ProfileData.vue';
+import {profile_unique_key} from '@/utilities/format_util';
 
-import ControlTable from '../../src/components/cards/controltable/ControlTable.vue';
+import ControlTable from '@/components/cards/controltable/ControlTable.vue';
 import {context} from 'inspecjs';
 interface ListElt {
   // A unique id to be used as a key.

--- a/apps/frontend/tests/unit/Sidebar.spec.ts
+++ b/apps/frontend/tests/unit/Sidebar.spec.ts
@@ -5,7 +5,7 @@ import {shallowMount, Wrapper, createLocalVue} from '@vue/test-utils';
 import {FilteredDataModule} from '@/store/data_filters';
 import {InspecDataModule} from '@/store/data_store';
 import {loadAll} from '../util/testingUtils';
-import Sidebar from '../../src/components/global/Sidebar.vue';
+import Sidebar from '@/components/global/Sidebar.vue';
 import VueRouter from 'vue-router';
 
 const vuetify = new Vuetify();

--- a/apps/frontend/tests/util/testingUtils.ts
+++ b/apps/frontend/tests/util/testingUtils.ts
@@ -27,9 +27,9 @@ export function loadSample(sampleName: string) {
 
 export function loadAll(): void {
   let data = AllRaw();
-  Object.values(data).map((file_result) => {
+  Object.values(data).forEach((file_result) => {
     // Do intake
-    return InspecIntakeModule.loadText({
+    InspecIntakeModule.loadText({
       filename: file_result.name,
       text: file_result.content
     });

--- a/apps/frontend/tests/util/testingUtils.ts
+++ b/apps/frontend/tests/util/testingUtils.ts
@@ -1,6 +1,6 @@
 import 'jest';
 import {AllRaw} from '../util/fs';
-import {InspecIntakeModule} from '../../src/store/report_intake';
+import {InspecIntakeModule} from '@/store/report_intake';
 
 import {StatusCountModule} from '@/store/status_counts';
 import {InspecDataModule} from '@/store/data_store';


### PR DESCRIPTION
Previously the application was declaring props separately for every component. This made it very annoying to use with typescript since it limited to only primitive types. Now that the application is using vue-property-decorator, it is possible to put any type on a model, making declarations much simpler in a lot of cases.

Fixes #89