### PR TITLE
Show all subdescriptions on the Descriptions page

### DIFF
--- a/apps/frontend/src/components/cards/controltable/ControlRowDetails.vue
+++ b/apps/frontend/src/components/cards/controltable/ControlRowDetails.vue
@@ -138,6 +138,7 @@ export default class ControlRowDetails extends mixins(HtmlSanitizeMixin) {
   }
 
   get details(): Detail[] {
+    const hiddenDescriptions = ["default", "check", "fix"]
     let c = this.control;
     const details: Detail[] = [
       {
@@ -190,10 +191,12 @@ export default class ControlRowDetails extends mixins(HtmlSanitizeMixin) {
       },
     ].filter((v) => v.value); // Get rid of nulls
     for (const prop in c.hdf.descriptions) {
-      details.push({
-        name: `Custom Description (${prop})`,
-        value: c.hdf.descriptions[prop]
-      })
+      if (!hiddenDescriptions.includes(prop)){
+        details.push({
+          name: `Custom Description (${prop})`,
+          value: c.hdf.descriptions[prop]
+        })
+      }
     }
     return details
   }

--- a/apps/frontend/src/components/cards/controltable/ControlRowDetails.vue
+++ b/apps/frontend/src/components/cards/controltable/ControlRowDetails.vue
@@ -74,6 +74,7 @@ import 'prismjs/themes/prism-tomorrow.css';
 
 import {context} from 'inspecjs';
 import {Prop, Watch} from 'vue-property-decorator';
+import _ from 'lodash';
 
 interface Detail {
   name: string;
@@ -123,10 +124,6 @@ export default class ControlRowDetails extends mixins(HtmlSanitizeMixin) {
     this.$emit('update:tab', tab);
   }
 
-  capitalize(value: string) {
-    return value.charAt(0).toUpperCase() + value.slice(1)
-  }
-
   /** Shown above the description */
   get header(): string {
     let msg_split = this.control.root.hdf.finding_details.split(':');
@@ -158,8 +155,8 @@ export default class ControlRowDetails extends mixins(HtmlSanitizeMixin) {
     detailsMap.set('Fix', c.hdf.descriptions.fix || c.data.tags.fix)
 
     for (const prop in c.hdf.descriptions) {
-      if (!detailsMap.has(this.capitalize(prop)) && !Array.from(detailsMap.values()).includes(c.hdf.descriptions[prop])){
-        detailsMap.set(this.capitalize(prop), c.hdf.descriptions[prop])
+      if (!detailsMap.has(_.capitalize(prop))){
+        detailsMap.set(_.capitalize(prop), c.hdf.descriptions[prop])
       }
     }
     return Array.from(detailsMap, ([name, value]) => ({name, value})).filter((v) => v.value);

--- a/apps/frontend/src/components/cards/controltable/ControlRowDetails.vue
+++ b/apps/frontend/src/components/cards/controltable/ControlRowDetails.vue
@@ -139,7 +139,7 @@ export default class ControlRowDetails extends mixins(HtmlSanitizeMixin) {
 
   get details(): Detail[] {
     let c = this.control;
-    return [
+    const details: Detail[] = [
       {
         name: 'Control',
         value: c.data.id
@@ -187,8 +187,15 @@ export default class ControlRowDetails extends mixins(HtmlSanitizeMixin) {
       {
         name: 'Fix Text',
         value: c.hdf.descriptions.fix || c.data.tags.fix
-      }
+      },
     ].filter((v) => v.value); // Get rid of nulls
+    for (const prop in c.hdf.descriptions) {
+      details.push({
+        name: `Custom Description (${prop})`,
+        value: c.hdf.descriptions[prop]
+      })
+    }
+    return details
   }
 
   //for zebra background

--- a/apps/frontend/src/components/cards/controltable/ControlRowDetails.vue
+++ b/apps/frontend/src/components/cards/controltable/ControlRowDetails.vue
@@ -123,6 +123,10 @@ export default class ControlRowDetails extends mixins(HtmlSanitizeMixin) {
     this.$emit('update:tab', tab);
   }
 
+  capitalize(value: string) {
+    return value.charAt(0).toUpperCase() + value.slice(1)
+  }
+
   /** Shown above the description */
   get header(): string {
     let msg_split = this.control.root.hdf.finding_details.split(':');
@@ -138,67 +142,27 @@ export default class ControlRowDetails extends mixins(HtmlSanitizeMixin) {
   }
 
   get details(): Detail[] {
-    const hiddenDescriptions = ["default", "check", "fix"]
     let c = this.control;
-    const details: Detail[] = [
-      {
-        name: 'Control',
-        value: c.data.id
-      },
-      {
-        name: 'Title',
-        value: c.data.title
-      },
-      {
-        name: 'Caveat',
-        value: c.hdf.descriptions.caveat
-      },
-      {
-        name: 'Desc',
-        value: c.data.desc
-      },
-      {
-        name: 'Rationale',
-        value: c.hdf.descriptions.rationale
-      },
-      {
-        name: 'Justification',
-        value: c.hdf.descriptions.justification
-      },
-      {
-        name: 'Severity',
-        value: c.root.hdf.severity
-      },
-      {
-        name: 'Impact',
-        value: c.data.impact
-      },
-      {
-        name: 'Nist controls',
-        value: c.hdf.raw_nist_tags.join(', ')
-      },
-      {
-        name: 'CCI controls',
-        value: this.cciControlString
-      },
-      {
-        name: 'Check Text',
-        value: c.hdf.descriptions.check || c.data.tags.check
-      },
-      {
-        name: 'Fix Text',
-        value: c.hdf.descriptions.fix || c.data.tags.fix
-      },
-    ].filter((v) => v.value); // Get rid of nulls
+    const detailsMap = new Map();
+
+    detailsMap.set('Control', c.data.id)
+    detailsMap.set('Title', c.data.title)
+    detailsMap.set('Caveat', c.hdf.descriptions.caveat)
+    detailsMap.set('Desc', c.data.desc)
+    detailsMap.set('Rationale', c.hdf.descriptions.rationale)
+    detailsMap.set('Severity', c.root.hdf.severity)
+    detailsMap.set('Impact', c.data.impact)
+    detailsMap.set('Nist controls', c.hdf.raw_nist_tags.join(', '))
+    detailsMap.set('CCI controls', this.cciControlString)
+    detailsMap.set('Check', c.hdf.descriptions.check || c.data.tags.check)
+    detailsMap.set('Fix', c.hdf.descriptions.fix || c.data.tags.fix)
+
     for (const prop in c.hdf.descriptions) {
-      if (!hiddenDescriptions.includes(prop)){
-        details.push({
-          name: `Custom Description (${prop})`,
-          value: c.hdf.descriptions[prop]
-        })
+      if (!detailsMap.has(this.capitalize(prop)) && !Array.from(detailsMap.values()).includes(c.hdf.descriptions[prop])){
+        detailsMap.set(this.capitalize(prop), c.hdf.descriptions[prop])
       }
     }
-    return details
+    return Array.from(detailsMap, ([name, value]) => ({name, value})).filter((v) => v.value);
   }
 
   //for zebra background


### PR DESCRIPTION
Closes #1305, adds all `c.hdf.descriptions` to the details tab.