### PR TITLE
Enable @typescript-eslint/no-unused-vars for Frontend

### DIFF
--- a/apps/frontend/.eslintrc.js
+++ b/apps/frontend/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
     '@typescript-eslint/no-explicit-any': 'warn',
     'vue/require-default-prop': 'off',
     'vue/prop-name-casing': 'off',
+    '@typescript-eslint/no-unused-vars': ['warn', {argsIgnorePattern: '^_'}],
     'object-curly-spacing': 'warn',
     'vue/html-self-closing': [
       'warn',

--- a/apps/frontend/tests/unit/Compare.spec.ts
+++ b/apps/frontend/tests/unit/Compare.spec.ts
@@ -21,7 +21,6 @@ export interface SeriesItem {
 }
 
 const redHatControlCount = 247;
-const redHatDelta = 27;
 const nginxControlCount = 41;
 const nginxDelta = 3;
 


### PR DESCRIPTION
Makes ESLint warn about unused imports and variables on the frontend.