### PR TITLE
Small fix to display the correct sub-part of the failure message in the test results

### DIFF
--- a/apps/frontend/src/components/cards/controltable/ControlRowCol.vue
+++ b/apps/frontend/src/components/cards/controltable/ControlRowCol.vue
@@ -26,7 +26,9 @@
     <v-col v-if="result.message" cols="12" sm="6" lg="5" class="left">
       <h3 class="pa-2">Result</h3>
       <v-divider />
-      <div class="pa-2 mono text-justify">{{ result.code_desc.trim() }}</div>
+      <div class="pa-2 mono text-justify">
+        {{ result.message.trim() }}
+      </div>
     </v-col>
   </v-row>
 </template>

--- a/apps/frontend/tests/unit/ControlRowCol.spec.ts
+++ b/apps/frontend/tests/unit/ControlRowCol.spec.ts
@@ -1,0 +1,34 @@
+import ControlRowCol from '@/components/cards/controltable/ControlRowCol.vue';
+import {mount, Wrapper} from '@vue/test-utils';
+import Vuetify from 'vuetify';
+import {addElemWithDataAppToBody} from '../util/testingUtils';
+
+addElemWithDataAppToBody();
+
+describe('The Topbar', () => {
+  const vuetify = new Vuetify();
+  let wrapper: Wrapper<Vue>;
+
+  beforeEach(() => {
+    wrapper = mount(ControlRowCol, {
+      vuetify,
+      propsData: {
+        statusCode: 'passed',
+        result: {
+          status: 'passed',
+          message: 'This is the message',
+          code_desc: 'This is the code description',
+          start_time: '2020-01-01T12:12:12+05:00'
+        }
+      }
+    });
+  });
+
+  it('displays the result message', async () => {
+    expect(wrapper.text()).toContain('This is the message');
+  });
+
+  it('displays the proper status', async () => {
+    expect(wrapper.get('button.statuspassed').text()).toEqual('PASSED');
+  });
+});


### PR DESCRIPTION
small fix introduced in 2.3.3 with the failed test results message vs the code_desc

Fixes #494

Signed-off-by: Aaron Lippold <lippold@gmail.com>