### PR TITLE
Gitignore NGINX Certificates, do not specify nginx container name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ data/
 
 # Ignore cloud.gov manifest
 manifest.yml
+
+# Ignore nginx SSL certificate and key
+nginx/certs/ssl_certificate.crt
+nginx/certs/ssl_certificate_key.key

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,6 @@ services:
       - "database"
   nginx:
     image: nginx:alpine
-    container_name: production_nginx
     environment:
       NGINX_HOST: ${NGINX_HOST}
     volumes:


### PR DESCRIPTION
Avoid users mistakenly committing their SSL certificates to git, avoid naming conflicts by allowing docker compose to pick the name of the container.