### PR TITLE
Fixed bug where you couldn't open group members dialog more than once

### DIFF
--- a/apps/frontend/src/components/global/groups/GroupManagement.vue
+++ b/apps/frontend/src/components/global/groups/GroupManagement.vue
@@ -87,6 +87,7 @@
     <GroupUsers
       v-model="selectedGroupUsers"
       :dialog-display-users="dialogDisplayUsers"
+      @close-group-users-dialog="dialogDisplayUsers = false"
     />
   </v-card>
 </template>

--- a/apps/frontend/src/components/global/groups/GroupUsers.vue
+++ b/apps/frontend/src/components/global/groups/GroupUsers.vue
@@ -12,7 +12,7 @@
       </v-card-text>
       <v-card-actions>
         <v-col class="text-right">
-          <v-btn color="primary" text @click="dialogDisplayUsers = false"
+          <v-btn color="primary" text @click="$emit('close-group-users-dialog')"
             >Close</v-btn
           >
         </v-col>
@@ -37,6 +37,5 @@ import Users from '@/components/global/groups/Users.vue';
 export default class GroupUsers extends Vue {
   @VModel({type: Array, required: true}) selectedGroupUsers!: ISlimUser[];
   @Prop({type: Boolean, default: false}) readonly dialogDisplayUsers!: boolean;
-
 }
 </script>


### PR DESCRIPTION
Closes #1651. Can't click on group members chip more than once.

Signed-off-by: Sam Sunvold <sunvoldsj@vcu.edu>