### PR TITLE
Show Evaluations by Groups

### DIFF
--- a/apps/frontend/src/components/global/upload_tabs/DatabaseReader.vue
+++ b/apps/frontend/src/components/global/upload_tabs/DatabaseReader.vue
@@ -3,8 +3,7 @@
     <v-card-subtitle>
       View files loaded into your organizations Heimdall Server instance.
     </v-card-subtitle>
-    <LoadFileList
-      :headers="headers"
+    <GroupFileList
       :files="files"
       :loading="loading"
       @load-results="load_results($event)"
@@ -14,7 +13,7 @@
 
 <script lang="ts">
 import Component, {mixins} from 'vue-class-component';
-import LoadFileList from '@/components/global/upload_tabs/LoadFileList.vue';
+import GroupFileList from '@/components/global/upload_tabs/GroupFileList.vue';
 import {EvaluationModule} from '@/store/evaluations';
 import RefreshButton from '@/components/generic/RefreshButton.vue';
 import {IEvaluation} from '@heimdall/interfaces';
@@ -29,37 +28,12 @@ import {FileID} from '@/store/report_intake';
  */
 @Component({
   components: {
-    LoadFileList,
+    GroupFileList,
     RefreshButton
   }
 })
 export default class DatabaseReader extends mixins(ServerMixin, RouteMixin) {
   @Prop({default: false}) readonly refresh!: Boolean;
-
-  headers: Object[] = [
-    {
-      text: 'Filename',
-      align: 'start',
-      sortable: true,
-      value: 'filename'
-    },
-    {
-      text: 'Tags',
-      value: 'evaluationTags',
-      sortable: true
-    },
-    {
-      text: 'Groups',
-      value: 'groups',
-      sortable: true
-    },
-    {text: 'Uploaded', value: 'createdAt', sortable: true},
-    {
-      text: 'Actions',
-      value: 'actions',
-      align: 'right'
-    }
-  ];
 
   @Watch('refresh')
   onChildChanged(newRefreshValue: boolean, _oldValue: boolean) {

--- a/apps/frontend/src/components/global/upload_tabs/EditEvaluationModal.vue
+++ b/apps/frontend/src/components/global/upload_tabs/EditEvaluationModal.vue
@@ -158,7 +158,7 @@ export default class EditEvaluationModal extends Vue {
   async update(): Promise<void> {
     Promise.all([EvaluationModule.updateEvaluation(this.activeEvaluation), this.updateGroups()]).then(() => {
       SnackbarModule.notify('Evaluation Updated Successfully');
-      this.$emit('update-groups', this.active.id)
+      this.$emit('update', this.active.id)
     })
     this.visible = false;
   }

--- a/apps/frontend/src/components/global/upload_tabs/GroupFileList.vue
+++ b/apps/frontend/src/components/global/upload_tabs/GroupFileList.vue
@@ -1,0 +1,221 @@
+<template>
+  <div>
+    <v-text-field
+      v-model="search"
+      class="px-3 pb-1"
+      append-icon="mdi-magnify"
+      label="Search"
+      hide-details
+    />
+    <DeleteDialog
+      v-model="deleteItemDialog"
+      type="file"
+      @cancel="deleteItemDialog = false"
+      @confirm="deleteItemConfirm"
+    />
+    <v-data-table
+      v-model="selectedFiles"
+      :headers="headers"
+      :loading="loading"
+      :items="filteredFiles"
+      group-by="group"
+      show-select
+      dense
+      ><template #[`item.filename`]="{item}">
+        <span class="cursor-pointer" @click="load_results([item])">{{
+          item.filename
+        }}</span>
+      </template>
+      <template #[`item.evaluationTags`]="{item}">
+        <TagRow :evaluation="item"
+      /></template>
+      <template #[`item.createdAt`]="{item}">
+        <span>{{ new Date(item.createdAt).toLocaleString() }}</span>
+      </template>
+      <template #[`item.actions`]="{item}">
+        <v-row class="d-flex flex-row-reverse">
+          <ShareEvaluationButton title="Share Result" :evaluation="item" />
+          <div v-if="item.editable">
+            <EditEvaluationModal
+              id="editEvaluationModal"
+              :active="item"
+              @update="updateEvaluations"
+            >
+              <template #clickable="{on}"
+                ><v-icon
+                  data-cy="edit"
+                  small
+                  title="Edit"
+                  class="mr-2"
+                  v-on="on"
+                >
+                  mdi-pencil
+                </v-icon>
+              </template>
+            </EditEvaluationModal>
+            <v-icon
+              data-cy="delete"
+              class="mr-2"
+              small
+              @click="deleteItem(item)"
+              >mdi-delete</v-icon
+            >
+          </div>
+        </v-row>
+      </template></v-data-table
+    ><v-btn
+      block
+      class="card-outter"
+      :disabled="loading"
+      @click="load_results(selectedFiles)"
+    >
+      Load Selected
+      <v-icon class="pl-2"> mdi-file-download</v-icon>
+    </v-btn>
+  </div>
+</template>
+
+<script lang="ts">
+import {IEvaluation, IGroup} from '@heimdall/interfaces';
+import Vue from 'vue';
+import Component from 'vue-class-component';
+import TagRow from '@/components/global/tags/TagRow.vue';
+import {Prop, Watch} from 'vue-property-decorator';
+import {EvaluationModule} from '../../../store/evaluations';
+import DeleteDialog from '@/components/generic/DeleteDialog.vue';
+import ShareEvaluationButton from '@/components/generic/ShareEvaluationButton.vue';
+import EditEvaluationModal from '@/components/global/upload_tabs/EditEvaluationModal.vue';
+import {SnackbarModule} from '../../../store/snackbar';
+
+@Component({
+    components: {
+        DeleteDialog,
+        EditEvaluationModal,
+        ShareEvaluationButton,
+        TagRow
+    }
+})
+export default class GroupFileList extends Vue {
+    @Prop({required: true}) readonly files!: IEvaluation[];
+    @Prop({type: Boolean, default: false}) readonly loading!: boolean;
+
+    search = '';
+    activeItem!: IEvaluation;
+    selectedFiles: IEvaluation[] = [];
+    deleteItemDialog = false;
+    convertedFiles: (IEvaluation & {group: string})[] = []
+    headers: Object[] = [
+        {
+            text: 'Filename',
+            align: 'start',
+            sortable: true,
+            value: 'filename'
+        },
+        {
+            text: 'Tags',
+            value: 'evaluationTags',
+            sortable: true
+        },
+        {
+            text: 'Group',
+            value: 'group',
+            sortable: true
+        },
+        {
+            text: 'Uploaded',
+            value: 'createdAt',
+            sortable: true
+        },
+        {
+            text: 'Actions',
+            value: 'actions',
+            align: 'right'
+        }
+    ];
+
+    @Watch('files')
+    onUpdateFiles() {
+        this.convertFilesToGroups();
+    }
+
+    async updateEvaluations() {
+        await EvaluationModule.getAllEvaluations();
+        this.convertFilesToGroups();
+    }
+
+    load_results(evaluations: IEvaluation[]) {
+        this.selectedFiles = [];
+        this.$emit('load-results', evaluations);
+    }
+
+    convertFilesToGroups() {
+        const foundGroups: IGroup[] = [];
+        this.convertedFiles = [];
+        // Filter out all unique groups
+        this.files.forEach((file) => {
+            if(file.groups?.length !== 0){
+                file.groups?.forEach((group) => {
+                    if(!foundGroups.some((foundGroup) => foundGroup.id === group.id)){
+                        foundGroups.push(group);
+                    }
+                    foundGroups.forEach((foundGroup) => {
+                        if(foundGroup.id === group.id) {
+                            this.convertedFiles.push({...file, group: group.name});
+                        }
+                    })
+                })
+            } else {
+                this.convertedFiles.push({...file, group: 'No Group'});
+            }
+        })
+    }
+
+     filterEvaluationTags(file: IEvaluation, search: string): boolean {
+        let result = false;
+        file.evaluationTags.forEach((tag) => {
+            if (tag.value.toLowerCase().includes(search)) {
+                result = true;
+            };
+        })
+        return result
+    }
+
+    get filteredFiles() {
+        let matches: (IEvaluation & {group: string})[] = []
+        if (this.search != '') {
+            let searchToLower = this.search.toLowerCase();
+            this.convertedFiles.forEach(async (item) => {
+                if (this.filterEvaluationTags(item, searchToLower) || item.filename.toLowerCase().includes(searchToLower)) {
+                    matches.push(item)
+                }
+            })
+        } else {
+            return this.convertedFiles;
+        }
+        return matches
+    }
+
+    deleteItem(item: IEvaluation) {
+        this.activeItem = item;
+        this.deleteItemDialog = true;
+    }
+
+    async deleteItemConfirm(): Promise<void>{
+        await EvaluationModule.deleteEvaluation(this.activeItem).then(() => {
+            SnackbarModule.notify("Deleted evaluation successfully.")
+        })
+        this.deleteItemDialog = false;
+        this.updateEvaluations();
+    }
+}
+</script>
+
+<style scoped>
+.cursor-pointer {
+  cursor: pointer;
+}
+.card-outter {
+  position: absolute;
+  bottom: 0;
+}
+</style>

--- a/apps/frontend/src/views/Results.vue
+++ b/apps/frontend/src/views/Results.vue
@@ -79,7 +79,7 @@
                         <EditEvaluationModal
                           id="editEvaluationModal"
                           :active="getDbFile(file.from_file)"
-                          @update-groups="onUpdateGroups"
+                          @update="onUpdateGroups"
                         >
                           <template #clickable="{on}"
                             ><v-icon


### PR DESCRIPTION
Closes #906, sorts evaluations in DatabaseReader table by their groups. Evaluations that belong to multiple groups are duplicated in the table.

![image](https://user-images.githubusercontent.com/66680985/121219996-3ced7300-c852-11eb-80ba-d9aa82c6e093.png)
