### PR TITLE
Restart OIDC Auth Flow on Invalid State

### DIFF
--- a/apps/backend/src/authn/authn.controller.ts
+++ b/apps/backend/src/authn/authn.controller.ts
@@ -118,6 +118,7 @@ export class AuthnController {
 
   @Get('oidc/callback')
   @UseGuards(AuthGuard('oidc'))
+  @UseFilters(new AuthenticationExceptionFilter())
   async getUserFromOIDC(@Req() req: Request): Promise<void> {
     const session = await this.authnService.login(req.user as User);
     await this.setSessionCookies(req, session);

--- a/apps/backend/src/filters/authentication-exception.filter.ts
+++ b/apps/backend/src/filters/authentication-exception.filter.ts
@@ -1,4 +1,5 @@
 import {ArgumentsHost, Catch, ExceptionFilter} from '@nestjs/common';
+import _ from 'lodash';
 import {ConfigService} from '../config/config.service';
 
 @Catch(Error)
@@ -6,7 +7,15 @@ export class AuthenticationExceptionFilter implements ExceptionFilter {
   configService = new ConfigService();
   catch(exception: Error, host: ArgumentsHost): void {
     const ctx = host.switchToHttp();
+    const request = ctx.getRequest();
     const response = ctx.getResponse();
+    // Restart OIDC auth flow if state fails to verify, this is a known bug with passport-openidconnect that occours sometimes when logging in.
+    if (
+      _.get(request, 'authInfo.message') ===
+      'Unable to verify authorization request state.'
+    ) {
+      return response.redirect(301, '/authn/oidc');
+    }
     response.cookie('authenticationError', exception.message, {
       secure: this.configService.isInProductionMode()
     });


### PR DESCRIPTION
Fixes a bug where logging in with OIDC fails while using keycloak. See https://github.com/jaredhanson/passport-openidconnect/issues/76