### PR TITLE
Fix issue where certain filetypes wouldn't be uploaded via fingerprinting

### DIFF
--- a/apps/frontend/src/components/global/ExportSplunkModal.vue
+++ b/apps/frontend/src/components/global/ExportSplunkModal.vue
@@ -80,7 +80,7 @@ import {FileID} from '@/store/report_intake';
 import {FromHDFToSplunkMapper, SplunkConfig} from '@mitre/hdf-converters';
 import Vue from 'vue';
 import Component from 'vue-class-component';
-import winston from 'winston';
+import {Logger} from 'winston';
 import {SnackbarModule} from '../../store/snackbar';
 import AuthStep from '../global/upload_tabs/splunk/AuthStep.vue';
 
@@ -139,7 +139,7 @@ export default class ExportSplunkModal extends Vue {
     FilteredDataModule.evaluations(ids).forEach(async (evaluation) => {
       this.statusLog += `Starting Upload of File: ${evaluation.from_file.filename}\n`;
       if (this.splunkConfig) {
-        new FromHDFToSplunkMapper(evaluation, this.logger as winston.Logger)
+        new FromHDFToSplunkMapper(evaluation, this.logger as Logger)
           .toSplunk(this.splunkConfig, evaluation.from_file.filename, true)
           .then(() => {
             this.statusLog += `Sucessfully uploaded file ${evaluation.from_file.filename}\n`;

--- a/apps/frontend/vue.config.js
+++ b/apps/frontend/vue.config.js
@@ -44,6 +44,20 @@ module.exports = {
   },
   outputDir: '../../dist/frontend',
   configureWebpack: {
+    module: {
+      rules: [
+        {
+          test: /\.m?js$/,
+          exclude: /(node_modules|bower_components)/,
+          use: {
+            loader: 'babel-loader',
+            options: {
+              presets: ['@babel/preset-env']
+            }
+          }
+        }
+      ]
+    },
     devtool: 'source-map',
     plugins: [
       new webpack.DefinePlugin({

--- a/libs/hdf-converters/src/converters-from-hdf/splunk/reverse-splunk-mapper.ts
+++ b/libs/hdf-converters/src/converters-from-hdf/splunk/reverse-splunk-mapper.ts
@@ -8,6 +8,7 @@ import {
   ExecJSON
 } from 'inspecjs';
 import _ from 'lodash';
+import {Logger} from 'winston'
 import {MappedTransform} from '../../base-converter';
 import {createWinstonLogger} from '../../utils/global';
 import {FromAnyBaseConverter} from '../reverse-any-base-converter';
@@ -292,7 +293,7 @@ export class FromHDFToSplunkMapper extends FromAnyBaseConverter {
 
   constructor(
     data: ExecJSON.Execution | ContextualizedEvaluation,
-    logService?: winston.Logger,
+    logService?: Logger,
     loggingLevel?: string
   ) {
     if (logService) {

--- a/libs/hdf-converters/src/converters-from-hdf/splunk/reverse-splunk-mapper.ts
+++ b/libs/hdf-converters/src/converters-from-hdf/splunk/reverse-splunk-mapper.ts
@@ -8,7 +8,6 @@ import {
   ExecJSON
 } from 'inspecjs';
 import _ from 'lodash';
-import winston from 'winston';
 import {MappedTransform} from '../../base-converter';
 import {createWinstonLogger} from '../../utils/global';
 import {FromAnyBaseConverter} from '../reverse-any-base-converter';
@@ -41,7 +40,7 @@ export type SplunkData = {
   reports: SplunkReport[];
 };
 
-let logger: winston.Logger = winston.createLogger();
+let logger = createWinstonLogger("HDF2Splunk", "INFO");
 
 export function createGUID(length: number) {
   let result = '';

--- a/libs/hdf-converters/src/converters-from-hdf/splunk/reverse-splunk-mapper.ts
+++ b/libs/hdf-converters/src/converters-from-hdf/splunk/reverse-splunk-mapper.ts
@@ -8,7 +8,7 @@ import {
   ExecJSON
 } from 'inspecjs';
 import _ from 'lodash';
-import {Logger} from 'winston'
+import {Logger} from 'winston';
 import {MappedTransform} from '../../base-converter';
 import {createWinstonLogger} from '../../utils/global';
 import {FromAnyBaseConverter} from '../reverse-any-base-converter';
@@ -41,7 +41,7 @@ export type SplunkData = {
   reports: SplunkReport[];
 };
 
-let logger = createWinstonLogger("HDF2Splunk", "INFO");
+let logger = createWinstonLogger('HDF2Splunk', 'INFO');
 
 export function createGUID(length: number) {
   let result = '';

--- a/libs/hdf-converters/src/splunk-mapper.ts
+++ b/libs/hdf-converters/src/splunk-mapper.ts
@@ -1,6 +1,7 @@
 import splunkjs, {Job} from '@mitre/splunk-sdk-no-env';
 import ProxyHTTP from '@mitre/splunk-sdk-no-env/lib/platform/client/jquery_http';
 import {ExecJSON} from 'inspecjs';
+import {Logger} from 'winston'
 import _ from 'lodash';
 import {SplunkConfig} from './converters-from-hdf/splunk/reverse-splunk-mapper';
 import {createWinstonLogger} from './utils/global';
@@ -203,7 +204,7 @@ export class SplunkMapper {
   constructor(
     config: SplunkConfig,
     webCompatibility = false,
-    logService?: winston.Logger,
+    logService?: Logger,
     loggingLevel?: string
   ) {
     this.config = config;

--- a/libs/hdf-converters/src/splunk-mapper.ts
+++ b/libs/hdf-converters/src/splunk-mapper.ts
@@ -2,7 +2,6 @@ import splunkjs, {Job} from '@mitre/splunk-sdk-no-env';
 import ProxyHTTP from '@mitre/splunk-sdk-no-env/lib/platform/client/jquery_http';
 import {ExecJSON} from 'inspecjs';
 import _ from 'lodash';
-import winston from 'winston';
 import {SplunkConfig} from './converters-from-hdf/splunk/reverse-splunk-mapper';
 import {createWinstonLogger} from './utils/global';
 
@@ -27,7 +26,7 @@ export type FileMetaData = {
 
 const MAPPER_NAME = 'Splunk2HDF';
 
-let logger: winston.Logger = winston.createLogger();
+let logger = createWinstonLogger("Splunk2HDF")
 
 // Groups items by using the provided key function
 export function group_by<T>(

--- a/libs/hdf-converters/src/splunk-mapper.ts
+++ b/libs/hdf-converters/src/splunk-mapper.ts
@@ -1,8 +1,8 @@
 import splunkjs, {Job} from '@mitre/splunk-sdk-no-env';
 import ProxyHTTP from '@mitre/splunk-sdk-no-env/lib/platform/client/jquery_http';
 import {ExecJSON} from 'inspecjs';
-import {Logger} from 'winston'
 import _ from 'lodash';
+import {Logger} from 'winston';
 import {SplunkConfig} from './converters-from-hdf/splunk/reverse-splunk-mapper';
 import {createWinstonLogger} from './utils/global';
 
@@ -27,7 +27,7 @@ export type FileMetaData = {
 
 const MAPPER_NAME = 'Splunk2HDF';
 
-let logger = createWinstonLogger("Splunk2HDF")
+let logger = createWinstonLogger('Splunk2HDF');
 
 // Groups items by using the provided key function
 export function group_by<T>(

--- a/libs/hdf-converters/src/utils/global.ts
+++ b/libs/hdf-converters/src/utils/global.ts
@@ -1,6 +1,6 @@
 import {ExecJSON} from 'inspecjs';
 import _ from 'lodash';
-import {createLogger, transports, format} from 'winston';
+import {createLogger, format, transports} from 'winston';
 
 // DEFAULT_NIST_TAG is applicable to all automated configuration tests.
 // SA-11 (DEVELOPER SECURITY TESTING AND EVALUATION) - RA-5 (VULNERABILITY SCANNING)
@@ -9,10 +9,7 @@ export const DEFAULT_STATIC_CODE_ANALYSIS_NIST_TAGS = ['SA-11', 'RA-5'];
 // The "Types" field of ASFF only supports a maximum of 2 slashes, and will get replaced with this text. Note that the default AWS CLI doesn't support UTF-8 encoding
 export const FROM_ASFF_TYPES_SLASH_REPLACEMENT = /{{{SLASH}}}/gi;
 
-export function createWinstonLogger(
-  mapperName: string,
-  level = 'debug'
-) {
+export function createWinstonLogger(mapperName: string, level = 'debug') {
   return createLogger({
     transports: [new transports.Console()],
     level: level,

--- a/libs/hdf-converters/src/utils/global.ts
+++ b/libs/hdf-converters/src/utils/global.ts
@@ -1,6 +1,6 @@
 import {ExecJSON} from 'inspecjs';
 import _ from 'lodash';
-import winston from 'winston';
+import {createLogger, transports, format} from 'winston';
 
 // DEFAULT_NIST_TAG is applicable to all automated configuration tests.
 // SA-11 (DEVELOPER SECURITY TESTING AND EVALUATION) - RA-5 (VULNERABILITY SCANNING)
@@ -12,15 +12,15 @@ export const FROM_ASFF_TYPES_SLASH_REPLACEMENT = /{{{SLASH}}}/gi;
 export function createWinstonLogger(
   mapperName: string,
   level = 'debug'
-): winston.Logger {
-  return winston.createLogger({
-    transports: [new winston.transports.Console()],
+) {
+  return createLogger({
+    transports: [new transports.Console()],
     level: level,
-    format: winston.format.combine(
-      winston.format.timestamp({
+    format: format.combine(
+      format.timestamp({
         format: 'MMM-DD-YYYY HH:mm:ss Z'
       }),
-      winston.format.printf(
+      format.printf(
         (info) => `[${[info.timestamp]}] ${mapperName} ${info.message}`
       )
     )

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "sourceMap": true,
-    "target": "ES2019",
+    "target": "ES6",
     "esModuleInterop": true,
     "noImplicitAny": true,
     "resolveJsonModule": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "sourceMap": true,
-    "target": "ES6",
+    "target": "ES2019",
     "esModuleInterop": true,
     "noImplicitAny": true,
     "resolveJsonModule": true


### PR DESCRIPTION
This fixes an issue where objects of a certain type were not being created properly

See [this](https://stackoverflow.com/questions/51860043/javascript-es6-typeerror-class-constructor-client-cannot-be-invoked-without-ne) link for information on a similar bug someone was having.

* Use `@babel/preset-env` in Vue Config
* Change Winston usage to import the functions/objects directly instead of using the default import