### PR TITLE
More Dockerfile cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM node:lts-alpine as builder
+ARG BASE_CONTAINER=node:lts-alpine
+
+FROM $BASE_CONTAINER as builder
 
 ARG YARNREPO_MIRROR=https://registry.yarnpkg.com
 ENV YARNREPO=$YARNREPO_MIRROR
@@ -14,7 +16,7 @@ COPY libs ./libs
 # This allows for building in offline environments, and according to the
 # documentation fixes some segfaults with alpine and node-bcrypt.
 ENV npm_config_build_from_source true
-RUN apk --no-cache add --virtual builds-deps build-base python
+RUN if [ -x "$(command -v apk)" ] ; then apk --no-cache add --virtual builds-deps build-base python ; fi
 
 RUN sed -i s^https://registry.yarnpkg.com^$YARNREPO^g yarn.lock
 RUN yarn --frozen-lockfile --production
@@ -23,7 +25,7 @@ RUN yarn run build
 
 ### Production image
 
-FROM node:lts-alpine as app
+FROM $BASE_CONTAINER as app
 
 WORKDIR /app
 

--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -1,4 +1,7 @@
-FROM node:lts-alpine as builder
+ARG BUILD_CONTAINER=node:lts-alpine
+ARG BASE_CONTAINER=nginx:stable-alpine
+
+FROM $BUILD_CONTAINER as builder
 
 ARG YARNREPO_MIRROR=https://registry.yarnpkg.com
 ENV YARNREPO=$YARNREPO_MIRROR
@@ -16,7 +19,7 @@ RUN yarn --frozen-lockfile --production
 RUN yarn frontend build
 
 # production stage
-FROM nginx:stable-alpine as production-stage
+FROM $BASE_CONTAINER as production-stage
 COPY --from=builder /src/dist/frontend /usr/share/nginx/html
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -70,7 +70,6 @@
     "express-session": "^1.17.1",
     "helmet": "^4.1.1",
     "js-levenshtein": "^1.1.6",
-    "oauth2-mock-server": "^3.1.0",
     "passport": "^0.4.1",
     "passport-github": "^1.1.0",
     "passport-gitlab2": "^5.0.0",
@@ -101,6 +100,7 @@
     "@types/puppeteer": "^5.4.0",
     "jest": "^26.4.2",
     "mock-fs": "^4.12.0",
+    "oauth2-mock-server": "^3.1.0",
     "puppeteer": "^8.0.0",
     "supertest": "^6.0.0",
     "ts-jest": "^26.1.3"


### PR DESCRIPTION
Make Dockerfile more generic to allow for building against different base containers.

Move `oauth2-mock-server` to `devDependencies` since it is not required for building (and has very stringent node requirements).