### PR TITLE
Limit Admin JWT Token Validity to 10 Minutes

### DIFF
--- a/apps/backend/src/authn/authn.service.ts
+++ b/apps/backend/src/authn/authn.service.ts
@@ -80,8 +80,8 @@ export class AuthnService {
       role: user.role,
       forcePasswordChange: user.forcePasswordChange
     };
-    if (payload.forcePasswordChange) {
-      // Give the user 10 minutes to (hopefully) change their password.
+    if (payload.forcePasswordChange || user.role === 'admin') {
+      // Admin sessions are only valid for 10 minutes, for regular users give them 10 minutes to (hopefully) change their password.
       return {
         userID: user.id,
         accessToken: this.jwtService.sign(payload, {expiresIn: '600s'})


### PR DESCRIPTION
Closes #1775, limits admin JWT tokens to 10 minutes.