### PR TITLE
Fix consistent E2E UI test failure by forcing a click

### DIFF
--- a/test/support/components/UploadModal.ts
+++ b/test/support/components/UploadModal.ts
@@ -15,7 +15,7 @@ export default class UploadModal {
 
   loadFile(name: string): void {
     cy.get('[data-cy=loadFileList]').within(() => {
-      cy.contains(name).click();
+      cy.contains(name).click({force: true});
     });
   }
 


### PR DESCRIPTION
This potentially fixes an issue with the E2E UI tests where they keep failing over and over due to the database filename element potentially being masked by another element.