### PR TITLE
Remove Access to Port 3000 from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,6 @@ services:
     env_file: .env-prod
     ports:
       - "3000"
-      - "3000:3000"
     depends_on:
       - "database"
   nginx:


### PR DESCRIPTION
Closes #2063, removes exposed port 3000 from docker-compose.yml.