### PR TITLE
Lock to old version of Dart sass

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -91,7 +91,7 @@
     "prismjs": "^1.21.0",
     "roboto-fontface": "*",
     "sanitize-html": "^2.3.3",
-    "sass": "^1.23.6",
+    "sass": "~1.32.6",
     "sass-loader": "^10.0.3",
     "uuid": "^8.3.0",
     "vue": "~2.6.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17057,10 +17057,10 @@ sass-loader@^10.0.3:
     schema-utils "^3.0.0"
     semver "^7.3.2"
 
-sass@^1.23.6:
-  version "1.35.1"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.35.1.tgz#90ecf774dfe68f07b6193077e3b42fb154b9e1cd"
-  integrity sha512-oCisuQJstxMcacOPmxLNiLlj4cUyN2+8xJnG7VanRoh2GOLr9RqkvI4AxA4a6LHVg/rsu+PmxXeGhrdSF9jCiQ==
+sass@~1.32.6:
+  version "1.32.13"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.32.13.tgz#8d29c849e625a415bce71609c7cf95e15f74ed00"
+  integrity sha512-dEgI9nShraqP7cXQH+lEXVf73WOPCse0QlFzSD8k+1TcOxCMwVXfQlr0jtoluZysQOyJGnfr21dLvYKDJq8HkA==
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
 


### PR DESCRIPTION
The dart sass developers have decided that hiding deprecation warnings, even if they are out of our control, should not be allowed: https://github.com/sass/libsass/issues/2822#issuecomment-482914373

They have recommended locking to a version that does not have the warnings so this PR does just that.