### PR TITLE
Set CNAME on deploy

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -20,6 +20,12 @@ jobs:
       - name: Build Heimdall Lite
         run: yarn frontend build
 
+      - name: Build Heimdall Lite
+        run: yarn frontend build
+
+      - name: Write Heimdall-Lite CNAME file
+        run: 'echo "heimdall-lite.mitre.org" > ./dist/frontend/CNAME'
+
       - name: deploy
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
Going to Settings on Github and setting a CNAME simply commits the CNAME to the gh-pages branch. Without explicitly setting the CNAME in the branch on every deploy it will be deleted on every release.