### PR TITLE
Fix broken tests caused by change in return codes

### DIFF
--- a/apps/backend/src/users/users.service.spec.ts
+++ b/apps/backend/src/users/users.service.spec.ts
@@ -3,8 +3,8 @@ import {DatabaseModule} from '../database/database.module';
 import {UsersService} from './users.service';
 import {
   NotFoundException,
-  UnauthorizedException,
-  BadRequestException
+  BadRequestException,
+  ForbiddenException
 } from '@nestjs/common';
 import {SequelizeModule} from '@nestjs/sequelize';
 import {User} from './user.model';
@@ -354,7 +354,7 @@ describe('UsersService', () => {
           user.id,
           UPDATE_USER_DTO_WITH_INVALID_CURRENT_PASSWORD
         )
-      ).rejects.toThrow(UnauthorizedException);
+      ).rejects.toThrow(ForbiddenException);
     });
 
     it('should throw an error when the email is invalid', async () => {
@@ -411,7 +411,7 @@ describe('UsersService', () => {
       expect.assertions(1);
       await expect(
         usersService.remove(user.id, DELETE_FAILURE_USER_DTO_TEST_OBJ)
-      ).rejects.toThrow(UnauthorizedException);
+      ).rejects.toThrow(ForbiddenException);
     });
 
     // Tests the remove function with DeleteUserDto that has no password field
@@ -423,7 +423,7 @@ describe('UsersService', () => {
           user.id,
           DELETE_USER_DTO_TEST_OBJ_WITH_MISSING_PASSWORD
         )
-      ).rejects.toThrow(UnauthorizedException);
+      ).rejects.toThrow(ForbiddenException);
     });
 
     it('should remove created user', async () => {

--- a/apps/backend/test/users.e2e-spec.ts
+++ b/apps/backend/test/users.e2e-spec.ts
@@ -367,12 +367,12 @@ describe('/users', () => {
           });
       });
 
-      it('should return 401 status when currentPassword is wrong', async () => {
+      it('should return 403 status when currentPassword is wrong', async () => {
         return request(app.getHttpServer())
           .put('/users/' + id)
           .set('Authorization', 'bearer ' + jwtToken)
           .send(UPDATE_USER_DTO_WITH_INVALID_CURRENT_PASSWORD)
-          .expect(HttpStatus.UNAUTHORIZED);
+          .expect(HttpStatus.FORBIDDEN);
       });
 
       it('should return 400 status when password does not meet complexity requirements', async () => {
@@ -448,12 +448,12 @@ describe('/users', () => {
           });
       });
 
-      it('should return 401 status because password is wrong', async () => {
+      it('should return 403 status because password is wrong', async () => {
         return request(app.getHttpServer())
           .delete('/users/' + id)
           .set('Authorization', 'bearer ' + jwtToken)
           .send(DELETE_FAILURE_USER_DTO_TEST_OBJ)
-          .expect(HttpStatus.UNAUTHORIZED);
+          .expect(HttpStatus.FORBIDDEN);
       });
 
       it('should return 200 status after user is deleted by admin', async () => {


### PR DESCRIPTION
The return codes for a user changing their profile information were changed to avoid our global 401 catch all to handle bad tokens.