### PR TITLE
Set default cookie expiration to much lower, do not use JWT for secrets

### DIFF
--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -45,9 +45,10 @@ async function bootstrap() {
     })
   );
   app.use(json({limit: '50mb'}));
+  // Sessions are only used for oauth callbacks
   app.use(
     session({
-      secret: configService.get('JWT_SECRET') || generateDefault(),
+      secret: generateDefault(),
       store: new (postgresSessionStore(session))({
         conObject: {
           ...configService.getDbConfig(),
@@ -57,7 +58,7 @@ async function bootstrap() {
         },
         tableName: 'session'
       }),
-      cookie: {maxAge: 30 * 24 * 60 * 60 * 1000},
+      cookie: {maxAge: 60 * 60}, // 1 hour
       saveUninitialized: true,
       resave: false
     })


### PR DESCRIPTION
Current cookie expiration is 82 years, this is very long for how long the oauth workflow should reasonably take.

The JWT secret is really only intended for JWT, since these are not for long standing sessions, a short term session is acceptable.