### PR TITLE
Add Support for Custom Gitlab Base URL

### DIFF
--- a/apps/backend/.env-example
+++ b/apps/backend/.env-example
@@ -19,8 +19,9 @@ GITHUB_CLIENTSECRET=<Github Application Client Secret>
 GITHUB_ENTERPRISE_INSTANCE_BASE_URL=<Github Enterprise Instance Base URL (default=https://github.com/)>
 GITHUB_ENTERPRISE_INSTANCE_API_URL=<Github Enterprise Instance API URL (default=https://api.github.com/)>
 
-GITLAB_CLIENTID=<Github Application Client ID>
-GITLAB_CLIENTSECRET=<Github Application Client Secret>
+GITLAB_CLIENTID=<Gitlab Application Client ID>
+GITLAB_CLIENTSECRET=<Gitlab Application Client Secret>
+GITLAB_BASEURL=<Gitlab Base URL (default=https://gitlab.com)>
 
 GOOGLE_CLIENTID=<Google Application Client ID (apps.googleusercontent.com)>
 GOOGLE_CLIENTSECRET="<Google Application Client Secret>"

--- a/apps/backend/src/authn/gitlab.strategy.ts
+++ b/apps/backend/src/authn/gitlab.strategy.ts
@@ -24,6 +24,7 @@ export class GitlabStrategy extends PassportStrategy(Strategy, 'gitlab') {
     super({
       clientID: configService.get('GITLAB_CLIENTID') || 'disabled',
       clientSecret: configService.get('GITLAB_SECRET') || 'disabled',
+      baseURL: configService.get('GITLAB_BASEURL'),
       callbackURL:
         `${configService.get('EXTERNAL_URL')}/authn/gitlab/callback` ||
         'disabled'


### PR DESCRIPTION
Closes #1553, adds `GITLAB_BASEURL` environment variable to specify a custom Gitlab instance.