### PR TITLE
Replace removed Component name for Cell.vue

### DIFF
--- a/apps/frontend/src/components/cards/treemap/Cell.vue
+++ b/apps/frontend/src/components/cards/treemap/Cell.vue
@@ -56,7 +56,9 @@ export interface XYScale {
  * Categories property must be of type Category
  * Emits "select-node" with payload of type d3.HierarchyRectangularNode<TreemapNode>
  */
-@Component
+@Component({
+  name: 'Cell'
+})
 export default class Cell extends Vue {
   @Prop({type: String}) readonly selected_control_id!: string;
   @Prop({type: Object, required: true})


### PR DESCRIPTION
Without this declaration, strange behavior was happening only on production builds. Adding it back has corrected the missing Treemap. Fixes #370