### PR TITLE
Remove unnecessary imports of Prism

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -103,7 +103,6 @@
     "vue-file-agent": "^1.7.3",
     "vue-highlightjs": "^1.3.3",
     "vue-prism-component": "~1.2.0",
-    "vue-prismjs": "~1.2.0",
     "vue-property-decorator": "^9.0.0",
     "vue-resize-directive": "^1.2.0",
     "vue-router": "^3.1.3",

--- a/apps/frontend/src/components/cards/controltable/ControlRowDetails.vue
+++ b/apps/frontend/src/components/cards/controltable/ControlRowDetails.vue
@@ -60,7 +60,6 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
 import Component, {mixins} from 'vue-class-component';
 import ControlRowCol from '@/components/cards/controltable/ControlRowCol.vue';
 import HtmlSanitizeMixin from '@/mixins/HtmlSanitizeMixin';
@@ -72,7 +71,6 @@ import 'prismjs/components/prism-ruby.js';
 //@ts-ignore
 import Prism from 'vue-prism-component';
 import 'prismjs/themes/prism-tomorrow.css';
-Vue.component('Prism', Prism);
 
 import {context} from 'inspecjs';
 import {Prop, Watch} from 'vue-property-decorator';

--- a/apps/frontend/vue.config.js
+++ b/apps/frontend/vue.config.js
@@ -41,6 +41,9 @@ module.exports = {
     ]
   },
   chainWebpack: (config) => {
+    // Disable resolve symlinks to silence eslint when using `npm link`
+    // (when developing inspecjs locally): https://stackoverflow.com/a/57518476/1670307
+    config.resolve.symlinks(false);
     config.module
       .rule('vue')
       .use('vue-svg-inline-loader')

--- a/yarn.lock
+++ b/yarn.lock
@@ -15819,7 +15819,7 @@ printj@~1.1.0, printj@~1.1.2:
   resolved "https://registry.yarnpkg.com/printj/-/printj-1.1.2.tgz#d90deb2975a8b9f600fb3a1c94e3f4c53c78a222"
   integrity sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==
 
-prismjs@^1.20.0, prismjs@^1.21.0, prismjs@^1.6.0:
+prismjs@^1.20.0, prismjs@^1.21.0:
   version "1.23.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.23.0.tgz#d3b3967f7d72440690497652a9d40ff046067f33"
   integrity sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==
@@ -19235,13 +19235,6 @@ vue-prism-component@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/vue-prism-component/-/vue-prism-component-1.2.0.tgz#406252e16979def13b5d28827d95b2b6dc647825"
   integrity sha512-0N9CNuQu+36CJpdsZHrhdq7d18oBvjVMjawyKdIr8xuzFWLfdxECZQYbFaYoopPBg3SvkEEMtkhYqdgTQl5Y+A==
-
-vue-prismjs@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/vue-prismjs/-/vue-prismjs-1.2.0.tgz#b137f5ed958685ce1fd55ca6b068289f3359b8b7"
-  integrity sha512-1mICbMknMiKw4mfM1AU7vkFT3VX4Cq8ySyDU7IBr9tYW1fzxIPkfLoERkRMbQLBc+J74K3FIiuuZ+WfBjO3SCQ==
-  dependencies:
-    prismjs "^1.6.0"
 
 vue-property-decorator@^9.0.0:
   version "9.1.2"


### PR DESCRIPTION
Heimdall was pulling in 2 prism components but not using both of them. This removes the unused one and cleans up the imports of the one we do use.