### PR TITLE
Rename raw_nist_tags to rawNistTags for nist search

### DIFF
--- a/apps/frontend/src/store/data_filters.ts
+++ b/apps/frontend/src/store/data_filters.ts
@@ -323,7 +323,7 @@ export class FilteredData extends VuexModule {
         'hdf.wraps.id': filter.ids,
         'hdf.wraps.title': filter.titleSearchTerms,
         'hdf.wraps.desc': filter.descriptionSearchTerms,
-        'hdf.raw_nist_tags': filter.nistIdFilter,
+        'hdf.rawNistTags': filter.nistIdFilter,
         full_code: filter.codeSearchTerms,
         'hdf.waived': filter.status?.includes('Waived'),
         'root.hdf.status': _.filter(


### PR DESCRIPTION
Fixes `nist:` search.