### PR TITLE
Set CCI Chips to not Act as Buttons on Hover

### DIFF
--- a/apps/frontend/src/components/cards/controltable/ControlRowHeader.vue
+++ b/apps/frontend/src/components/cards/controltable/ControlRowHeader.vue
@@ -57,7 +57,7 @@
     </template>
     <template #tags>
       <v-chip-group column active-class="NONE">
-        <v-tooltip v-for="(tag, i) in all_tags" :key="'chip' + i" bottom>
+        <v-tooltip v-for="(tag, i) in nistTags" :key="'chip' + i" bottom>
           <template #activator="{on}">
             <v-chip
               :href="tag.url"
@@ -65,6 +65,16 @@
               active-class="NONE"
               v-on="on"
             >
+              {{ tag.label }}
+            </v-chip>
+          </template>
+          <span>{{ tag.description }}</span>
+        </v-tooltip>
+      </v-chip-group>
+      <v-chip-group column active-class="NONE">
+        <v-tooltip v-for="(tag, i) in cciTags" :key="'chip' + i" bottom>
+          <template #activator="{on}">
+            <v-chip style="cursor: help" active-class="NONE" v-on="on">
               {{ tag.label }}
             </v-chip>
           </template>
@@ -155,7 +165,7 @@ export default class ControlRowHeader extends mixins(HtmlSanitizeMixin) {
     return 'Unrecognized Tag';
   }
 
-  get all_tags(): Tag[] {
+  get nistTags(): Tag[] {
     let nist_tags = this.control.hdf.raw_nist_tags;
     nist_tags = nist_tags.filter((tag) => tag.search(/Rev.*\d/i) == -1);
     let nist_tag_objects = nist_tags.map((tag) => {
@@ -172,16 +182,20 @@ export default class ControlRowHeader extends mixins(HtmlSanitizeMixin) {
       }
       return {label: tag, url: url, description: this.descriptionForTag(tag)};
     });
+    return nist_tag_objects
+  }
+
+  get cciTags(): Tag[] {
     let cci_tags: string | string[] = this.control.data.tags.cci || '';
     if (!cci_tags) {
-      return nist_tag_objects;
+      return [];
     } else if (typeof cci_tags == 'string') {
       cci_tags = cci_tags.split(' ');
     }
     let cci_tag_objects = cci_tags.map((cci) => {
       return {label: cci, url: '', description: this.descriptionForTag(cci)};
     });
-    return [...nist_tag_objects, ...cci_tag_objects];
+    return cci_tag_objects
   }
 }
 </script>


### PR DESCRIPTION
Closes #108, removes the clickable properties of CCI tags and shows a help cursor on hover.