### PR TITLE
Properly wrap filename in Results View Data, allow sorting by filename

### DIFF
--- a/apps/frontend/src/components/cards/controltable/ControlTable.vue
+++ b/apps/frontend/src/components/cards/controltable/ControlTable.vue
@@ -328,6 +328,14 @@ export default class ControlTable extends Vue {
       if (this.sortSet === 'ascending') {
         factor = -1;
       }
+    } else if (
+      this.sortSet === 'ascending' ||
+      this.sortSet === 'descending'
+    ) {
+      cmp = (a: ListElt, b: ListElt) => a.filename.localeCompare(b.filename);
+      if (this.sortSet === 'ascending') {
+        factor = -1;
+      }
     } else {
       return this.raw_items;
     }


### PR DESCRIPTION
Partial columns do not work in Vuetify, it breaks word wrapping. Reverting to regular column sizes.

Sorting by filename was broken, this adds proper sorting by filename.

Fixes #1241