### PR TITLE
Update Mergify and Dependabot merge configurations

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,22 +1,16 @@
+queue_rules:
+  - name: default
+    conditions:
+      - "#approved-reviews-by>=1"
+      - base=master
+
 pull_request_rules:
   - name: automatic merge for master when reviewed and CI passes
     conditions:
-      - "#approved-reviews-by>=1"
-      - base=master
       - label=ready-to-merge
     actions:
-        merge:
-          strict: true
-          method: squash
-  - name: automatic merge for updates when CI passes
-    conditions:
-      - "#approved-reviews-by>=1"
-      - base=master
-      - label=dependencies
-    actions:
-        merge:
-          strict: true
-          method: squash
+      queue:
+        name: default
   - name: delete head branch after merge
     conditions:
       - merged
@@ -29,10 +23,3 @@ pull_request_rules:
     actions:
         comment:
           message: This pull request has a conflict. Could you fix it @{{author}}?
-  - name: ask dependabot to recreate PRs with conflicts
-    conditions:
-      - conflict
-      - author~=^dependabot(|-preview)\[bot\]$
-    actions:
-        comment:
-          message: \@dependabot recreate

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -11,6 +11,7 @@ pull_request_rules:
     actions:
       queue:
         name: default
+        method: squash
   - name: delete head branch after merge
     conditions:
       - merged

--- a/.github/workflows/auto-approve-and-merge.yml
+++ b/.github/workflows/auto-approve-and-merge.yml
@@ -1,7 +1,10 @@
-name: Auto approve Dependabot PRs
+name: Auto approve and Merge Dependabot PRs
 on:
   pull_request_target:
     types: [labeled]
+permissions:
+  pull-requests: write
+  contents: write
 
 jobs:
   approve:
@@ -12,3 +15,8 @@ jobs:
     - uses: hmarr/auto-approve-action@v2
       with:
         github-token: "${{ secrets.GITHUB_TOKEN }}"
+    - name: Enable auto-merge for Dependabot PRs
+      run: gh pr merge --auto --merge "$PR_URL"
+      env:
+        PR_URL: ${{github.event.pull_request.html_url}}
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Stop using mergify for merging Depndabot PRs, use Github Action instead