### PR TITLE
Specify classification type on CKL Export

### DIFF
--- a/apps/frontend/public/static/export/cklExport.ckl
+++ b/apps/frontend/public/static/export/cklExport.ckl
@@ -24,7 +24,7 @@
 				</SI_DATA>
 				<SI_DATA>
 					<SID_NAME>classification</SID_NAME>
-					<SID_DATA>{{classification}}</SID_DATA>
+					<SID_DATA>UNCLASSIFIED</SID_DATA>
 				</SI_DATA>
 				<SI_DATA>
 					<SID_NAME>customname</SID_NAME>


### PR DESCRIPTION
Closes #2813. Adds a field now required by STIG Viewer