### PR TITLE
Make linter errors warnings instead of errors on build.

### DIFF
--- a/apps/frontend/vue.config.js
+++ b/apps/frontend/vue.config.js
@@ -13,6 +13,7 @@ const branch = parsed.branch || '';
 const issues = parsed.issues || '';
 
 module.exports = {
+  lintOnSave: 'warning',
   publicPath: '/',
   devServer: {
     // JWT_SECRET is a required secret for the backend. If it is sourced


### PR DESCRIPTION
This fixes an issue where builds can fail just do to linter errors.