### PR TITLE
Display Password Complexity Before Allowing Signup

### DIFF
--- a/apps/backend/src/pipes/password-complexity.pipe.ts
+++ b/apps/backend/src/pipes/password-complexity.pipe.ts
@@ -5,6 +5,33 @@ import {
   PipeTransform
 } from '@nestjs/common';
 
+export function checkLength(password: string): boolean {
+  return password.length < 15;
+}
+
+export function hasClasses(password: string): boolean {
+  const validators = [
+    RegExp('[a-z]'),
+    RegExp('[A-Z]'),
+    RegExp('[0-9]'),
+    RegExp(/[^\w\s]/)
+  ];
+  return (
+    validators.filter((expr) => expr.test(password)).length == validators.length
+  );
+}
+
+export function noRepeats(password: string): boolean {
+  const validators = [
+    RegExp(/(.)\1{3,}/),
+    RegExp('[a-z]{4,}'),
+    RegExp('[A-Z]{4,}'),
+    RegExp('[0-9]{4,}'),
+    RegExp(/[^\w\s]{4,}/)
+  ];
+  return validators.filter((expr) => expr.test(password)).length === 0;
+}
+
 @Injectable()
 export class PasswordComplexityPipe implements PipeTransform {
   transform(
@@ -19,8 +46,9 @@ export class PasswordComplexityPipe implements PipeTransform {
     }
     if (
       typeof value.password == 'string' &&
-      this.hasClasses(value.password) &&
-      this.noRepeats(value.password)
+      hasClasses(value.password) &&
+      noRepeats(value.password) &&
+      checkLength(value.password)
     ) {
       return value;
     } else {
@@ -31,30 +59,5 @@ export class PasswordComplexityPipe implements PipeTransform {
           ' Passwords cannot contain more than four repeating characters from the same character class.'
       );
     }
-  }
-
-  hasClasses(password: string): boolean {
-    const validators = [
-      RegExp('[a-z]'),
-      RegExp('[A-Z]'),
-      RegExp('[0-9]'),
-      RegExp(/[^\w\s]/),
-      RegExp('.{15,}')
-    ];
-    return (
-      validators.filter((expr) => expr.test(password)).length ==
-      validators.length
-    );
-  }
-
-  noRepeats(password: string): boolean {
-    const validators = [
-      RegExp(/(.)\1{3,}/),
-      RegExp('[a-z]{4,}'),
-      RegExp('[A-Z]{4,}'),
-      RegExp('[0-9]{4,}'),
-      RegExp(/[^\w\s]{4,}/)
-    ];
-    return validators.filter((expr) => expr.test(password)).length === 0;
   }
 }

--- a/apps/backend/src/users/users.controller.ts
+++ b/apps/backend/src/users/users.controller.ts
@@ -20,7 +20,12 @@ import {ImplicitAllowJwtAuthGuard} from '../guards/implicit-allow-jwt-auth.guard
 import {JwtAuthGuard} from '../guards/jwt-auth.guard';
 import {TestGuard} from '../guards/test.guard';
 import {PasswordChangePipe} from '../pipes/password-change.pipe';
-import {PasswordComplexityPipe} from '../pipes/password-complexity.pipe';
+import {
+  checkLength,
+  hasClasses,
+  noRepeats,
+  PasswordComplexityPipe
+} from '../pipes/password-complexity.pipe';
 import {PasswordsMatchPipe} from '../pipes/passwords-match.pipe';
 import {User} from '../users/user.model';
 import {CreateUserDto} from './dto/create-user.dto';
@@ -69,6 +74,27 @@ export class UsersController {
 
     const users = await this.usersService.adminFindAll();
     return users.map((user) => new UserDto(user));
+  }
+
+  @Post('check-password-complexity')
+  async checkPasswordComplexity(
+    @Body() passwordData: {password: string}
+  ): Promise<string[]> {
+    if (typeof passwordData.password !== 'string') {
+      return ['Password must be of type string'];
+    }
+    const errors: string[] = [];
+    checkLength(passwordData.password) &&
+      errors.push('Password must be at least 15 characters');
+    !hasClasses(passwordData.password) &&
+      errors.push(
+        'Password must contain a combination of lowercase letters, uppercase letters, numbers, and special characters'
+      );
+    !noRepeats(passwordData.password) &&
+      errors.push(
+        'Password must not contain 4 consecutive characters of the same character class'
+      );
+    return errors;
   }
 
   @Post()

--- a/apps/frontend/src/components/global/RegistrationModal.vue
+++ b/apps/frontend/src/components/global/RegistrationModal.vue
@@ -57,13 +57,17 @@
           <v-text-field
             id="password"
             v-model="password"
-            :error-messages="requiredFieldError($v.password, 'Password')"
+            :error-messages="[
+              ...requiredFieldError($v.password, 'Password'),
+              ...passwordErrorMessages
+            ]"
             prepend-icon="mdi-lock"
             name="password"
             label="Password"
             loading
             :type="showPassword ? 'text' : 'password'"
             tabindex="4"
+            @change="checkPasswordComplexity"
             @blur="$v.password.$touch()"
           >
             <template #progress>
@@ -174,6 +178,7 @@ export default class RegistrationModal extends Vue {
   password = '';
   passwordConfirmation = '';
   showPassword = false;
+  passwordErrorMessages: string[] = [];
 
   @Prop({type: Boolean, default: false}) readonly adminRegisterMode!: boolean;
   @Prop({default: false}) readonly visible!: boolean;
@@ -212,6 +217,12 @@ export default class RegistrationModal extends Vue {
 
         });
     }
+  }
+
+  async checkPasswordComplexity() {
+    ServerModule.CheckPasswordComplexity(this.password).then((passwordErrors) => {
+      this.passwordErrorMessages = passwordErrors
+    })
   }
 
   // password strength bar expects a percentage

--- a/apps/frontend/src/store/server.ts
+++ b/apps/frontend/src/store/server.ts
@@ -208,6 +208,17 @@ class Server extends VuexModule implements IServerState {
   }
 
   @Action
+  public async CheckPasswordComplexity(password: string): Promise<string[]> {
+    return axios
+      .post(`/users/check-password-complexity`, {
+        password: password
+      })
+      .then(({data}) => {
+        return data;
+      });
+  }
+
+  @Action
   public async updateUserInfo(user: {
     id: string;
     info: IUpdateUser;


### PR DESCRIPTION
Closes #219.

Adds:
 - POST `/users/check-password-complexity` | Body: `{password: string}`
 - Checking password complexity on changing password on the sign up modal
 - Exports functions in password complexity pipe as functions so they can be imported from other parts of the backend.

![image](https://user-images.githubusercontent.com/66680985/122282613-9c362d80-ceb9-11eb-82c0-c6a069e45f80.png)