### PR TITLE
Do not hoist backend dependencies in order to slim server image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # compiled output
 /dist
-apps/frontend/dist
+apps/backend/dist
 node_modules
 
 # Logs

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,14 +28,18 @@ COPY apps/backend/package.json apps/backend/
 COPY apps/frontend/package.json apps/frontend/
 COPY libs/interfaces/package.json libs/interfaces/
 COPY --from=builder /src/apps/backend/node_modules apps/backend/node_modules
-COPY --from=builder /src/apps/frontend/node_modules apps/frontend/node_modules
-COPY --from=builder /src/node_modules node_modules
-COPY --from=builder /src/dist/ /app/dist/
+COPY --from=builder /src/dist/ dist/
 COPY apps/backend/.sequelizerc /app/apps/backend/
 COPY apps/backend/db /app/apps/backend/db
 COPY apps/backend/config /app/apps/backend/config
 COPY apps/backend/migrations /app/apps/backend/migrations
 COPY apps/backend/seeders /app/apps/backend/seeders
+
+# All of the node modules necessary to run the app
+# are stored in the backend node_modules folder
+# to avoid the dependencies of the frontend being
+# installed on the server production image.
+RUN ln -s apps/backend/node_modules node_modules
 
 WORKDIR /app/dist/server
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,20 +28,13 @@ COPY apps/backend/package.json apps/backend/
 COPY apps/frontend/package.json apps/frontend/
 COPY libs/interfaces/package.json libs/interfaces/
 COPY --from=builder /src/apps/backend/node_modules apps/backend/node_modules
+COPY --from=builder /src/apps/backend/dist apps/backend/dist
 COPY --from=builder /src/dist/ dist/
 COPY apps/backend/.sequelizerc /app/apps/backend/
 COPY apps/backend/db /app/apps/backend/db
 COPY apps/backend/config /app/apps/backend/config
 COPY apps/backend/migrations /app/apps/backend/migrations
 COPY apps/backend/seeders /app/apps/backend/seeders
-
-# All of the node modules necessary to run the app
-# are stored in the backend node_modules folder
-# to avoid the dependencies of the frontend being
-# installed on the server production image.
-RUN ln -s apps/backend/node_modules node_modules
-
-WORKDIR /app/dist/server
 
 EXPOSE 3000
 

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -4,6 +4,12 @@
   "description": "",
   "license": "Apache-2.0",
   "author": "",
+  "private": true,
+  "workspaces": {
+    "nohoist": [
+      "**"
+    ]
+  },
   "scripts": {
     "prebuild": "rimraf ../../dist/server",
     "build": "nest build",
@@ -102,7 +108,6 @@
     "@types/puppeteer": "^5.4.0",
     "jest": "^26.4.2",
     "mock-fs": "^5.0.0",
-    "oauth2-mock-server": "^3.1.0",
     "puppeteer": "^10.0.0",
     "supertest": "^6.0.0",
     "ts-jest": "^26.1.3"

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -11,12 +11,12 @@
     ]
   },
   "scripts": {
-    "prebuild": "rimraf ../../dist/server",
+    "prebuild": "rimraf dist",
     "build": "nest build",
     "lint": "eslint \"{src,migrations,seeders,test}/**/*.ts\" --fix",
     "lint:ci": "eslint \"{src,migrations,seeders,test}/**/*.ts\" --max-warnings 0",
     "sequelize-cli": "ts-node node_modules/.bin/sequelize",
-    "start": "node ../../dist/server/src/main",
+    "start": "node dist/src/main",
     "start:debug": "nest start --debug --watch",
     "start:dev": "nest start --watch",
     "test": "jest --silent",

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -20,7 +20,7 @@ import {UsersModule} from './users/users.module';
   controllers: [AppController],
   imports: [
     ServeStaticModule.forRoot({
-      rootPath: join(__dirname, '..', '..', 'frontend')
+      rootPath: join(__dirname, '..', '..', '..', '..', 'dist', 'frontend')
     }),
     UsersModule,
     DatabaseModule,

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -5,7 +5,7 @@
     "declaration": true,
     "removeComments": true,
     "emitDecoratorMetadata": true,
-    "outDir": "../../dist/server",
+    "outDir": "./dist",
     "baseUrl": "./",
     "incremental": true,
     "strict": true,

--- a/test/package.json
+++ b/test/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "eslint-plugin-cypress": "^2.11.2",
-    "json-server": "^0.16.3"
+    "json-server": "^0.16.3",
+    "oauth2-mock-server": "^3.1.0"
   }
 }


### PR DESCRIPTION
All of the backend dependencies are required to execute the server image. By not hoisting them it is possible to isolate the packages required and only install those on the server image, limiting the number of dependencies installed and slimming ~300MB from the production image.