### PR TITLE
Leverage EXTERNAL_URL to show an absolute URL to users uploading results via the API

### DIFF
--- a/apps/backend/src/evaluations/evaluations.controller.spec.ts
+++ b/apps/backend/src/evaluations/evaluations.controller.spec.ts
@@ -18,6 +18,7 @@ import {
   CREATE_USER_DTO_TEST_OBJ_2
 } from '../../test/constants/users-test.constant';
 import {AuthzService} from '../authz/authz.service';
+import {ConfigService} from '../config/config.service';
 import {DatabaseModule} from '../database/database.module';
 import {DatabaseService} from '../database/database.service';
 import {EvaluationTag} from '../evaluation-tags/evaluation-tag.model';
@@ -67,6 +68,7 @@ describe('EvaluationsController', () => {
       ],
       providers: [
         AuthzService,
+        ConfigService,
         DatabaseService,
         UsersService,
         EvaluationsService,

--- a/apps/backend/src/evaluations/evaluations.controller.ts
+++ b/apps/backend/src/evaluations/evaluations.controller.ts
@@ -16,6 +16,7 @@ import {FileInterceptor} from '@nestjs/platform-express';
 import _ from 'lodash';
 import {AuthzService} from '../authz/authz.service';
 import {Action} from '../casl/casl-ability.factory';
+import {ConfigService} from '../config/config.service';
 import {GroupDto} from '../groups/dto/group.dto';
 import {Group} from '../groups/group.model';
 import {GroupsService} from '../groups/groups.service';
@@ -33,6 +34,7 @@ export class EvaluationsController {
   constructor(
     private readonly evaluationsService: EvaluationsService,
     private readonly groupsService: GroupsService,
+    private readonly configService: ConfigService,
     private readonly authz: AuthzService
   ) {}
   @Get(':id')
@@ -109,7 +111,7 @@ export class EvaluationsController {
     const createdDto: EvaluationDto = new EvaluationDto(
       evaluation,
       true,
-      `/results/${evaluation.id}`
+      `${this.configService.get('EXTERNAL_URL') || ''}/results/${evaluation.id}`
     );
     return _.omit(createdDto, 'data');
   }

--- a/apps/backend/src/evaluations/evaluations.module.ts
+++ b/apps/backend/src/evaluations/evaluations.module.ts
@@ -1,5 +1,6 @@
 import {Module} from '@nestjs/common';
 import {SequelizeModule} from '@nestjs/sequelize';
+import {ConfigModule} from '../config/config.module';
 import {DatabaseModule} from '../database/database.module';
 import {EvaluationTag} from '../evaluation-tags/evaluation-tag.model';
 import {GroupEvaluation} from '../group-evaluations/group-evaluation.model';
@@ -21,6 +22,7 @@ import {EvaluationsService} from './evaluations.service';
       GroupUser,
       GroupEvaluation
     ]),
+    ConfigModule,
     DatabaseModule
   ],
   providers: [EvaluationsService, UsersService, GroupsService],


### PR DESCRIPTION
Previously Heimdall was always showing a relative URL