### PR TITLE
Prevent Signup Modal From Being Dismissed

### DIFF
--- a/apps/frontend/src/components/global/RegistrationModal.vue
+++ b/apps/frontend/src/components/global/RegistrationModal.vue
@@ -2,6 +2,7 @@
   <Modal
     :visible="visible"
     :max-width="'500px'"
+    :persistent="true"
     @close-modal="$emit('close-modal')"
     @update-user-table="$emit('update-user-table')"
   >


### PR DESCRIPTION
This prevents dismissing the registration modal by accident, and then have to reload the page to get it back.