### PR TITLE
Add Missing Variables to .env-example

### DIFF
--- a/apps/backend/.env-example
+++ b/apps/backend/.env-example
@@ -8,14 +8,15 @@ DATABASE_NAME=<Name of the database (if nothing is provided, defaults to heimdal
 JWT_SECRET=<JSON Web Token Secret (no default, must be set)>
 JWT_EXPIRE_TIME=<JSON Web Token Length of time before signature expires (if nothing is provided, defaults to 60s)>
 NODE_ENV=<development, production, or test (no default, must be set)>
-HEIMDALL_HEADLESS_TESTS=<run integration tests in a headless browser (default=true)>
+HEIMDALL_HEADLESS_TESTS=<run integration tests in a headless browser (defaults to true)>
 ADMIN_PASSWORD=<Password for admin user (if nothing is provided, defaults to a randomly generated password)>
 EXTERNAL_URL=<The external URL for your Heimdall deployment, for example https://heimdall.mitre.org>
+REGISTRATION_DISABLED=<If public user registration should be allowed, if not then only the administrator user can create users (defaults to false)>
 
 # Oauth Client IDs and Secrets, If a variable does not have client id values assigned then the feature is disabled.
 GITHUB_CLIENTID=<Github Application Client ID>
 GITHUB_CLIENTSECRET=<Github Application Client Secret>
-GITHUB_ENTERPRISE_INSTANCE_BASE_URL=<Github Enterprise Instance URL (default=https://github.com/)>
+GITHUB_ENTERPRISE_INSTANCE_BASE_URL=<Github Enterprise Instance Base URL (default=https://github.com/)>
 GITHUB_ENTERPRISE_INSTANCE_API_URL=<Github Enterprise Instance API URL (default=https://api.github.com/)>
 
 GITLAB_CLIENTID=<Github Application Client ID>

--- a/apps/backend/.env-example
+++ b/apps/backend/.env-example
@@ -15,6 +15,8 @@ EXTERNAL_URL=<The external URL for your Heimdall deployment, for example https:/
 # Oauth Client IDs and Secrets, If a variable does not have client id values assigned then the feature is disabled.
 GITHUB_CLIENTID=<Github Application Client ID>
 GITHUB_CLIENTSECRET=<Github Application Client Secret>
+GITHUB_ENTERPRISE_INSTANCE_BASE_URL=<Github Enterprise Instance URL (default=https://github.com/)>
+GITHUB_ENTERPRISE_INSTANCE_API_URL=<Github Enterprise Instance API URL (default=https://api.github.com/)>
 
 GITLAB_CLIENTID=<Github Application Client ID>
 GITLAB_CLIENTSECRET=<Github Application Client Secret>


### PR DESCRIPTION
Fixes .env-example missing documentation for usage of GitHub enterprise instances as an authentication method via alternative authentication.

Changes were also made to the wiki to add this documentation and documentation for Open ID Connect.