### PR TITLE
Add back button to Groups and Admin pages

### DIFF
--- a/apps/frontend/src/components/global/Topbar.vue
+++ b/apps/frontend/src/components/global/Topbar.vue
@@ -8,6 +8,9 @@
   >
     <!-- The title and nav bar -->
     <v-toolbar-title id="toolbar_title" class="pr-2">
+      <v-app-bar-nav-icon v-if="showBackButton" @click.stop="goBack">
+        <v-icon>mdi-arrow-left</v-icon>
+      </v-app-bar-nav-icon>
       <v-app-bar-nav-icon
         v-if="!minimalTopbar"
         data-cy="openSidebar"
@@ -42,6 +45,7 @@ import {Prop} from 'vue-property-decorator';
 export default class Topbar extends mixins(ServerMixin) {
   @Prop({type: String, required: true}) readonly title!: string;
   @Prop({default: false}) readonly minimalTopbar!: boolean;
+  @Prop({default: false}) readonly showBackButton!: boolean;
 
   mounted() {
     this.onResize();
@@ -55,6 +59,10 @@ export default class Topbar extends mixins(ServerMixin) {
         HeightsModule.setTopbarHeight(this.$el.clientHeight);
       }, 2000);
     });
+  }
+
+  goBack() {
+    this.$router.go(-1);
   }
 
   /** Submits an event to clear all filters */

--- a/apps/frontend/src/views/Admin.vue
+++ b/apps/frontend/src/views/Admin.vue
@@ -1,5 +1,9 @@
 <template>
-  <Base title="Heimdall - Admin Panel">
+  <Base
+    :show-back-button="true"
+    :minimal-topbar="true"
+    title="Heimdall - Admin Panel"
+  >
     <template #main-content>
       <v-tabs v-model="activeTab" fixed-tabs dark>
         <v-tab key="users"> User Management </v-tab>

--- a/apps/frontend/src/views/Base.vue
+++ b/apps/frontend/src/views/Base.vue
@@ -19,6 +19,7 @@
         'margin-top': classification ? '1.5em' : '0'
       }"
       :minimal-topbar="minimalTopbar"
+      :show-back-button="showBackButton"
       @toggle-drawer="drawer = !drawer"
     >
       <template #content>
@@ -69,6 +70,7 @@ export default class Base extends Vue {
   @Prop({default: 'Heimdall'}) readonly title!: string;
   @Prop({default: 11}) readonly topbarZIndex!: number;
   @Prop({default: false}) readonly minimalTopbar!: boolean;
+  @Prop({default: false}) readonly showBackButton!: boolean;
   @Prop({default: true}) readonly showTopbar!: boolean;
   @Prop({default: false}) readonly showSearch!: boolean;
 

--- a/apps/frontend/src/views/Groups.vue
+++ b/apps/frontend/src/views/Groups.vue
@@ -1,5 +1,10 @@
 <template>
-  <Base :show-search="false" title="Heimdall - Groups">
+  <Base
+    :show-search="false"
+    :minimal-topbar="true"
+    :show-back-button="true"
+    title="Heimdall - Groups"
+  >
     <template #main-content>
       <v-tabs v-model="activeTab" fixed-tabs dark>
         <v-tab key="my-groups"> My Groups </v-tab>


### PR DESCRIPTION
Adds an obvious way to go back to the previous page on the groups and admin page.

![image](https://user-images.githubusercontent.com/66680985/151241052-f9d9a4bd-03b5-4a21-b45b-218237c8e1f6.png)
![image](https://user-images.githubusercontent.com/66680985/151241103-0f60bae7-acbe-443d-8246-019fd5e8fa81.png)
