### PR TITLE
Fixed issue where you couldn't update role of LDAP user

### DIFF
--- a/apps/frontend/src/components/global/UserModal.vue
+++ b/apps/frontend/src/components/global/UserModal.vue
@@ -144,7 +144,7 @@
             id="closeAndSaveChanges"
             color="primary"
             text
-            :disabled="update_unavailable"
+            :disabled="!admin && update_unavailable"
             :loading="buttonLoading"
             @click="updateUserInfo"
             >Save Changes</v-btn
@@ -206,7 +206,7 @@ export default class UserModal extends Vue {
   async updateUserInfo(): Promise<void> {
     this.buttonLoading = true;
     this.$v.$touch()
-    if (this.userInfo != null && !this.$v.$invalid) {
+    if (this.userInfo != null && (this.admin || !this.$v.$invalid)) {
       var updateUserInfo: IUpdateUser = {
         ...this.userInfo,
         password: undefined,


### PR DESCRIPTION
Closes #1640. Allow role changes for identity provider login created users.

Signed-off-by: Sam Sunvold <sunvoldsj@vcu.edu>