### PR TITLE
Cleanup Status Counts

### DIFF
--- a/apps/frontend/src/components/cards/StatusCardRow.vue
+++ b/apps/frontend/src/components/cards/StatusCardRow.vue
@@ -69,46 +69,43 @@ export default class StatusCardRow extends Vue {
       {
         icon: 'check-circle',
         title: 'Passed',
-        subtitle: `Has ${StatusCountModule.countOf(
+        subtitle: `${StatusCountModule.countOf(
           this.filter,
           'PassedTests'
-        )} tests passed out of ${StatusCountModule.countOf(
-          this.filter,
-          'TotalTests'
-        )}`,
+        )} individual checks passed`,
         color: 'statusPassed',
         number: StatusCountModule.countOf(this.filter, 'Passed')
       },
       {
         icon: 'close-circle',
         title: 'Failed',
-        subtitle: `Has ${StatusCountModule.countOf(
+        subtitle: `${StatusCountModule.countOf(
+          this.filter,
+          'PassingTestsFailedControl'
+        )} individual checks passed, ${StatusCountModule.countOf(
           this.filter,
           'FailedTests'
-        )} of ${StatusCountModule.countOf(
+        )} failed out of ${StatusCountModule.countOf(
           this.filter,
-          'TotalTests'
-        )} tests that failed`,
+          'PassingTestsFailedControl'
+        ) + StatusCountModule.countOf(
+          this.filter,
+          'FailedTests'
+        )} total checks`,
         color: 'statusFailed',
         number: StatusCountModule.countOf(this.filter, 'Failed')
       },
       {
         icon: 'minus-circle',
         title: 'Not Applicable',
-        subtitle: `System exception or absent component (${StatusCountModule.countOf(
-          this.filter,
-          'NotApplicableTests'
-        )} tests)`,
+        subtitle: `System exception or absent component`,
         color: 'statusNotApplicable',
         number: StatusCountModule.countOf(this.filter, 'Not Applicable')
       },
       {
         icon: 'alert-circle',
         title: 'Not Reviewed',
-        subtitle: `Can only be tested manually at this time (${StatusCountModule.countOf(
-          this.filter,
-          'NotReviewedTests'
-        )} tests)`,
+        subtitle: `Can only be tested manually at this time`,
         color: 'statusNotReviewed',
         number: StatusCountModule.countOf(this.filter, 'Not Reviewed')
       }
@@ -124,12 +121,9 @@ export default class StatusCardRow extends Vue {
     return {
       icon: 'alert-circle',
       title: 'Profile Errors',
-      subtitle: `Errors running test - check profile run privileges or check with the author of profile (${StatusCountModule.countOf(
-        filter,
-        'ErroredTests'
-      )} tests)`,
+      subtitle: `Errors running test - check profile run privileges or check with the author of profile`,
       color: 'statusProfileError',
-      number: StatusCountModule.countOf(this.filter, 'Profile Error')
+      number: StatusCountModule.countOf(filter, 'Profile Error')
     };
   }
 }

--- a/apps/frontend/src/store/status_counts.ts
+++ b/apps/frontend/src/store/status_counts.ts
@@ -18,12 +18,7 @@ export type ControlStatusHash = {[key in ControlStatus]: number};
 export type StatusHash = ControlStatusHash & {
   PassedTests: number; // from passed controls
   FailedTests: number;
-  FailedOutOf: number; // total tests from failed controls
-  NotApplicableTests: number;
-  NotReviewedTests: number;
-  ErroredOutOf: number;
-  ErroredTests: number;
-  TotalTests: number;
+  PassingTestsFailedControl: number; // number of passing tests from failed controls
 };
 
 // Helper function for counting a status in a list of controls
@@ -47,37 +42,23 @@ function count_statuses(data: FilteredData, filter: Filter): StatusHash {
     'Profile Error': 0,
     PassedTests: 0,
     FailedTests: 0,
-    FailedOutOf: 0,
-    NotApplicableTests: 0,
-    NotReviewedTests: 0,
-    ErroredOutOf: 0,
-    ErroredTests: 0,
-    TotalTests: 0
+    PassingTestsFailedControl: 0
   };
   controls.forEach((c) => {
     c = c.root;
     const status: ControlStatus = c.hdf.status;
-    hash[status] += 1;
-    hash.TotalTests += (c.hdf.segments || []).length;
-    if (status == 'Passed') {
+    ++hash[status];
+    if (status === 'Passed') {
       hash.PassedTests += (c.hdf.segments || []).length;
-    } else if (status == 'Failed') {
-      hash.FailedOutOf += (c.hdf.segments || []).length;
-      hash.FailedTests += (c.hdf.segments || []).filter(
-        (s) => s.status == 'failed'
+    } else if (status === 'Failed') {
+      hash.PassingTestsFailedControl += (c.hdf.segments || []).filter(
+        (s) => s.status === 'passed'
       ).length;
-    } else if (status == 'Not Applicable') {
-      hash.NotApplicableTests += (c.hdf.segments || []).length;
-    } else if (status == 'Not Reviewed') {
-      hash.NotReviewedTests += (c.hdf.segments || []).length;
-    } else if (status == 'Profile Error') {
-      hash.ErroredOutOf += (c.hdf.segments || []).length;
-      hash.ErroredTests += (c.hdf.segments || []).filter(
-        (s) => s.status == 'error'
+      hash.FailedTests += (c.hdf.segments || []).filter(
+        (s) => s.status === 'failed'
       ).length;
     }
   });
-
   // And we're done
   return hash;
 }

--- a/apps/frontend/tests/unit/parsing_and_counting.spec.ts
+++ b/apps/frontend/tests/unit/parsing_and_counting.spec.ts
@@ -64,14 +64,9 @@ describe('Parsing', () => {
 
       const strippedActualWithFilename = _.omit(
         actualWithFilename,
-        'ErroredOutOf',
-        'FailedOutOf',
         'PassedTests',
         'FailedTests',
-        'NotApplicableTests',
-        'TotalTests',
-        'ErroredTests',
-        'NotReviewedTests'
+        'PassingTestsFailedControl'
       );
 
       // Compare 'em


### PR DESCRIPTION
This clarifies the status counts along the top of Heimdall, removes the total count, and makes the count of passing and failing individual controls more clear in the failed box. It also stops the counting of "FailedOutOf", "NotApplicableTests", "NotReviewedTests", "ErroredOutOf", "ErroredTests", and "TotalTests" since those counts are no longer used anywhere and counting them would be a waste of CPU cycles.

Closes #80