### PR TITLE
Use First LDAP Email Available if Multiple

### DIFF
--- a/apps/backend/src/authn/ldap.strategy.ts
+++ b/apps/backend/src/authn/ldap.strategy.ts
@@ -37,12 +37,22 @@ export class LDAPStrategy extends PassportStrategy(Strategy, 'ldap') {
           user,
           configService.get('LDAP_MAILFIELD') || 'mail'
         );
-        req.user = this.authnService.validateOrCreateUser(
-          email,
-          firstName,
-          lastName,
-          'ldap'
-        );
+        // If user has multiple emails
+        if (typeof email === 'object') {
+          req.user = this.authnService.validateOrCreateUser(
+            email[0],
+            firstName,
+            lastName,
+            'ldap'
+          );
+        } else {
+          req.user = this.authnService.validateOrCreateUser(
+            email,
+            firstName,
+            lastName,
+            'ldap'
+          );
+        }
         return done(null, req.user);
       }
     );

--- a/apps/backend/src/authn/ldap.strategy.ts
+++ b/apps/backend/src/authn/ldap.strategy.ts
@@ -37,22 +37,12 @@ export class LDAPStrategy extends PassportStrategy(Strategy, 'ldap') {
           user,
           configService.get('LDAP_MAILFIELD') || 'mail'
         );
-        // If user has multiple emails
-        if (typeof email === 'object') {
-          req.user = this.authnService.validateOrCreateUser(
-            email[0],
-            firstName,
-            lastName,
-            'ldap'
-          );
-        } else {
-          req.user = this.authnService.validateOrCreateUser(
-            email,
-            firstName,
-            lastName,
-            'ldap'
-          );
-        }
+        req.user = this.authnService.validateOrCreateUser(
+          typeof email === 'object' ? email[0] : email,
+          firstName,
+          lastName,
+          'ldap'
+        );
         return done(null, req.user);
       }
     );

--- a/apps/backend/src/authn/ldap.strategy.ts
+++ b/apps/backend/src/authn/ldap.strategy.ts
@@ -38,7 +38,7 @@ export class LDAPStrategy extends PassportStrategy(Strategy, 'ldap') {
           configService.get('LDAP_MAILFIELD') || 'mail'
         );
         req.user = this.authnService.validateOrCreateUser(
-          typeof email === 'object' ? email[0] : email,
+          Array.isArray(email) ? email[0] : email,
           firstName,
           lastName,
           'ldap'


### PR DESCRIPTION
This fixes the server failing to create an account when multiple email values are present on the LDAP account.