### PR TITLE
Speed up CI runs by only installing nessecary packages

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -42,7 +42,7 @@ jobs:
        run: rm -rf apps/frontend
 
      - name: Install project dependencies
-       run: yarn install --frozen-lockfile
+       run: yarn backend install --frozen-lockfile
 
      - name: Copy .env-ci to .env
        run: cp apps/backend/test/.env-ci apps/backend/.env

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -42,7 +42,10 @@ jobs:
        run: rm -rf apps/backend
 
      - name: Install project dependencies
-       run: yarn install --frozen-lockfile
+       run: yarn install --frozen-lockfile --production
+
+     - name: Install frontend dev dependencies
+       run: yarn frontend install --frozen-lock
 
      - name: Run frontend tests
        run: yarn frontend test

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -41,11 +41,8 @@ jobs:
      - name: Remove backend code to ensure the proper dependencies are declared in the frontend package.json
        run: rm -rf apps/backend
 
-     - name: Install project dependencies
-       run: yarn install --frozen-lockfile --production
-
      - name: Install frontend dev dependencies
-       run: yarn frontend install --frozen-lock
+       run: yarn frontend install --frozen-lockfile
 
      - name: Run frontend tests
        run: yarn frontend test

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,7 +15,7 @@ jobs:
           node-version: "14.x"
 
       - name: Install project dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile --production
 
       - name: Build Heimdall Lite
         run: yarn frontend build

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -39,7 +39,7 @@ jobs:
         node-version: '14.x'
 
      - name: Install project dependencies
-       run: yarn install --frozen-lockfile
+       run: yarn install --frozen-lockfile --production
 
      - name: Run lint
        run: yarn run lint:ci

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "typescript": "^4.0.5"
   },
   "devDependencies": {
-    "cypress": "6.8.0",
     "dotenv-cli": "^4.0.0"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -10,9 +10,10 @@
     "mock-openid": "node support/server/oidc-server.js"
   },
   "devDependencies": {
-    "eslint-plugin-cypress": "^2.11.2"
+    "cypress": "6.8.0"
   },
   "dependencies": {
+    "eslint-plugin-cypress": "^2.11.2",
     "json-server": "^0.16.3"
   }
 }


### PR DESCRIPTION
This should speed things up due to not having to download the large cypress package for unrelated tests.