### PR TITLE
Trim ASFF Input before processing

### DIFF
--- a/libs/hdf-converters/src/asff-mapper.ts
+++ b/libs/hdf-converters/src/asff-mapper.ts
@@ -47,6 +47,7 @@ function fixFileInput(asffJson: string) {
   } catch {
     // Prowler gives us JSON Lines format but we need regular JSON
     const fixedInput = `[${asffJson
+      .trim()
       .replace(/}\n/g, '},\n')
       .replace(/\},\n\$/g, '')}]`;
     let output = JSON.parse(fixedInput);


### PR DESCRIPTION
Closes #2259, trims extra newlines from Prowler ASFFs to ensure data is converted correctly.