### PR TITLE
Cleanup instructions in setup-docker-secrets.sh, add defaults for Certificate Info

### DIFF
--- a/setup-docker-secrets.sh
+++ b/setup-docker-secrets.sh
@@ -24,7 +24,7 @@ EOF
 fi
 
 if ! grep -qF "API_KEY_SECRET" .env-prod; then
-	read -p ".env-prod does not contain API_KEY_SECRET, would you like to enable API Keys? " -n 1 -r
+	read -p ".env-prod does not contain API_KEY_SECRET, would you like to enable API Keys? [Y/n]" -n 1 -r
 	if [[ $REPLY =~ ^[Yy]$ ]]
 	then
 		echo "API_KEY_SECRET=$(openssl rand -hex 33)" >> .env-prod
@@ -50,7 +50,8 @@ else
 							-days 7 \
 							-nodes \
 							-out nginx/certs/ssl_certificate.crt \
-							-keyout nginx/certs/ssl_certificate_key.key
+							-keyout nginx/certs/ssl_certificate_key.key \
+							-subj "/C=US/ST=SelfSigned/L=SelfSigned/O=SelfSigned/OU=SelfSigned"
 fi
 
 echo "Done"


### PR DESCRIPTION
Previously users were asked for information about the self signed certificate. If this information was left blank then it would fail to generate and cause errors when trying to run the app. These changes make the startup script not fail and instead just fills them with junk data (since this cert isn't meant to actually be used anyway)
