### PR TITLE
WIP: Automatically expand all controls whenever a user opens the system print dialog

### DIFF
--- a/apps/frontend/src/components/global/Footer.vue
+++ b/apps/frontend/src/components/global/Footer.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-footer app title="footer" class="bar font-weight-light">
+  <v-footer app title="footer" class="bar font-weight-light d-print-none">
     <span class="bar-visible--text">
       The MITRE Corporation &copy; 2018-{{ new Date().getFullYear() }}
     </span>

--- a/apps/frontend/src/components/global/Topbar.vue
+++ b/apps/frontend/src/components/global/Topbar.vue
@@ -1,5 +1,10 @@
 <template>
-  <v-app-bar :clipped-left="$vuetify.breakpoint.lgAndUp" app color="bar">
+  <v-app-bar
+    :clipped-left="$vuetify.breakpoint.lgAndUp"
+    app
+    color="bar"
+    class="d-print-none"
+  >
     <!-- The title and nav bar -->
     <v-toolbar-title v-if="!minimalTopbar" id="toolbar_title" class="pr-2">
       <v-app-bar-nav-icon @click.stop="$emit('toggle-drawer')">


### PR DESCRIPTION
Currently only works in chrome. This could potentially be fixed by adding a `Print` button for other browsers and requiring users to click on it.