### PR TITLE
Ensure Evaluation is from Database Before Loading TagRow on Compare View

### DIFF
--- a/apps/frontend/src/views/Compare.vue
+++ b/apps/frontend/src/views/Compare.vue
@@ -66,6 +66,7 @@
                                 <br />
                                 <span>{{ fileTimes[i] }}</span>
                                 <TagRow
+                                  v-if="file.database_id"
                                   style="max-width: 400px"
                                   :evaluation="toIEvaluation(file)"
                                 />


### PR DESCRIPTION
Closes #1535, ensures evaluations have a matching IEvaluation before loading its TagRow on compare view.