### PR TITLE
Show users of IE that we do not support their current browser

### DIFF
--- a/apps/frontend/public/index.html
+++ b/apps/frontend/public/index.html
@@ -11,11 +11,20 @@
 
 <body>
   <noscript>
-    <strong>We're sorry but heimdall-lite doesn't work properly without JavaScript enabled. Please enable it to
-      continue.</strong>
+    <strong>We're sorry but Heimdall doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
   </noscript>
+  <div id="ieWarning" style="display: none;"><h1>We're sorry, Heimdall does not support Internet Explorer. Please use a different browser.</h1></div>
   <div id="app"></div>
   <!-- built files will be auto injected -->
+  <script type="text/javascript">
+    var ua = window.navigator.userAgent;
+    var isIE = /MSIE|Trident/.test(ua);
+
+    if (isIE) {
+      //show unsupported message
+      document.getElementById('ieWarning').style.display = 'block';
+    }
+  </script>
 </body>
 
 </html>


### PR DESCRIPTION
Currently, Heimdall is loading as a blank page in IE. This provides users with a more explicit message instructing them to use a different browser.