### PR TITLE
Build node-bcrypt dependencies in Docker instead of reaching out to GitHub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:lts-alpine as builder
 
+ARG YARNREPO_MIRROR=https://registry.yarnpkg.com
+ENV YARNREPO=$YARNREPO_MIRROR
+
 WORKDIR /src
 USER 0
 
@@ -13,6 +16,7 @@ COPY libs ./libs
 ENV npm_config_build_from_source true
 RUN apk --no-cache add --virtual builds-deps build-base python
 
+RUN sed -i s^https://registry.yarnpkg.com^$YARNREPO^g yarn.lock
 RUN yarn --frozen-lockfile --production
 
 RUN yarn run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,12 @@ COPY package.json yarn.lock lerna.json tsconfig.json .prettierrc ./
 COPY apps ./apps
 COPY libs ./libs
 
+# https://github.com/kelektiv/node.bcrypt.js/wiki/Installation-Instructions
+# This allows for building in offline environments, and according to the
+# documentation fixes some segfaults with alpine and node-bcrypt.
+ENV npm_config_build_from_source true
+RUN apk --no-cache add --virtual builds-deps build-base python
+
 RUN yarn --frozen-lockfile --production
 
 RUN yarn run build
@@ -24,8 +30,6 @@ COPY libs/interfaces/package.json libs/interfaces/
 COPY --from=builder /src/apps/backend/node_modules apps/backend/node_modules
 COPY --from=builder /src/apps/frontend/node_modules apps/frontend/node_modules
 COPY --from=builder /src/node_modules node_modules
-RUN yarn --production=true --frozen-lockfile
-
 COPY --from=builder /src/dist/ /app/dist/
 COPY apps/backend/.sequelizerc /app/apps/backend/
 COPY apps/backend/db /app/apps/backend/db

--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -1,5 +1,8 @@
 FROM node:lts-alpine as builder
 
+ARG YARNREPO_MIRROR=https://registry.yarnpkg.com
+ENV YARNREPO=$YARNREPO_MIRROR
+
 WORKDIR /src
 USER 0
 
@@ -7,6 +10,7 @@ COPY package.json yarn.lock lerna.json tsconfig.json .prettierrc ./
 COPY apps/frontend ./apps/frontend
 COPY libs ./libs
 
+RUN sed -i s^https://registry.yarnpkg.com^$YARNREPO^g yarn.lock
 RUN yarn --frozen-lockfile --production
 
 RUN yarn frontend build

--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -1,4 +1,4 @@
-FROM node:lts as builder
+FROM node:lts-alpine as builder
 
 WORKDIR /src
 USER 0

--- a/package.json
+++ b/package.json
@@ -8,13 +8,13 @@
   ],
   "scripts": {
     "backend": "yarn workspace heimdall-server",
-    "build": "npx lerna run build",
+    "build": "lerna run build",
     "cypress-test": "yarn workspace @heimdall/cypress-tests",
     "frontend": "yarn workspace heimdall-lite",
-    "lint": "npx lerna run lint",
-    "lint:ci": "npx lerna run lint:ci",
+    "lint": "lerna run lint",
+    "lint:ci": "lerna run lint:ci",
     "start": "yarn backend start",
-    "start:dev": "dotenv -e apps/backend/.env -- npx lerna exec yarn run start:dev --ignore @heimdall/interfaces --ignore @heimdall/cypress-tests",
+    "start:dev": "dotenv -e apps/backend/.env -- lerna exec yarn run start:dev --ignore @heimdall/interfaces --ignore @heimdall/cypress-tests",
     "test:ui": "cypress run",
     "test:ui:open": "cypress open"
   },
@@ -24,13 +24,13 @@
     "eslint": "^7.13.0",
     "eslint-config-prettier": "^8.0.0",
     "eslint-plugin-prettier": "^3.1.4",
+    "lerna": "^4.0.0",
     "prettier": "^2.1.2",
     "prettier-plugin-organize-imports": "^1.1.1",
     "typescript": "^4.0.5"
   },
   "devDependencies": {
     "cypress": "6.6.0",
-    "dotenv-cli": "^4.0.0",
-    "lerna": "^4.0.0"
+    "dotenv-cli": "^4.0.0"
   }
 }


### PR DESCRIPTION
This fixes an apparent segfault in node-bcrypt and also makes it possible to build in offline environments.

Instead of using the lerna located in the repo, `npx lerna` was reaching out to the internet. This was causing another failure when building offline.