### PR TITLE
Remove PDF Report and Print View from feature list

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ As a single-page javascript app - you can run Heimdall-Lite from any web-server,
 | Data Table / Control Summary                                 |                            x                             |                              x                               |
 | InSpec Code / Control Viewer                                 |                            x                             |                              x                               |
 | SSP Content Generator                                        |                                                          |                              x                               |
-| PDF Report and Print View                                    |                            x                             |                              x                               |
 | Users & Roles & multi-team support                           |                                                          |                              x                               |
 | Authentication & Authorization                               |                    Hosting Webserver                     | Hosting Webserver<br />LDAP<br />OAuth Support for:<br /> GitHub, GitLab, Google, and Okta. |
 | Advanced Data / Filters for Reports and Viewing              |                                                          |                              x                               |


### PR DESCRIPTION
This was a holdover from Heimdall Lite 1.0 which is not currently relevant.