### PR TITLE
Add Sensitivity Classifications to Evaluations

### DIFF
--- a/apps/backend/migrations/20210806190424-add-classification-to-evaluations.js
+++ b/apps/backend/migrations/20210806190424-add-classification-to-evaluations.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+   await queryInterface.addColumn('Evaluations', 'classification', {
+     type: Sequelize.TEXT,
+     allowNull: true
+   })
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn('Evaluations', 'classification', {
+      type: Sequelize.TEXT,
+      allowNull: true
+    })
+  }
+};

--- a/apps/backend/src/evaluations/dto/create-evaluation.dto.ts
+++ b/apps/backend/src/evaluations/dto/create-evaluation.dto.ts
@@ -18,6 +18,10 @@ export class CreateEvaluationDto implements ICreateEvaluation {
   readonly public!: boolean;
 
   @IsOptional()
+  @IsString()
+  readonly classification!: string;
+
+  @IsOptional()
   @IsArray()
   readonly evaluationTags: CreateEvaluationTagDto[] | undefined;
 

--- a/apps/backend/src/evaluations/dto/evaluation.dto.ts
+++ b/apps/backend/src/evaluations/dto/evaluation.dto.ts
@@ -11,6 +11,7 @@ export class EvaluationDto implements IEvaluation {
   readonly groups: GroupDto[];
   readonly userId: string;
   readonly public: boolean;
+  readonly classification?: string;
   readonly createdAt: Date;
   readonly updatedAt: Date;
   readonly editable: boolean;
@@ -41,6 +42,7 @@ export class EvaluationDto implements IEvaluation {
     }
     this.userId = evaluation.userId;
     this.public = evaluation.public;
+    this.classification = evaluation.classification;
     this.createdAt = evaluation.createdAt;
     this.updatedAt = evaluation.updatedAt;
     this.editable = editable;

--- a/apps/backend/src/evaluations/dto/update-evaluation.dto.ts
+++ b/apps/backend/src/evaluations/dto/update-evaluation.dto.ts
@@ -13,4 +13,8 @@ export class UpdateEvaluationDto implements IUpdateEvaluation {
   @IsOptional()
   @IsBoolean()
   readonly public: boolean | undefined;
+
+  @IsOptional()
+  @IsString()
+  readonly classification: boolean | undefined;
 }

--- a/apps/backend/src/evaluations/evaluation.model.ts
+++ b/apps/backend/src/evaluations/evaluation.model.ts
@@ -40,6 +40,11 @@ export class Evaluation extends Model {
   @Column(DataType.BOOLEAN)
   public!: boolean;
 
+  @AllowNull(true)
+  @Default(null)
+  @Column(DataType.TEXT)
+  classification!: string;
+
   @ForeignKey(() => User)
   @Column(DataType.BIGINT)
   userId!: string;

--- a/apps/frontend/src/components/cards/EvaluationInfo.vue
+++ b/apps/frontend/src/components/cards/EvaluationInfo.vue
@@ -1,48 +1,59 @@
 <template>
-  <v-row class="pa-4" dense justify="space-between">
-    <v-col data-cy="fileinfo" cols="11">
-      <strong>Filename:</strong> {{ filename }}<br />
-      <div v-if="inspec_version">
-        <strong>Tool Version:</strong> {{ inspec_version }}
-      </div>
-      <div v-if="platform"><strong>Platform:</strong> {{ platform }}</div>
-      <div v-if="duration"><strong>Duration:</strong> {{ duration }}</div>
-      <div v-if="startTime"><strong>Start Time:</strong> {{ startTime }}</div>
-      <div v-if="evaluation" class="d-flex flex-nowrap">
-        <strong class="pt-2 pr-1">Tags:</strong>
-        <TagRow v-if="evaluation.id" :evaluation="evaluation" />
-      </div>
-      <div
-        v-if="evaluation && evaluation.groups.length !== 0"
-        class="d-flex flex-nowrap"
-      >
-        <strong class="pt-2 pr-1">Groups:</strong>
-        <GroupRow :evaluation="evaluation" />
-      </div>
-    </v-col>
-    <v-col cols="1">
-      <div
-        v-if="file.from_file.database_id && evaluation.editable"
-        class="top-right"
-      >
-        <v-icon
-          data-cy="edit"
-          title="Edit"
-          class="mr-3 mt-3"
-          @click="showEditEvaluationModal = true"
+  <span>
+    <v-row class="pa-4" dense justify="space-between">
+      <v-col data-cy="fileinfo" cols="11">
+        <strong>Filename:</strong> {{ filename }}<br />
+        <div v-if="inspec_version">
+          <strong>Tool Version:</strong> {{ inspec_version }}
+        </div>
+        <div v-if="platform"><strong>Platform:</strong> {{ platform }}</div>
+        <div v-if="duration"><strong>Duration:</strong> {{ duration }}</div>
+        <div v-if="startTime"><strong>Start Time:</strong> {{ startTime }}</div>
+        <div v-if="evaluation" class="d-flex flex-nowrap">
+          <strong class="pt-2 pr-1">Tags:</strong>
+          <TagRow v-if="evaluation.id" :evaluation="evaluation" />
+        </div>
+        <div
+          v-if="evaluation && evaluation.groups.length !== 0"
+          class="d-flex flex-nowrap"
         >
-          mdi-pencil
-        </v-icon>
-        <EditEvaluationModal
-          v-if="showEditEvaluationModal"
-          id="editEvaluationModal"
-          :visible="showEditEvaluationModal"
-          :active="evaluation"
-          @close="showEditEvaluationModal = false"
-        />
-      </div>
-    </v-col>
-  </v-row>
+          <strong class="pt-2 pr-1">Groups:</strong>
+          <GroupRow :evaluation="evaluation" />
+        </div>
+      </v-col>
+      <v-col cols="1">
+        <div
+          v-if="file.from_file.database_id && evaluation.editable"
+          class="top-right"
+        >
+          <v-icon
+            data-cy="edit"
+            title="Edit"
+            class="mr-3 mt-3"
+            @click="showEditEvaluationModal = true"
+          >
+            mdi-pencil
+          </v-icon>
+          <EditEvaluationModal
+            v-if="showEditEvaluationModal"
+            id="editEvaluationModal"
+            :visible="showEditEvaluationModal"
+            :active="evaluation"
+            @close="showEditEvaluationModal = false"
+          />
+        </div>
+      </v-col>
+    </v-row>
+    <v-banner
+      v-if="evaluation && evaluation.classification"
+      single-line
+      class="rounded-b"
+      color="warning"
+      icon="mdi-alert"
+    >
+      This file has been marked as {{ evaluation.classification }}
+    </v-banner>
+  </span>
 </template>
 
 <script lang="ts">

--- a/apps/frontend/src/components/global/upload_tabs/EditEvaluationModal.vue
+++ b/apps/frontend/src/components/global/upload_tabs/EditEvaluationModal.vue
@@ -12,18 +12,25 @@
       <v-card-text>
         <v-container>
           <v-row>
-            <v-col cols="12" sm="7">
+            <v-col cols="12" sm="5">
               <v-text-field
                 v-model="activeEvaluation.filename"
                 data-cy="filename"
                 label="File name"
               />
             </v-col>
-            <v-col cols="12" sm="5">
+            <v-col cols="12" sm="4">
               <v-select
                 v-model="activeEvaluation.public"
                 :items="visibilityOptions"
                 label="Visibility"
+              />
+            </v-col>
+            <v-col cols="12" sm="3">
+              <v-combobox
+                v-model="activeEvaluation.classification"
+                :items="classifications"
+                label="Classification"
               />
             </v-col>
           </v-row>
@@ -51,6 +58,7 @@
                 </template>
               </v-autocomplete>
             </v-col>
+
             <v-col cols="12" sm="5" md="3">
               <GroupModal id="groupModal" :create="true">
                 <template #clickable="{on, attrs}"
@@ -119,6 +127,15 @@ export default class EditEvaluationModal extends mixins(EvaluationMixin) {
   originalGroups: IVuetifyItems[] = [];
   groups: IVuetifyItems[] = [];
   groupSearch = '';
+  classifications = [
+    'Top Secret',
+    'Secret',
+    'Confidential',
+    'Non-Confidential',
+    'CUI',
+    'Containing PII',
+    'Sensitive'
+  ];
 
   visibilityOptions: IVuetifyItems[] = [
     {

--- a/libs/interfaces/evaluation/evaluation.interface.ts
+++ b/libs/interfaces/evaluation/evaluation.interface.ts
@@ -9,6 +9,7 @@ export interface IEvaluation {
   groups: IGroup[];
   readonly userId: string;
   readonly public: boolean;
+  readonly classification?: string;
   readonly createdAt: Date;
   readonly updatedAt: Date;
   readonly editable: boolean;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint:ci": "lerna run lint:ci",
     "pack:all": "lerna exec yarn pack --scope inspecjs --scope @mitre/heimdall-lite --scope @mitre/hdf-converters --parallel",
     "start": "yarn backend start",
-    "start:dev": "dotenv -e apps/backend/.env -- lerna exec yarn run start:dev --ignore @heimdall/interfaces --ignore @heimdall/hdf-converters --ignore @heimdall/cypress-tests --ignore inspecjs",
+    "start:dev": "dotenv -e apps/backend/.env -- lerna exec yarn run start:dev --ignore @heimdall/interfaces --ignore @mitre/hdf-converters --ignore @heimdall/cypress-tests --ignore inspecjs",
     "test:ui": "cypress run",
     "test:ui:open": "cypress open"
   },


### PR DESCRIPTION
Closes #1716. Adds a sensitivity banner to EvaluationInfo when files have been marked with a classification value.

<details>
<summary>Examples</summary>

![image](https://user-images.githubusercontent.com/66680985/128562846-ca4877ae-8e1b-49f0-9ef4-9f5db1ef8796.png)
![image](https://user-images.githubusercontent.com/66680985/128562987-f4a6fbb0-8ce6-4991-8a87-09bfb5a60095.png)

</details>