### PR TITLE
Prevent Creating Empty Tag on Upload

### DIFF
--- a/apps/backend/src/interceptors/create-evaluation-interceptor.ts
+++ b/apps/backend/src/interceptors/create-evaluation-interceptor.ts
@@ -25,7 +25,10 @@ export class CreateEvaluationInterceptor implements NestInterceptor {
     if (request.body.public) {
       request.body.public = [true, 'true'].includes(request.body.public);
     }
-    if (request.body.evaluationTags !== undefined) {
+    if (
+      request.body.evaluationTags !== undefined &&
+      request.body.evaluationTags !== ''
+    ) {
       request.body.evaluationTags = request.body.evaluationTags
         .split(',')
         .map(


### PR DESCRIPTION
Closes #1191, checks if evaluationTags is an empty string before splitting.