### PR TITLE
Automatically merge dependabot updates.

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -5,6 +5,14 @@ pull_request_rules:
       - base=master
       - label=ready-to-merge
     actions:
+        merge:
+          strict: true
+          method: squash
+  - name: automatic merge for updates when CI passes
+    conditions:
+      - "#approved-reviews-by>=1"
+      - base=master
+      - label=dependencies
     actions:
         merge:
           strict: true


### PR DESCRIPTION
The updated version of dependabot does not support automatic PR merging. This sets up mergify to do it instead.