### PR TITLE
Veracodemapperfixes

### DIFF
--- a/libs/hdf-converters/sample_jsons/veracode_mapper/veracode-hdf.json
+++ b/libs/hdf-converters/sample_jsons/veracode_mapper/veracode-hdf.json
@@ -1715,17 +1715,240 @@
           ]
         },
         {
-          "id": "CVE-2012-5783",
-          "title": "CVE-2012-5783",
-          "desc": "Apache Commons HttpClient 3.x, as used in Amazon Flexible Payments Service &#x28;FPS&#x29; merchant Java SDK and other products, does not verify that the server hostname matches a domain name in the subject&#x27;s Common Name &#x28;CN&#x29; or subjectAltName field of the X.509 certificate, which allows man-in-the-middle attackers to spoof SSL servers via an arbitrary valid certificate.",
-          "impact": 0.5,
+          "id": "057e93d5-c7c8-4b3a-bf16-d7450929ced2",
+          "title": "tomcat-jni-9.0.36.jar",
+          "desc": "",
+          "impact": 0,
           "refs": [],
           "tags": {
-            "cwe": "CWE-20",
+            "sha1": "",
+            "library_id": "maven&#x3a;org.apache.tomcat&#x3a;tomcat-jni&#x3a;9.0.36&#x3a;",
+            "library": "tomcat-jni",
+            "vendor": "org.apache.tomcat",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;19 UTC",
             "nist": [
               "SI-2",
               "RA-5"
-            ]
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;tomcat-embed-core-9.0.36.jar&#x3a;tomcat-jni-9.0.36.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "0a7e5504-34d8-49a9-9910-10fc8e8ff384",
+          "title": "jakarta.el-api-3.0.3.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "",
+            "library_id": "maven&#x3a;jakarta.el&#x3a;jakarta.el-api&#x3a;3.0.3&#x3a;",
+            "library": "Jakarta Expression Language API",
+            "vendor": "jakarta.el",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": [
+                {
+                  "name": "Eclipse Public License 2.0",
+                  "spdx_id": "EPL-2.0",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;EPL-2.0.html",
+                  "risk_rating": "3",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                },
+                {
+                  "name": "GNU General Public License with Classpath Exceptions version 2.0",
+                  "spdx_id": "GPL-2.0-with-classpath-exception",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;GPL-2.0-with-classpath-exception.html",
+                  "risk_rating": "4",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                }
+              ]
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;jakarta.el-3.0.3.jar&#x3a;jakarta.el-api-3.0.3.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "0d64a1dd-b9ae-4b6e-9b41-f811c7885b91",
+          "title": "spring-boot-starter-json-2.3.1.RELEASE.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "8342003919c7e5a2470072595ea190cb8a9552c0",
+            "library_id": "maven&#x3a;org.springframework.boot&#x3a;spring-boot-starter-json&#x3a;2.3.1.RELEASE&#x3a;",
+            "library": "spring-boot-starter-json",
+            "vendor": "org.springframework.boot",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;spring-boot-starter-json-2.3.1.RELEASE.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "10838146-6cb6-421a-9cad-8c6a1643157e",
+          "title": "slf4j-log4j12-1.7.7.jar",
+          "desc": "SLF4J LOG4J-12 Binding",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "58f588119ffd1702c77ccab6acb54bfb41bed8bd",
+            "library_id": "maven&#x3a;org.slf4j&#x3a;slf4j-log4j12&#x3a;1.7.7&#x3a;",
+            "library": "SLF4J LOG4J-12 Binding",
+            "vendor": "org.slf4j",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;19 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "MIT License",
+                "spdx_id": "MIT",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;MIT.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;slf4j-log4j12-1.7.7.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "11a5a4d1-f78b-4e66-8a3c-24177ee8c7a4",
+          "title": "org.apache.servicemix.bundles.javax-el-impl-3.0.3_1.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "",
+            "library_id": "maven&#x3a;org.apache.servicemix.bundles&#x3a;org.apache.servicemix.bundles.javax-el-impl&#x3a;3.0.3_1&#x3a;",
+            "library": "org.apache.servicemix.bundles.javax-el-impl",
+            "vendor": "org.apache.servicemix.bundles",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;jakarta.el-3.0.3.jar&#x3a;org.apache.servicemix.bundles.javax-el-impl-3.0.3_1.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "16f00554-a92c-4a63-b8a2-e71b572a529e",
+          "title": "maven-repository-metadata-2.0.jar",
+          "desc": "Maven Plugin Mapping",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "3f162989e8077f37911ec7d025f3480e65c2c5be",
+            "library_id": "maven&#x3a;org.apache.maven&#x3a;maven-repository-metadata&#x3a;2.0&#x3a;",
+            "library": "Maven Repository Metadata Model",
+            "vendor": "org.apache.maven",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;maven-repository-metadata-2.0.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "1793362a-098a-47f2-95e8-0565117aa7fd",
+          "title": "commons-httpclient-3.1.jar",
+          "desc": "The HttpClient  component supports the client-side of RFC 1945 &#x28;HTTP&#x2f;1.0&#x29;  and RFC 2616 &#x28;HTTP&#x2f;1.1&#x29; , several related specifications &#x28;RFC 2109 &#x28;Cookies&#x29; , RFC 2617 &#x28;HTTP Authentication&#x29; , etc.&#x29;, and provides a framework by which new request types &#x28;methods&#x29; or HTTP extensions can be created easily.",
+          "impact": 0.58,
+          "refs": [],
+          "tags": {
+            "sha1": "964cd74171f427720480efdec40a7c7f6e58426a",
+            "library_id": "maven&#x3a;commons-httpclient&#x3a;commons-httpclient&#x3a;3.1&#x3a;",
+            "library": "HttpClient",
+            "vendor": "commons-httpclient",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
           },
           "source_location": {
             "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;commons-httpclient-3.1.jar"
@@ -1733,172 +1956,202 @@
           "results": [
             {
               "status": "failed",
-              "code_desc": "component_id: 1793362a-098a-47f2-95e8-0565117aa7fd;sha1: 964cd74171f427720480efdec40a7c7f6e58426a\nmax_cvss_score: 5.8\nversion: 3.1\nlibrary: HttpClient\nvendor: commons-httpclient\ndescription: The HttpClient  component supports the client-side of RFC 1945 &#x28;HTTP&#x2f;1.0&#x29;  and RFC 2616 &#x28;HTTP&#x2f;1.1&#x29; , several related specifications &#x28;RFC 2109 &#x28;Cookies&#x29; , RFC 2617 &#x28;HTTP Authentication&#x29; , etc.&#x29;, and provides a framework by which new request types &#x28;methods&#x29; or HTTP extensions can be created easily.\nadded_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;commons-httpclient-3.1.jar",
-              "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
-            }
-          ]
-        },
-        {
-          "id": "CVE-2012-6153",
-          "title": "CVE-2012-6153",
-          "desc": "http&#x2f;conn&#x2f;ssl&#x2f;AbstractVerifier.java in Apache Commons HttpClient before 4.2.3 does not properly verify that the server hostname matches a domain name in the subject&#x27;s Common Name &#x28;CN&#x29; or subjectAltName field of the X.509 certificate, which allows man-in-the-middle attackers to spoof SSL servers via a certificate with a subject that specifies a common name in a field that is not the CN field.  NOTE&#x3a; this issue exists because of an incomplete fix for CVE-2012-5783.",
-          "impact": 0.5,
-          "refs": [],
-          "tags": {
-            "cwe": "CWE-20",
-            "nist": [
-              "SI-2",
-              "RA-5"
-            ]
-          },
-          "source_location": {
-            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;commons-httpclient-3.1.jar"
-          },
-          "results": [
-            {
-              "status": "failed",
-              "code_desc": "component_id: 1793362a-098a-47f2-95e8-0565117aa7fd;sha1: 964cd74171f427720480efdec40a7c7f6e58426a\nmax_cvss_score: 5.8\nversion: 3.1\nlibrary: HttpClient\nvendor: commons-httpclient\ndescription: The HttpClient  component supports the client-side of RFC 1945 &#x28;HTTP&#x2f;1.0&#x29;  and RFC 2616 &#x28;HTTP&#x2f;1.1&#x29; , several related specifications &#x28;RFC 2109 &#x28;Cookies&#x29; , RFC 2617 &#x28;HTTP Authentication&#x29; , etc.&#x29;, and provides a framework by which new request types &#x28;methods&#x29; or HTTP extensions can be created easily.\nadded_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;commons-httpclient-3.1.jar",
-              "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
-            }
-          ]
-        },
-        {
-          "id": "CVE-2014-3577",
-          "title": "CVE-2014-3577",
-          "desc": "org.apache.http.conn.ssl.AbstractVerifier in Apache HttpComponents HttpClient before 4.3.5 and HttpAsyncClient before 4.0.2 does not properly verify that the server hostname matches a domain name in the subject&#x27;s Common Name &#x28;CN&#x29; or subjectAltName field of the X.509 certificate, which allows man-in-the-middle attackers to spoof SSL servers via a &#x22;CN&#x3d;&#x22; string in a field in the distinguished name &#x28;DN&#x29; of a certificate, as demonstrated by the &#x22;foo,CN&#x3d;www.apache.org&#x22; string in the O field.",
-          "impact": 0.5,
-          "refs": [],
-          "tags": {
-            "cwe": "",
-            "nist": [
-              "SI-2",
-              "RA-5"
-            ]
-          },
-          "source_location": {
-            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;commons-httpclient-3.1.jar"
-          },
-          "results": [
-            {
-              "status": "failed",
-              "code_desc": "component_id: 1793362a-098a-47f2-95e8-0565117aa7fd;sha1: 964cd74171f427720480efdec40a7c7f6e58426a\nmax_cvss_score: 5.8\nversion: 3.1\nlibrary: HttpClient\nvendor: commons-httpclient\ndescription: The HttpClient  component supports the client-side of RFC 1945 &#x28;HTTP&#x2f;1.0&#x29;  and RFC 2616 &#x28;HTTP&#x2f;1.1&#x29; , several related specifications &#x28;RFC 2109 &#x28;Cookies&#x29; , RFC 2617 &#x28;HTTP Authentication&#x29; , etc.&#x29;, and provides a framework by which new request types &#x28;methods&#x29; or HTTP extensions can be created easily.\nadded_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;commons-httpclient-3.1.jar",
-              "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
-            }
-          ]
-        },
-        {
-          "id": "CVE-2015-5262",
-          "title": "CVE-2015-5262",
-          "desc": "http&#x2f;conn&#x2f;ssl&#x2f;SSLConnectionSocketFactory.java in Apache HttpComponents HttpClient before 4.3.6 ignores the http.socket.timeout configuration setting during an SSL handshake, which allows remote attackers to cause a denial of service &#x28;HTTPS call hang&#x29; via unspecified vectors.",
-          "impact": 0.5,
-          "refs": [],
-          "tags": {
-            "cwe": "CWE-399",
-            "nist": [
-              "SI-2",
-              "RA-5"
-            ]
-          },
-          "source_location": {
-            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;commons-httpclient-3.1.jar"
-          },
-          "results": [
-            {
-              "status": "failed",
-              "code_desc": "component_id: 1793362a-098a-47f2-95e8-0565117aa7fd;sha1: 964cd74171f427720480efdec40a7c7f6e58426a\nmax_cvss_score: 5.8\nversion: 3.1\nlibrary: HttpClient\nvendor: commons-httpclient\ndescription: The HttpClient  component supports the client-side of RFC 1945 &#x28;HTTP&#x2f;1.0&#x29;  and RFC 2616 &#x28;HTTP&#x2f;1.1&#x29; , several related specifications &#x28;RFC 2109 &#x28;Cookies&#x29; , RFC 2617 &#x28;HTTP Authentication&#x29; , etc.&#x29;, and provides a framework by which new request types &#x28;methods&#x29; or HTTP extensions can be created easily.\nadded_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;commons-httpclient-3.1.jar",
-              "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
-            }
-          ]
-        },
-        {
-          "id": "CVE-2019-2692",
-          "title": "CVE-2019-2692",
-          "desc": "Vulnerability in the MySQL Connectors component of Oracle MySQL &#x28;subcomponent&#x3a; Connector&#x2f;J&#x29;. Supported versions that are affected are 8.0.15 and prior. Difficult to exploit vulnerability allows high privileged attacker with logon to the infrastructure where MySQL Connectors executes to compromise MySQL Connectors. Successful attacks require human interaction from a person other than the attacker. Successful attacks of this vulnerability can result in takeover of MySQL Connectors. CVSS 3.0 Base Score 6.3 &#x28;Confidentiality, Integrity and Availability impacts&#x29;. CVSS Vector&#x3a; &#x28;CVSS&#x3a;3.0&#x2f;AV&#x3a;L&#x2f;AC&#x3a;H&#x2f;PR&#x3a;H&#x2f;UI&#x3a;R&#x2f;S&#x3a;U&#x2f;C&#x3a;H&#x2f;I&#x3a;H&#x2f;A&#x3a;H&#x29;.",
-          "impact": 0.3,
-          "refs": [],
-          "tags": {
-            "cwe": "CWE-20",
-            "nist": [
-              "SI-2",
-              "RA-5"
-            ]
-          },
-          "source_location": {
-            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;mysql-connector-java-5.1.48.jar"
-          },
-          "results": [
-            {
-              "status": "failed",
-              "code_desc": "component_id: 28614053-0ad6-4c0f-817e-6b4c89777501;sha1: 9140be77aafa5050bf4bb936d560cbacb5a6b5c1\nmax_cvss_score: 3.5\nversion: 5.1.48\nlibrary: MySQL Connector&#x2f;J\nvendor: mysql\ndescription: \nadded_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;mysql-connector-java-5.1.48.jar",
-              "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
-            }
-          ]
-        },
-        {
-          "id": "CVE-2020-2933",
-          "title": "CVE-2020-2933",
-          "desc": "mysql-connector-java is vulnerable to denial of service. When working with a load balancing setup, if the connection property &#x60;loadBalanceStrategy&#x60; was set to &#x60;bestResponseTime&#x60; and connections to all the hosts in the original setup failed, a denial of service condition will occur in Connector&#x2f;J, even if newly-added hosts are available.",
-          "impact": 0.3,
-          "refs": [],
-          "tags": {
-            "cwe": "",
-            "nist": [
-              "SI-2",
-              "RA-5"
-            ]
-          },
-          "source_location": {
-            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;mysql-connector-java-5.1.48.jar"
-          },
-          "results": [
-            {
-              "status": "failed",
-              "code_desc": "component_id: 28614053-0ad6-4c0f-817e-6b4c89777501;sha1: 9140be77aafa5050bf4bb936d560cbacb5a6b5c1\nmax_cvss_score: 3.5\nversion: 5.1.48\nlibrary: MySQL Connector&#x2f;J\nvendor: mysql\ndescription: \nadded_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;mysql-connector-java-5.1.48.jar",
-              "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
-            }
-          ]
-        },
-        {
-          "id": "CVE-2020-13935",
-          "title": "CVE-2020-13935",
-          "desc": "apache tomcat is vulnerable to denial of service. An infinite loop to occurs when invalid payload lengths are parsed. An attacker is able to cause a denial of service condition in the application via malicious WebSocket frames with invalid payload lengths.",
-          "impact": 0.5,
-          "refs": [],
-          "tags": {
-            "cwe": "",
-            "nist": [
-              "SI-2",
-              "RA-5"
-            ]
-          },
-          "source_location": {
-            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;tomcat-embed-websocket-9.0.36.jar\nverademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;tomcat-embed-websocket-9.0.36.jar&#x3a;tomcat-websocket-9.0.36.jar"
-          },
-          "results": [
-            {
-              "status": "failed",
-              "code_desc": "component_id: 31117674-2020-41e0-be67-1385f0a4257d;sha1: 33fa5038aa66be6e9cc188000c2188aa4dd33c85\nmax_cvss_score: 5.0\nversion: 9.0.36\nlibrary: tomcat-embed-websocket\nvendor: org.apache.tomcat.embed\ndescription: \nadded_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;tomcat-embed-websocket-9.0.36.jar",
+              "code_desc": "cve_id: CVE-2012-5783\ncvss_score: 5.8\nseverity: 3\ncwe_id: CWE-20\nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncve_summary: Apache Commons HttpClient 3.x, as used in Amazon Flexible Payments Service &#x28;FPS&#x29; merchant Java SDK and other products, does not verify that the server hostname matches a domain name in the subject&#x27;s Common Name &#x28;CN&#x29; or subjectAltName field of the X.509 certificate, which allows man-in-the-middle attackers to spoof SSL servers via an arbitrary valid certificate.\nseverity_desc: Medium\nmitigation: false\nvulnerability_affects_policy_compliance: false",
               "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
             },
             {
               "status": "failed",
-              "code_desc": "component_id: d6ad47d1-6990-4a6d-b248-aa8cb1a968c1;sha1: \nmax_cvss_score: 5.0\nversion: 9.0.36\nlibrary: tomcat-websocket\nvendor: org.apache.tomcat\ndescription: \nadded_date: 2021-12-29 22&#x3a;18&#x3a;19 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;tomcat-embed-websocket-9.0.36.jar&#x3a;tomcat-websocket-9.0.36.jar",
+              "code_desc": "cve_id: CVE-2012-6153\ncvss_score: 4.3\nseverity: 3\ncwe_id: CWE-20\nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncve_summary: http&#x2f;conn&#x2f;ssl&#x2f;AbstractVerifier.java in Apache Commons HttpClient before 4.2.3 does not properly verify that the server hostname matches a domain name in the subject&#x27;s Common Name &#x28;CN&#x29; or subjectAltName field of the X.509 certificate, which allows man-in-the-middle attackers to spoof SSL servers via a certificate with a subject that specifies a common name in a field that is not the CN field.  NOTE&#x3a; this issue exists because of an incomplete fix for CVE-2012-5783.\nseverity_desc: Medium\nmitigation: false\nvulnerability_affects_policy_compliance: false",
+              "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
+            },
+            {
+              "status": "failed",
+              "code_desc": "cve_id: CVE-2014-3577\ncvss_score: 5.8\nseverity: 3\ncwe_id: \nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncve_summary: org.apache.http.conn.ssl.AbstractVerifier in Apache HttpComponents HttpClient before 4.3.5 and HttpAsyncClient before 4.0.2 does not properly verify that the server hostname matches a domain name in the subject&#x27;s Common Name &#x28;CN&#x29; or subjectAltName field of the X.509 certificate, which allows man-in-the-middle attackers to spoof SSL servers via a &#x22;CN&#x3d;&#x22; string in a field in the distinguished name &#x28;DN&#x29; of a certificate, as demonstrated by the &#x22;foo,CN&#x3d;www.apache.org&#x22; string in the O field.\nseverity_desc: Medium\nmitigation: false\nvulnerability_affects_policy_compliance: false",
+              "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
+            },
+            {
+              "status": "failed",
+              "code_desc": "cve_id: CVE-2015-5262\ncvss_score: 4.3\nseverity: 3\ncwe_id: CWE-399\nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncve_summary: http&#x2f;conn&#x2f;ssl&#x2f;SSLConnectionSocketFactory.java in Apache HttpComponents HttpClient before 4.3.6 ignores the http.socket.timeout configuration setting during an SSL handshake, which allows remote attackers to cause a denial of service &#x28;HTTPS call hang&#x29; via unspecified vectors.\nseverity_desc: Medium\nmitigation: false\nvulnerability_affects_policy_compliance: false",
               "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
             }
           ]
         },
         {
-          "id": "CVE-2013-2172",
-          "title": "CVE-2013-2172",
-          "desc": "jcp&#x2f;xml&#x2f;dsig&#x2f;internal&#x2f;dom&#x2f;DOMCanonicalizationMethod.java in Apache Santuario XML Security for Java 1.4.x before 1.4.8 and 1.5.x before 1.5.5 allows context-dependent attackers to spoof an XML Signature by using the CanonicalizationMethod parameter to specify an arbitrary weak &#x22;canonicalization algorithm to apply to the SignedInfo part of the Signature.&#x22;",
-          "impact": 0.5,
+          "id": "28614053-0ad6-4c0f-817e-6b4c89777501",
+          "title": "mysql-connector-java-5.1.48.jar",
+          "desc": "",
+          "impact": 0.35,
           "refs": [],
           "tags": {
-            "cwe": "CWE-310",
+            "sha1": "9140be77aafa5050bf4bb936d560cbacb5a6b5c1",
+            "library_id": "maven&#x3a;mysql&#x3a;mysql-connector-java&#x3a;5.1.48&#x3a;",
+            "library": "MySQL Connector&#x2f;J",
+            "vendor": "mysql",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
             "nist": [
               "SI-2",
               "RA-5"
-            ]
+            ],
+            "licenses": {
+              "license": {
+                "name": "GNU General Public License v2.0 only",
+                "spdx_id": "GPL-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;GPL-2.0.html",
+                "risk_rating": "4",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;mysql-connector-java-5.1.48.jar"
+          },
+          "results": [
+            {
+              "status": "failed",
+              "code_desc": "cve_id: CVE-2019-2692\ncvss_score: 3.5\nseverity: 2\ncwe_id: CWE-20\nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncve_summary: Vulnerability in the MySQL Connectors component of Oracle MySQL &#x28;subcomponent&#x3a; Connector&#x2f;J&#x29;. Supported versions that are affected are 8.0.15 and prior. Difficult to exploit vulnerability allows high privileged attacker with logon to the infrastructure where MySQL Connectors executes to compromise MySQL Connectors. Successful attacks require human interaction from a person other than the attacker. Successful attacks of this vulnerability can result in takeover of MySQL Connectors. CVSS 3.0 Base Score 6.3 &#x28;Confidentiality, Integrity and Availability impacts&#x29;. CVSS Vector&#x3a; &#x28;CVSS&#x3a;3.0&#x2f;AV&#x3a;L&#x2f;AC&#x3a;H&#x2f;PR&#x3a;H&#x2f;UI&#x3a;R&#x2f;S&#x3a;U&#x2f;C&#x3a;H&#x2f;I&#x3a;H&#x2f;A&#x3a;H&#x29;.\nseverity_desc: Low\nmitigation: false\nvulnerability_affects_policy_compliance: false",
+              "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
+            },
+            {
+              "status": "failed",
+              "code_desc": "cve_id: CVE-2020-2933\ncvss_score: 3.5\nseverity: 2\ncwe_id: \nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncve_summary: mysql-connector-java is vulnerable to denial of service. When working with a load balancing setup, if the connection property &#x60;loadBalanceStrategy&#x60; was set to &#x60;bestResponseTime&#x60; and connections to all the hosts in the original setup failed, a denial of service condition will occur in Connector&#x2f;J, even if newly-added hosts are available.\nseverity_desc: Low\nmitigation: false\nvulnerability_affects_policy_compliance: false",
+              "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
+            }
+          ]
+        },
+        {
+          "id": "2d1e78d8-89d7-46bb-9633-2fbea4d0e2c7",
+          "title": "tomcat-jasper-el-9.0.36.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "",
+            "library_id": "maven&#x3a;org.apache.tomcat&#x3a;tomcat-jasper-el&#x3a;9.0.36&#x3a;",
+            "library": "tomcat-jasper-el",
+            "vendor": "org.apache.tomcat",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;19 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;tomcat-embed-el-9.0.36.jar&#x3a;tomcat-jasper-el-9.0.36.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "2dddf946-16e7-406d-9b77-ce36e04cf1f2",
+          "title": "spring-boot-2.3.1.RELEASE.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "ce8d8b6838ecceb68962b975b18682f4237ccf71",
+            "library_id": "maven&#x3a;org.springframework.boot&#x3a;spring-boot&#x3a;2.3.1.RELEASE&#x3a;",
+            "library": "spring-boot",
+            "vendor": "org.springframework.boot",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;spring-boot-2.3.1.RELEASE.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "31117674-2020-41e0-be67-1385f0a4257d",
+          "title": "tomcat-embed-websocket-9.0.36.jar",
+          "desc": "",
+          "impact": 0.5,
+          "refs": [],
+          "tags": {
+            "sha1": "33fa5038aa66be6e9cc188000c2188aa4dd33c85",
+            "library_id": "maven&#x3a;org.apache.tomcat.embed&#x3a;tomcat-embed-websocket&#x3a;9.0.36&#x3a;",
+            "library": "tomcat-embed-websocket",
+            "vendor": "org.apache.tomcat.embed",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;tomcat-embed-websocket-9.0.36.jar"
+          },
+          "results": [
+            {
+              "status": "failed",
+              "code_desc": "cve_id: CVE-2020-13935\ncvss_score: 5.0\nseverity: 3\ncwe_id: \nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncve_summary: apache tomcat is vulnerable to denial of service. An infinite loop to occurs when invalid payload lengths are parsed. An attacker is able to cause a denial of service condition in the application via malicious WebSocket frames with invalid payload lengths.\nseverity_desc: Medium\nmitigation: false\nvulnerability_affects_policy_compliance: false",
+              "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
+            }
+          ]
+        },
+        {
+          "id": "36fa0a91-39cf-4663-96e1-a413324a37df",
+          "title": "xmlsec-1.5.1.jar",
+          "desc": "Apache XML Security for Java supports XML-Signature Syntax and Processing,&#xa;        W3C Recommendation 12 February 2002, and XML Encryption Syntax and&#xa;        Processing, W3C Recommendation 10 December 2002. As of version 1.4,&#xa;        the library supports the standard Java API JSR-105&#x3a; XML Digital Signature APIs.",
+          "impact": 0.5,
+          "refs": [],
+          "tags": {
+            "sha1": "bbf5d96a49a2b58b8988202a3c8728461639090e",
+            "library_id": "maven&#x3a;org.apache.santuario&#x3a;xmlsec&#x3a;1.5.1&#x3a;",
+            "library": "Apache XML Security for Java",
+            "vendor": "org.apache.santuario",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;19 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
           },
           "source_location": {
             "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;xmlsec-1.5.1.jar"
@@ -1906,71 +2159,81 @@
           "results": [
             {
               "status": "failed",
-              "code_desc": "component_id: 36fa0a91-39cf-4663-96e1-a413324a37df;sha1: bbf5d96a49a2b58b8988202a3c8728461639090e\nmax_cvss_score: 5.0\nversion: 1.5.1\nlibrary: Apache XML Security for Java\nvendor: org.apache.santuario\ndescription: Apache XML Security for Java supports XML-Signature Syntax and Processing,&#xa;        W3C Recommendation 12 February 2002, and XML Encryption Syntax and&#xa;        Processing, W3C Recommendation 10 December 2002. As of version 1.4,&#xa;        the library supports the standard Java API JSR-105&#x3a; XML Digital Signature APIs.\nadded_date: 2021-12-29 22&#x3a;18&#x3a;19 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;xmlsec-1.5.1.jar",
+              "code_desc": "cve_id: CVE-2013-2172\ncvss_score: 4.3\nseverity: 3\ncwe_id: CWE-310\nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;19 UTC\ncve_summary: jcp&#x2f;xml&#x2f;dsig&#x2f;internal&#x2f;dom&#x2f;DOMCanonicalizationMethod.java in Apache Santuario XML Security for Java 1.4.x before 1.4.8 and 1.5.x before 1.5.5 allows context-dependent attackers to spoof an XML Signature by using the CanonicalizationMethod parameter to specify an arbitrary weak &#x22;canonicalization algorithm to apply to the SignedInfo part of the Signature.&#x22;\nseverity_desc: Medium\nmitigation: false\nvulnerability_affects_policy_compliance: false",
               "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
-            }
-          ]
-        },
-        {
-          "id": "CVE-2013-4517",
-          "title": "CVE-2013-4517",
-          "desc": "Apache Santuario XML Security for Java before 1.5.6, when applying Transforms, allows remote attackers to cause a denial of service &#x28;memory consumption&#x29; via crafted Document Type Definitions &#x28;DTDs&#x29;, related to signatures.",
-          "impact": 0.5,
-          "refs": [],
-          "tags": {
-            "cwe": "CWE-399",
-            "nist": [
-              "SI-2",
-              "RA-5"
-            ]
-          },
-          "source_location": {
-            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;xmlsec-1.5.1.jar"
-          },
-          "results": [
+            },
             {
               "status": "failed",
-              "code_desc": "component_id: 36fa0a91-39cf-4663-96e1-a413324a37df;sha1: bbf5d96a49a2b58b8988202a3c8728461639090e\nmax_cvss_score: 5.0\nversion: 1.5.1\nlibrary: Apache XML Security for Java\nvendor: org.apache.santuario\ndescription: Apache XML Security for Java supports XML-Signature Syntax and Processing,&#xa;        W3C Recommendation 12 February 2002, and XML Encryption Syntax and&#xa;        Processing, W3C Recommendation 10 December 2002. As of version 1.4,&#xa;        the library supports the standard Java API JSR-105&#x3a; XML Digital Signature APIs.\nadded_date: 2021-12-29 22&#x3a;18&#x3a;19 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;xmlsec-1.5.1.jar",
+              "code_desc": "cve_id: CVE-2013-4517\ncvss_score: 4.3\nseverity: 3\ncwe_id: CWE-399\nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;19 UTC\ncve_summary: Apache Santuario XML Security for Java before 1.5.6, when applying Transforms, allows remote attackers to cause a denial of service &#x28;memory consumption&#x29; via crafted Document Type Definitions &#x28;DTDs&#x29;, related to signatures.\nseverity_desc: Medium\nmitigation: false\nvulnerability_affects_policy_compliance: false",
               "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
-            }
-          ]
-        },
-        {
-          "id": "CVE-2021-40690",
-          "title": "CVE-2021-40690",
-          "desc": "Apache Santuario is vulnerable to bypass of secure validation. Lack of secure handling of &#x60;secureValidation&#x60; property allows an attacker to abuse an XPath Transform and to extract any local .xml files in a RetrievalMethod element during the creation of a KeyInfo from a KeyInfoReference element.&#xa;",
-          "impact": 0.5,
-          "refs": [],
-          "tags": {
-            "cwe": "",
-            "nist": [
-              "SI-2",
-              "RA-5"
-            ]
-          },
-          "source_location": {
-            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;xmlsec-1.5.1.jar"
-          },
-          "results": [
+            },
             {
               "status": "failed",
-              "code_desc": "component_id: 36fa0a91-39cf-4663-96e1-a413324a37df;sha1: bbf5d96a49a2b58b8988202a3c8728461639090e\nmax_cvss_score: 5.0\nversion: 1.5.1\nlibrary: Apache XML Security for Java\nvendor: org.apache.santuario\ndescription: Apache XML Security for Java supports XML-Signature Syntax and Processing,&#xa;        W3C Recommendation 12 February 2002, and XML Encryption Syntax and&#xa;        Processing, W3C Recommendation 10 December 2002. As of version 1.4,&#xa;        the library supports the standard Java API JSR-105&#x3a; XML Digital Signature APIs.\nadded_date: 2021-12-29 22&#x3a;18&#x3a;19 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;xmlsec-1.5.1.jar",
+              "code_desc": "cve_id: CVE-2021-40690\ncvss_score: 5.0\nseverity: 3\ncwe_id: \nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;19 UTC\ncve_summary: Apache Santuario is vulnerable to bypass of secure validation. Lack of secure handling of &#x60;secureValidation&#x60; property allows an attacker to abuse an XPath Transform and to extract any local .xml files in a RetrievalMethod element during the creation of a KeyInfo from a KeyInfoReference element.&#xa;\nseverity_desc: Medium\nmitigation: false\nvulnerability_affects_policy_compliance: false",
               "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
             }
           ]
         },
         {
-          "id": "CVE-2021-22096",
-          "title": "CVE-2021-22096",
-          "desc": "Spring Framework is vulnerable to privilege escalation. The vulnerability exists due to lack of secure validations of user input which allows a malicious user to inject additional log files.",
-          "impact": 0.3,
+          "id": "372535e6-627f-4e28-8779-8737df8c8e4a",
+          "title": "maven-artifact-manager-2.0.jar",
+          "desc": "",
+          "impact": 0,
           "refs": [],
           "tags": {
-            "cwe": "",
+            "sha1": "8672c4278c184dbd4b18fed7e72688fd6018e112",
+            "library_id": "maven&#x3a;org.apache.maven&#x3a;maven-artifact-manager&#x3a;2.0&#x3a;",
+            "library": "Maven Artifact Manager",
+            "vendor": "org.apache.maven",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
             "nist": [
               "SI-2",
               "RA-5"
-            ]
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;maven-artifact-manager-2.0.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "38678b7f-6718-4b4f-adb6-390ca146c1dc",
+          "title": "spring-core-5.2.7.RELEASE.jar",
+          "desc": "",
+          "impact": 0.4,
+          "refs": [],
+          "tags": {
+            "sha1": "56e14a3a5e2813534b5db2da1502cd58ab5bc61d",
+            "library_id": "maven&#x3a;org.springframework&#x3a;spring-core&#x3a;5.2.7.RELEASE&#x3a;",
+            "library": "Spring Core",
+            "vendor": "org.springframework",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
           },
           "source_location": {
             "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;spring-core-5.2.7.RELEASE.jar"
@@ -1978,52 +2241,202 @@
           "results": [
             {
               "status": "failed",
-              "code_desc": "component_id: 38678b7f-6718-4b4f-adb6-390ca146c1dc;sha1: 56e14a3a5e2813534b5db2da1502cd58ab5bc61d\nmax_cvss_score: 4.0\nversion: 5.2.7.RELEASE\nlibrary: Spring Core\nvendor: org.springframework\ndescription: \nadded_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;spring-core-5.2.7.RELEASE.jar",
+              "code_desc": "cve_id: CVE-2021-22096\ncvss_score: 4.0\nseverity: 2\ncwe_id: \nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncve_summary: Spring Framework is vulnerable to privilege escalation. The vulnerability exists due to lack of secure validations of user input which allows a malicious user to inject additional log files.\nseverity_desc: Low\nmitigation: false\nvulnerability_affects_policy_compliance: false",
               "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
             }
           ]
         },
         {
-          "id": "CVE-2021-42550",
-          "title": "CVE-2021-42550",
-          "desc": "logback is vulnerable to remote code execution. The vulnerability exists due to a lack of sanitization of write access allowing an attacker to craft a malicious configuration.&#xa;",
-          "impact": 0.9,
+          "id": "3c4a1c6a-aa0d-4a98-9125-a2ec75b88f58",
+          "title": "tomcat-jaspic-api-9.0.2.jar",
+          "desc": "javax.security.auth.message package",
+          "impact": 0,
           "refs": [],
           "tags": {
-            "cwe": "",
+            "sha1": "",
+            "library_id": "maven&#x3a;org.apache.tomcat&#x3a;tomcat-jaspic-api&#x3a;9.0.2&#x3a;",
+            "library": "tomcat-jaspic-api",
+            "vendor": "org.apache.tomcat",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;19 UTC",
             "nist": [
               "SI-2",
               "RA-5"
-            ]
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
           },
           "source_location": {
-            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;logback-classic-1.2.3.jar\nverademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;logback-core-1.2.3.jar"
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;tomcat-embed-core-9.0.36.jar&#x3a;tomcat-jaspic-api-9.0.2.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "3e54457b-9cff-40ca-a06b-0ffcd76136b3",
+          "title": "hamcrest-core-2.2.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "3f2bd07716a31c395e2837254f37f21f0f0ab24b",
+            "library_id": "maven&#x3a;org.hamcrest&#x3a;hamcrest-core&#x3a;2.2&#x3a;",
+            "library": "Hamcrest Core",
+            "vendor": "org.hamcrest",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "BSD 3-Clause &#x22;New&#x22; or &#x22;Revised&#x22; License",
+                "spdx_id": "BSD-3-Clause",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;BSD-3-Clause.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;hamcrest-core-2.2.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "47004b3b-df69-4a60-a235-ac4a0e62d206",
+          "title": "logback-classic-1.2.3.jar",
+          "desc": "logback-classic module",
+          "impact": 0.85,
+          "refs": [],
+          "tags": {
+            "sha1": "7c4f3c474fb2c041d8028740440937705ebb473a",
+            "library_id": "maven&#x3a;ch.qos.logback&#x3a;logback-classic&#x3a;1.2.3&#x3a;",
+            "library": "Logback Classic Module",
+            "vendor": "ch.qos.logback",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;19 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": [
+                {
+                  "name": "Eclipse Public License 1.0",
+                  "spdx_id": "EPL-1.0",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;EPL-1.0.html",
+                  "risk_rating": "3",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                },
+                {
+                  "name": "GNU Lesser General Public License v2.1 only",
+                  "spdx_id": "LGPL-2.1",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;LGPL-2.1.html",
+                  "risk_rating": "4",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                },
+                {
+                  "name": "GNU Lesser General Public License v2.1 only",
+                  "spdx_id": "LGPL-2.1-only",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;LGPL-2.1-only.html",
+                  "risk_rating": "4",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                },
+                {
+                  "name": "GNU Lesser General Public License v3.0 only",
+                  "spdx_id": "LGPL-3.0-only",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;LGPL-3.0-only.html",
+                  "risk_rating": "4",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                }
+              ]
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;logback-classic-1.2.3.jar"
           },
           "results": [
             {
               "status": "failed",
-              "code_desc": "component_id: 47004b3b-df69-4a60-a235-ac4a0e62d206;sha1: 7c4f3c474fb2c041d8028740440937705ebb473a\nmax_cvss_score: 8.5\nversion: 1.2.3\nlibrary: Logback Classic Module\nvendor: ch.qos.logback\ndescription: logback-classic module\nadded_date: 2021-12-29 22&#x3a;18&#x3a;19 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;logback-classic-1.2.3.jar",
-              "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
-            },
-            {
-              "status": "failed",
-              "code_desc": "component_id: 58dab3c5-b691-4006-9be3-91edbf87d27f;sha1: 864344400c3d4d92dfeb0a305dc87d953677c03c\nmax_cvss_score: 8.5\nversion: 1.2.3\nlibrary: Logback Core Module\nvendor: ch.qos.logback\ndescription: logback-core module\nadded_date: 2021-12-29 22&#x3a;18&#x3a;21 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;logback-core-1.2.3.jar",
+              "code_desc": "cve_id: CVE-2021-42550\ncvss_score: 8.5\nseverity: 5\ncwe_id: \nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;19 UTC\ncve_summary: logback is vulnerable to remote code execution. The vulnerability exists due to a lack of sanitization of write access allowing an attacker to craft a malicious configuration.&#xa;\nseverity_desc: Very High\nmitigation: false\nvulnerability_affects_policy_compliance: false",
               "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
             }
           ]
         },
         {
-          "id": "CVE-2020-15250",
-          "title": "CVE-2020-15250",
-          "desc": "junit is vulnerable to information disclosure. The vulnerability exists through the behaviour of &#x60;TemporaryFolder&#x60; on UNIX-like systems, where the system&#x27;s temporary directory is shared between all users on that system by default.",
-          "impact": 0.1,
+          "id": "4bc7d82b-07f5-4b02-bd8c-4a2d278645d4",
+          "title": "spring-beans-5.2.7.RELEASE.jar",
+          "desc": "",
+          "impact": 0,
           "refs": [],
           "tags": {
-            "cwe": "",
+            "sha1": "05465ab17688ed62254fdef411cf883fd5c3b77a",
+            "library_id": "maven&#x3a;org.springframework&#x3a;spring-beans&#x3a;5.2.7.RELEASE&#x3a;",
+            "library": "Spring Beans",
+            "vendor": "org.springframework",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
             "nist": [
               "SI-2",
               "RA-5"
-            ]
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;spring-beans-5.2.7.RELEASE.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "4ebeadf3-e305-4520-8e20-f7b2b15141c4",
+          "title": "junit-4.13.jar",
+          "desc": "",
+          "impact": 0.19,
+          "refs": [],
+          "tags": {
+            "sha1": "e49ccba652b735c93bd6e6f59760d8254cf597dd",
+            "library_id": "maven&#x3a;junit&#x3a;junit&#x3a;4.13&#x3a;",
+            "library": "JUnit",
+            "vendor": "junit",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;19 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Eclipse Public License 1.0",
+                "spdx_id": "EPL-1.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;EPL-1.0.html",
+                "risk_rating": "3",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
           },
           "source_location": {
             "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;junit-4.13.jar"
@@ -2031,23 +2444,1052 @@
           "results": [
             {
               "status": "failed",
-              "code_desc": "component_id: 4ebeadf3-e305-4520-8e20-f7b2b15141c4;sha1: e49ccba652b735c93bd6e6f59760d8254cf597dd\nmax_cvss_score: 1.9\nversion: 4.13\nlibrary: JUnit\nvendor: junit\ndescription: \nadded_date: 2021-12-29 22&#x3a;18&#x3a;19 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;junit-4.13.jar",
+              "code_desc": "cve_id: CVE-2020-15250\ncvss_score: 1.9\nseverity: 1\ncwe_id: \nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;19 UTC\ncve_summary: junit is vulnerable to information disclosure. The vulnerability exists through the behaviour of &#x60;TemporaryFolder&#x60; on UNIX-like systems, where the system&#x27;s temporary directory is shared between all users on that system by default.\nseverity_desc: Very Low\nmitigation: false\nvulnerability_affects_policy_compliance: false",
               "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
             }
           ]
         },
         {
-          "id": "CVE-2015-0254",
-          "title": "CVE-2015-0254",
-          "desc": "Apache Standard Taglibs before 1.2.3 allows remote attackers to execute arbitrary code or conduct external XML entity &#x28;XXE&#x29; attacks via a crafted XSLT extension in a &#x28;1&#x29; &#x3c;x&#x3a;parse&#x3e; or &#x28;2&#x29; &#x3c;x&#x3a;transform&#x3e; JSTL XML tag.",
-          "impact": 0.7,
+          "id": "50739ae5-8acf-4331-afac-66410b4a688b",
+          "title": "tomcat-servlet-api-9.0.35.jar",
+          "desc": "",
+          "impact": 0,
           "refs": [],
           "tags": {
-            "cwe": "",
+            "sha1": "",
+            "library_id": "maven&#x3a;org.apache.tomcat&#x3a;tomcat-servlet-api&#x3a;9.0.35&#x3a;",
+            "library": "tomcat-servlet-api",
+            "vendor": "org.apache.tomcat",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
             "nist": [
               "SI-2",
               "RA-5"
-            ]
+            ],
+            "licenses": {
+              "license": [
+                {
+                  "name": "Apache License 2.0",
+                  "spdx_id": "Apache-2.0",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                  "risk_rating": "2",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                },
+                {
+                  "name": "Common Development and Distribution License 1.0",
+                  "spdx_id": "CDDL-1.0",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;CDDL-1.0.html",
+                  "risk_rating": "3",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                }
+              ]
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;tomcat-embed-core-9.0.36.jar&#x3a;tomcat-servlet-api-9.0.35.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "522b27c1-fea7-4b03-bf79-25354ebe0270",
+          "title": "encoder-jsp-1.2.2.jar",
+          "desc": "The OWASP Encoder JSP package contains JSP tag definitions and TLDs to allow&#xa;        easy use of the OWASP Encoder Project&#x27;s core API. The TLDs contain both tag&#xa;        definitions and JSP EL functions.",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "3f124a0eb702c11389aa79018781cb43c8041f32",
+            "library_id": "maven&#x3a;org.owasp.encoder&#x3a;encoder-jsp&#x3a;1.2.2&#x3a;",
+            "library": "JSP Encoder",
+            "vendor": "org.owasp.encoder",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "BSD 3-Clause &#x22;New&#x22; or &#x22;Revised&#x22; License",
+                "spdx_id": "BSD-3-Clause",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;BSD-3-Clause.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;encoder-jsp-1.2.2.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "556904e5-40b0-49b9-be83-3822f3c1a11c",
+          "title": "tomcat-websocket-api-9.0.16.jar",
+          "desc": "WebSocket &#x28;JSR356&#x29; API",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "",
+            "library_id": "maven&#x3a;org.apache.tomcat&#x3a;tomcat-websocket-api&#x3a;9.0.16&#x3a;",
+            "library": "tomcat-websocket-api",
+            "vendor": "org.apache.tomcat",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;tomcat-embed-websocket-9.0.36.jar&#x3a;tomcat-websocket-api-9.0.16.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "58dab3c5-b691-4006-9be3-91edbf87d27f",
+          "title": "logback-core-1.2.3.jar",
+          "desc": "logback-core module",
+          "impact": 0.85,
+          "refs": [],
+          "tags": {
+            "sha1": "864344400c3d4d92dfeb0a305dc87d953677c03c",
+            "library_id": "maven&#x3a;ch.qos.logback&#x3a;logback-core&#x3a;1.2.3&#x3a;",
+            "library": "Logback Core Module",
+            "vendor": "ch.qos.logback",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;21 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": [
+                {
+                  "name": "Eclipse Public License 1.0",
+                  "spdx_id": "EPL-1.0",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;EPL-1.0.html",
+                  "risk_rating": "3",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                },
+                {
+                  "name": "GNU Lesser General Public License v2.1 only",
+                  "spdx_id": "LGPL-2.1",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;LGPL-2.1.html",
+                  "risk_rating": "4",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                },
+                {
+                  "name": "GNU Lesser General Public License v2.1 only",
+                  "spdx_id": "LGPL-2.1-only",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;LGPL-2.1-only.html",
+                  "risk_rating": "4",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                },
+                {
+                  "name": "GNU Lesser General Public License v3.0 only",
+                  "spdx_id": "LGPL-3.0-only",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;LGPL-3.0-only.html",
+                  "risk_rating": "4",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                }
+              ]
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;logback-core-1.2.3.jar"
+          },
+          "results": [
+            {
+              "status": "failed",
+              "code_desc": "cve_id: CVE-2021-42550\ncvss_score: 8.5\nseverity: 5\ncwe_id: \nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;21 UTC\ncve_summary: logback is vulnerable to remote code execution. The vulnerability exists due to a lack of sanitization of write access allowing an attacker to craft a malicious configuration.&#xa;\nseverity_desc: Very High\nmitigation: false\nvulnerability_affects_policy_compliance: false",
+              "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
+            }
+          ]
+        },
+        {
+          "id": "592cbbec-e7d4-4881-bc8b-3fa364cb1dce",
+          "title": "org.apache.sling.commons.osgi-2.0.2-incubator.jar",
+          "desc": "Commons OSGi",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "7b13d706ac8019b269408831210707df64f93798",
+            "library_id": "maven&#x3a;org.apache.sling&#x3a;org.apache.sling.commons.osgi&#x3a;2.0.2-incubator&#x3a;",
+            "library": "Apache Sling Commons OSGi support",
+            "vendor": "org.apache.sling",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;org.apache.sling.commons.osgi-2.0.2-incubator.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "5bc897b9-5207-4702-a9b6-82f43266bcdd",
+          "title": "jackson-datatype-jsr310-2.11.0.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "168b2d0e11478b9f0a1bfccd62d6b5e8547b1e6f",
+            "library_id": "maven&#x3a;com.fasterxml.jackson.datatype&#x3a;jackson-datatype-jsr310&#x3a;2.11.0&#x3a;",
+            "library": "Jackson datatype&#x3a; JSR310",
+            "vendor": "com.fasterxml.jackson.datatype",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;jackson-datatype-jsr310-2.11.0.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "5d9e6e34-bc64-4f09-ba83-dd176dec6157",
+          "title": "maven-sling-plugin-2.0.4-incubator.jar",
+          "desc": "Maven Plugin supporting various Sling Development Tasks",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "d8b247e9c2e9b5b6e8d16142af9a5c66cd913430",
+            "library_id": "maven&#x3a;org.apache.sling&#x3a;maven-sling-plugin&#x3a;2.0.4-incubator&#x3a;",
+            "library": "Apache Sling Maven Plugin Relocation",
+            "vendor": "org.apache.sling",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;maven-sling-plugin-2.0.4-incubator.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "5e780142-ba84-431f-b2f7-72cdf66861a0",
+          "title": "tomcat-jasper-9.0.35.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "",
+            "library_id": "maven&#x3a;org.apache.tomcat&#x3a;tomcat-jasper&#x3a;9.0.35&#x3a;",
+            "library": "tomcat-jasper",
+            "vendor": "org.apache.tomcat",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;tomcat-embed-jasper-9.0.36.jar&#x3a;tomcat-jasper-9.0.35.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "5f415b4a-faa3-4ce8-97c7-78df73712658",
+          "title": "jakarta.el-3.0.3.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "dab46ee1ee23f7197c13d7c40fce14817c9017df",
+            "library_id": "maven&#x3a;org.glassfish&#x3a;jakarta.el&#x3a;3.0.3&#x3a;",
+            "library": "Jakarta Expression Language 3.0",
+            "vendor": "org.glassfish",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": [
+                {
+                  "name": "Eclipse Public License 2.0",
+                  "spdx_id": "EPL-2.0",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;EPL-2.0.html",
+                  "risk_rating": "3",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                },
+                {
+                  "name": "GNU General Public License with Classpath Exceptions version 2.0",
+                  "spdx_id": "GPL-2.0-with-classpath-exception",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;GPL-2.0-with-classpath-exception.html",
+                  "risk_rating": "4",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                }
+              ]
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;jakarta.el-3.0.3.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "6599f523-eda1-4491-8724-418b20fe6380",
+          "title": "javax.mail-api-1.4.7.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "",
+            "library_id": "maven&#x3a;javax.mail&#x3a;javax.mail-api&#x3a;1.4.7&#x3a;",
+            "library": "JavaMail API jar",
+            "vendor": "javax.mail",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": [
+                {
+                  "name": "Apache License 2.0",
+                  "spdx_id": "Apache-2.0",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                  "risk_rating": "2",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                },
+                {
+                  "name": "Common Development and Distribution License 1.0",
+                  "spdx_id": "CDDL-1.0",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;CDDL-1.0.html",
+                  "risk_rating": "3",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                },
+                {
+                  "name": "CeCILL Free Software License Agreement v1.0",
+                  "spdx_id": "CECILL-1.0",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;CECILL-1.0.html",
+                  "risk_rating": "3",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                },
+                {
+                  "name": "Eclipse Distribution License &#x28;EDL&#x29;",
+                  "spdx_id": "EDL",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;www.eclipse.org&#x2f;org&#x2f;documents&#x2f;edl-v10.php",
+                  "risk_rating": "2",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                },
+                {
+                  "name": "Eclipse Public License 2.0",
+                  "spdx_id": "EPL-2.0",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;EPL-2.0.html",
+                  "risk_rating": "3",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                },
+                {
+                  "name": "GNU General Public License with Classpath Exceptions version 2.0",
+                  "spdx_id": "GPL-2.0-with-classpath-exception",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;GPL-2.0-with-classpath-exception.html",
+                  "risk_rating": "4",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                }
+              ]
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;mail-1.4.7.jar&#x3a;javax.mail-api-1.4.7.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "696ebdd0-a72f-4254-8433-ad57b7f8ff8b",
+          "title": "tomcat-annotations-api-9.0.36.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "accb87a9bffc36d717a8dc6bd6ae05982a172f8a",
+            "library_id": "maven&#x3a;org.apache.tomcat&#x3a;tomcat-annotations-api&#x3a;9.0.36&#x3a;",
+            "library": "tomcat-annotations-api",
+            "vendor": "org.apache.tomcat",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;tomcat-annotations-api-9.0.36.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "6d58721f-b672-4d42-b8b8-cdaf0c8a3e01",
+          "title": "tomcat-embed-el-9.0.36.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "0df7c99202598126a5897b37bbf7993ce321efdd",
+            "library_id": "maven&#x3a;org.apache.tomcat.embed&#x3a;tomcat-embed-el&#x3a;9.0.36&#x3a;",
+            "library": "tomcat-embed-el",
+            "vendor": "org.apache.tomcat.embed",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;19 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;tomcat-embed-el-9.0.36.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "6d7c9b3e-39cd-4843-a0b3-4945a701ae8f",
+          "title": "tomcat-jsp-api-9.0.36.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "",
+            "library_id": "maven&#x3a;org.apache.tomcat&#x3a;tomcat-jsp-api&#x3a;9.0.36&#x3a;",
+            "library": "tomcat-jsp-api",
+            "vendor": "org.apache.tomcat",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;tomcat-embed-jasper-9.0.36.jar&#x3a;tomcat-jsp-api-9.0.36.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "6e6add0e-02ba-4bd9-9445-a3fb27e96b95",
+          "title": "spring-boot-starter-web-2.3.1.RELEASE.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "555c4f90141cdbc7637145e413bca0d622ba6796",
+            "library_id": "maven&#x3a;org.springframework.boot&#x3a;spring-boot-starter-web&#x3a;2.3.1.RELEASE&#x3a;",
+            "library": "spring-boot-starter-web",
+            "vendor": "org.springframework.boot",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;21 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;spring-boot-starter-web-2.3.1.RELEASE.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "6f481977-a06c-45ff-a1ff-42a0079dcbcb",
+          "title": "org.osgi.core-1.2.0.jar",
+          "desc": "OSGi Service Platform Release 4 Core Interfaces and Classes.",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "3006beb1ca6a83449def6127dad3c060148a0209",
+            "library_id": "maven&#x3a;org.apache.felix&#x3a;org.osgi.core&#x3a;1.2.0&#x3a;",
+            "library": "OSGi R4 Core Bundle",
+            "vendor": "org.apache.felix",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;19 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;org.osgi.core-1.2.0.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "707fd737-73ed-4161-9863-b7b82cd59d72",
+          "title": "jaxb-api-2.3.1.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "8531ad5ac454cc2deb9d4d32c40c4d7451939b5d",
+            "library_id": "maven&#x3a;javax.xml.bind&#x3a;jaxb-api&#x3a;2.3.1&#x3a;",
+            "library": "jaxb-api",
+            "vendor": "javax.xml.bind",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": [
+                {
+                  "name": "Common Development and Distribution License 1.1&#x28;CDDL-1.1&#x29;",
+                  "spdx_id": "CDDL-1.1",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;CDDL-1.1.html",
+                  "risk_rating": "3",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                },
+                {
+                  "name": "GNU General Public License with Classpath Exceptions version 2.0",
+                  "spdx_id": "GPL-2.0-with-classpath-exception",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;GPL-2.0-with-classpath-exception.html",
+                  "risk_rating": "4",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                }
+              ]
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;jaxb-api-2.3.1.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "723432a9-fca7-4cd1-a32c-0625a828c664",
+          "title": "VeracodeAnnotations-1.2.1.jar",
+          "desc": "Annotations used by Veracode&#x27;s software analysis framework",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "c7b6bcfca2967d20caa5fd1f03fd0ce7aa42b809",
+            "library_id": "maven&#x3a;com.veracode.annotation&#x3a;VeracodeAnnotations&#x3a;1.2.1&#x3a;",
+            "library": "VeracodeAnnotations",
+            "vendor": "com.veracode.annotation",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "MIT License",
+                "spdx_id": "MIT",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;MIT.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;VeracodeAnnotations-1.2.1.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "72fb5479-fe7a-47f7-b7d2-85777227293d",
+          "title": "jul-to-slf4j-1.7.30.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "d58bebff8cbf70ff52b59208586095f467656c30",
+            "library_id": "maven&#x3a;org.slf4j&#x3a;jul-to-slf4j&#x3a;1.7.30&#x3a;",
+            "library": "JUL to SLF4J bridge",
+            "vendor": "org.slf4j",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "MIT License",
+                "spdx_id": "MIT",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;MIT.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;jul-to-slf4j-1.7.30.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "7339ff8f-298c-4821-98a9-7fd2c7a74fee",
+          "title": "pop3-1.4.6.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "",
+            "library_id": "maven&#x3a;com.sun.mail&#x3a;pop3&#x3a;1.4.6&#x3a;",
+            "library": "Jakarta Mail API pop3 provider",
+            "vendor": "com.sun.mail",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": [
+                {
+                  "name": "Common Development and Distribution License 1.0",
+                  "spdx_id": "CDDL-1.0",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;CDDL-1.0.html",
+                  "risk_rating": "3",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                },
+                {
+                  "name": "CeCILL Free Software License Agreement v1.0",
+                  "spdx_id": "CECILL-1.0",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;CECILL-1.0.html",
+                  "risk_rating": "3",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                },
+                {
+                  "name": "Eclipse Distribution License &#x28;EDL&#x29;",
+                  "spdx_id": "EDL",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;www.eclipse.org&#x2f;org&#x2f;documents&#x2f;edl-v10.php",
+                  "risk_rating": "2",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                },
+                {
+                  "name": "Eclipse Public License 2.0",
+                  "spdx_id": "EPL-2.0",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;EPL-2.0.html",
+                  "risk_rating": "3",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                },
+                {
+                  "name": "GNU General Public License v2.0 only",
+                  "spdx_id": "GPL-2.0",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;GPL-2.0.html",
+                  "risk_rating": "4",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                },
+                {
+                  "name": "GNU General Public License with Classpath Exceptions version 2.0",
+                  "spdx_id": "GPL-2.0-with-classpath-exception",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;GPL-2.0-with-classpath-exception.html",
+                  "risk_rating": "4",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                }
+              ]
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;mail-1.4.7.jar&#x3a;pop3-1.4.6.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "7af6c9ab-b28e-4870-8553-6fec23094864",
+          "title": "tomcat-embed-jasper-9.0.36.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "a2dbada2312d6fa749ca2d6266466f0a3cb279f2",
+            "library_id": "maven&#x3a;org.apache.tomcat.embed&#x3a;tomcat-embed-jasper&#x3a;9.0.36&#x3a;",
+            "library": "tomcat-embed-jasper",
+            "vendor": "org.apache.tomcat.embed",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;tomcat-embed-jasper-9.0.36.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "7b97d2dc-f55b-488d-a19b-f28a2c52a6e1",
+          "title": "maven-profile-2.0.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "442e147cd361128f56ce8003019421f0d90b388a",
+            "library_id": "maven&#x3a;org.apache.maven&#x3a;maven-profile&#x3a;2.0&#x3a;",
+            "library": "Maven Profile Model",
+            "vendor": "org.apache.maven",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;19 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;maven-profile-2.0.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "80921602-84bd-4397-ae9a-ef836cb936f9",
+          "title": "spring-boot-starter-tomcat-2.3.1.RELEASE.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "5b599d0da04e724479c22daa47f9bfd62533a2e9",
+            "library_id": "maven&#x3a;org.springframework.boot&#x3a;spring-boot-starter-tomcat&#x3a;2.3.1.RELEASE&#x3a;",
+            "library": "spring-boot-starter-tomcat",
+            "vendor": "org.springframework.boot",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;spring-boot-starter-tomcat-2.3.1.RELEASE.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "811aa8f7-da6c-4269-b1f8-5bbd19ce1a61",
+          "title": "hamcrest-2.2.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "1820c0968dba3a11a1b30669bb1f01978a91dedc",
+            "library_id": "maven&#x3a;org.hamcrest&#x3a;hamcrest&#x3a;2.2&#x3a;",
+            "library": "Hamcrest",
+            "vendor": "org.hamcrest",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "BSD 3-Clause &#x22;New&#x22; or &#x22;Revised&#x22; License",
+                "spdx_id": "BSD-3-Clause",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;BSD-3-Clause.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;hamcrest-2.2.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "818e21c0-1a85-4a0e-acf9-77d264d85da4",
+          "title": "jackson-annotations-2.11.0.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "c626020ae55d19c690d25cb51c1532ba76e5890f",
+            "library_id": "maven&#x3a;com.fasterxml.jackson.core&#x3a;jackson-annotations&#x3a;2.11.0&#x3a;",
+            "library": "Jackson-annotations",
+            "vendor": "com.fasterxml.jackson.core",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;jackson-annotations-2.11.0.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "83fe7fdd-3039-409a-8fab-555d5b823ed0",
+          "title": "log4j-to-slf4j-2.13.3.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "966f6fd1af4959d6b12bfa880121d4a2b164f857",
+            "library_id": "maven&#x3a;org.apache.logging.log4j&#x3a;log4j-to-slf4j&#x3a;2.13.3&#x3a;",
+            "library": "Apache Log4j to SLF4J Adapter",
+            "vendor": "org.apache.logging.log4j",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;19 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;log4j-to-slf4j-2.13.3.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "843d5a03-d3ab-42df-a149-3d89967d1f1c",
+          "title": "jackson-module-parameter-names-2.11.0.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "950a1e9a7c1093e7ffd92b216d5a0667f1e39058",
+            "library_id": "maven&#x3a;com.fasterxml.jackson.module&#x3a;jackson-module-parameter-names&#x3a;2.11.0&#x3a;",
+            "library": "Jackson-module-parameter-names",
+            "vendor": "com.fasterxml.jackson.module",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;jackson-module-parameter-names-2.11.0.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "8b4f55d4-ea0b-4115-a79f-41e564717d1e",
+          "title": "jstl-1.2.jar",
+          "desc": "",
+          "impact": 0.75,
+          "refs": [],
+          "tags": {
+            "sha1": "74aca283cd4f4b4f3e425f5820cda58f44409547",
+            "library_id": "maven&#x3a;javax.servlet&#x3a;jstl&#x3a;1.2&#x3a;",
+            "library": "jstl",
+            "vendor": "javax.servlet",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": [
+                {
+                  "name": "Common Development and Distribution License 1.0",
+                  "spdx_id": "CDDL-1.0",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;CDDL-1.0.html",
+                  "risk_rating": "3",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                },
+                {
+                  "name": "GNU General Public License v2.0 only",
+                  "spdx_id": "GPL-2.0",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;GPL-2.0.html",
+                  "risk_rating": "4",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                }
+              ]
+            }
           },
           "source_location": {
             "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;jstl-1.2.jar"
@@ -2055,23 +3497,71 @@
           "results": [
             {
               "status": "failed",
-              "code_desc": "component_id: 8b4f55d4-ea0b-4115-a79f-41e564717d1e;sha1: 74aca283cd4f4b4f3e425f5820cda58f44409547\nmax_cvss_score: 7.5\nversion: 1.2\nlibrary: jstl\nvendor: javax.servlet\ndescription: \nadded_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;jstl-1.2.jar",
+              "code_desc": "cve_id: CVE-2015-0254\ncvss_score: 7.5\nseverity: 4\ncwe_id: \nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncve_summary: Apache Standard Taglibs before 1.2.3 allows remote attackers to execute arbitrary code or conduct external XML entity &#x28;XXE&#x29; attacks via a crafted XSLT extension in a &#x28;1&#x29; &#x3c;x&#x3a;parse&#x3e; or &#x28;2&#x29; &#x3c;x&#x3a;transform&#x3e; JSTL XML tag.\nseverity_desc: High\nmitigation: false\nvulnerability_affects_policy_compliance: false",
               "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
             }
           ]
         },
         {
-          "id": "CVE-2019-17571",
-          "title": "CVE-2019-17571",
-          "desc": "log4j-core is vulnerable to arbitrary code execution. Deserialization of untrusted data in &#x60;TcpSocketServer&#x60; and &#x60;UdpSocketServer&#x60; when listening for log data allows an attacker to execute arbitrary code via a malicious deserialization gadget.",
-          "impact": 0.7,
+          "id": "8d83649b-8fe3-40fa-b124-9f9d43bb30b1",
+          "title": "org.ops4j.pax.tipi.tomcat-embed-core-9.0.36.1.jar",
+          "desc": "",
+          "impact": 0,
           "refs": [],
           "tags": {
-            "cwe": "",
+            "sha1": "",
+            "library_id": "maven&#x3a;org.ops4j.pax.tipi&#x3a;org.ops4j.pax.tipi.tomcat-embed-core&#x3a;9.0.36.1&#x3a;",
+            "library": "org.ops4j.pax.tipi.tomcat-embed-core",
+            "vendor": "org.ops4j.pax.tipi",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
             "nist": [
               "SI-2",
               "RA-5"
-            ]
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;tomcat-embed-core-9.0.36.jar&#x3a;org.ops4j.pax.tipi.tomcat-embed-core-9.0.36.1.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "8d9a63d8-808b-4233-9e54-279d0f51826f",
+          "title": "log4j-1.2.17.jar",
+          "desc": "Apache Log4j 1.2",
+          "impact": 0.75,
+          "refs": [],
+          "tags": {
+            "sha1": "5af35056b4d257e4b64b9e8069c0746e8b08629f",
+            "library_id": "maven&#x3a;log4j&#x3a;log4j&#x3a;1.2.17&#x3a;",
+            "library": "Apache Log4j",
+            "vendor": "log4j",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
           },
           "source_location": {
             "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;log4j-1.2.17.jar"
@@ -2079,47 +3569,241 @@
           "results": [
             {
               "status": "failed",
-              "code_desc": "component_id: 8d9a63d8-808b-4233-9e54-279d0f51826f;sha1: 5af35056b4d257e4b64b9e8069c0746e8b08629f\nmax_cvss_score: 7.5\nversion: 1.2.17\nlibrary: Apache Log4j\nvendor: log4j\ndescription: Apache Log4j 1.2\nadded_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;log4j-1.2.17.jar",
+              "code_desc": "cve_id: CVE-2019-17571\ncvss_score: 7.5\nseverity: 4\ncwe_id: \nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncve_summary: log4j-core is vulnerable to arbitrary code execution. Deserialization of untrusted data in &#x60;TcpSocketServer&#x60; and &#x60;UdpSocketServer&#x60; when listening for log data allows an attacker to execute arbitrary code via a malicious deserialization gadget.\nseverity_desc: High\nmitigation: false\nvulnerability_affects_policy_compliance: false",
               "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
-            }
-          ]
-        },
-        {
-          "id": "CVE-2021-4104",
-          "title": "CVE-2021-4104",
-          "desc": "JMSAppender in log4j is vulnerable to deserialization of untrusted object. When an application is configured to use JMSAppender with the setting TopicBindingName or TopicConnectionFactoryBindingName to something that JNDI can handle - for example &#x22;ldap&#x3a;&#x2f;&#x2f;host&#x3a;port&#x2f;a&#x22;, an attacker is able to execute code on the server as in Log4j 2.x CVE-2021-44228. However, this vulnerability is only depending on configuration. Note&#x3a; This CVE is for Log4j 1.x and its corresponding flaw information for Log4j 2.x is in CVE-2021-44228.",
-          "impact": 0.5,
-          "refs": [],
-          "tags": {
-            "cwe": "",
-            "nist": [
-              "SI-2",
-              "RA-5"
-            ]
-          },
-          "source_location": {
-            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;log4j-1.2.17.jar"
-          },
-          "results": [
+            },
             {
               "status": "failed",
-              "code_desc": "component_id: 8d9a63d8-808b-4233-9e54-279d0f51826f;sha1: 5af35056b4d257e4b64b9e8069c0746e8b08629f\nmax_cvss_score: 7.5\nversion: 1.2.17\nlibrary: Apache Log4j\nvendor: log4j\ndescription: Apache Log4j 1.2\nadded_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;log4j-1.2.17.jar",
+              "code_desc": "cve_id: CVE-2021-4104\ncvss_score: 6.0\nseverity: 3\ncwe_id: \nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncve_summary: JMSAppender in log4j is vulnerable to deserialization of untrusted object. When an application is configured to use JMSAppender with the setting TopicBindingName or TopicConnectionFactoryBindingName to something that JNDI can handle - for example &#x22;ldap&#x3a;&#x2f;&#x2f;host&#x3a;port&#x2f;a&#x22;, an attacker is able to execute code on the server as in Log4j 2.x CVE-2021-44228. However, this vulnerability is only depending on configuration. Note&#x3a; This CVE is for Log4j 1.x and its corresponding flaw information for Log4j 2.x is in CVE-2021-44228.\nseverity_desc: Medium\nmitigation: false\nvulnerability_affects_policy_compliance: false",
               "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
             }
           ]
         },
         {
-          "id": "CVE-2015-2944",
-          "title": "CVE-2015-2944",
-          "desc": "Multiple cross-site scripting &#x28;XSS&#x29; vulnerabilities in Apache Sling API before 2.2.2 and Apache Sling Servlets Post before 2.1.2 allow remote attackers to inject arbitrary web script or HTML via the URI, related to &#x28;1&#x29; org&#x2f;apache&#x2f;sling&#x2f;api&#x2f;servlets&#x2f;HtmlResponse and &#x28;2&#x29; org&#x2f;apache&#x2f;sling&#x2f;servlets&#x2f;post&#x2f;HtmlResponse.",
-          "impact": 0.5,
+          "id": "8e65d6c5-1044-42a1-9842-107728590261",
+          "title": "org.apache.sling.commons.json-2.0.4-incubator.jar",
+          "desc": "Apache Sling JSON Library",
+          "impact": 0,
           "refs": [],
           "tags": {
-            "cwe": "CWE-79",
+            "sha1": "19ce406cfe62be665037f5d397b62b4920a41e20",
+            "library_id": "maven&#x3a;org.apache.sling&#x3a;org.apache.sling.commons.json&#x3a;2.0.4-incubator&#x3a;",
+            "library": "Apache Sling JSON Library",
+            "vendor": "org.apache.sling",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
             "nist": [
               "SI-2",
               "RA-5"
-            ]
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;org.apache.sling.commons.json-2.0.4-incubator.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "8fadadf2-48d9-405b-a095-c526be235da2",
+          "title": "spring-boot-starter-2.3.1.RELEASE.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "e0d28696fea064578cb01da346232284f922eba4",
+            "library_id": "maven&#x3a;org.springframework.boot&#x3a;spring-boot-starter&#x3a;2.3.1.RELEASE&#x3a;",
+            "library": "spring-boot-starter",
+            "vendor": "org.springframework.boot",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;spring-boot-starter-2.3.1.RELEASE.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "909191b8-ab7f-4944-84bc-39f12b809732",
+          "title": "encoder-1.2.2.jar",
+          "desc": "The OWASP Encoders package is a collection of high-performance low-overhead&#xa;        contextual encoders, that when utilized correctly, is an effective tool in&#xa;        preventing Web Application security vulnerabilities such as Cross-Site&#xa;        Scripting.",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "664346e62c3a95e1de5153db231bd283392a9532",
+            "library_id": "maven&#x3a;org.owasp.encoder&#x3a;encoder&#x3a;1.2.2&#x3a;",
+            "library": "Java Encoder",
+            "vendor": "org.owasp.encoder",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;19 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "BSD 3-Clause &#x22;New&#x22; or &#x22;Revised&#x22; License",
+                "spdx_id": "BSD-3-Clause",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;BSD-3-Clause.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;encoder-1.2.2.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "91873e93-df8f-432b-b4eb-69c5ad96b775",
+          "title": "plexus-container-default-1.0-alpha-8.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "26fca33e988fb2c4a6688e65a1cd5bab3bb93a64",
+            "library_id": "maven&#x3a;org.codehaus.plexus&#x3a;plexus-container-default&#x3a;1.0-alpha-8&#x3a;",
+            "library": "Plexus &#x3a;&#x3a; Default Container",
+            "vendor": "org.codehaus.plexus",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;plexus-container-default-1.0-alpha-8.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "92d18e2a-1b13-46df-b9be-de51d4bc6c9e",
+          "title": "commons-logging-1.0.4.jar",
+          "desc": "Commons Logging is a thin adapter allowing configurable bridging to other,&#xa;    well known logging systems.",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "f029a2aefe2b3e1517573c580f948caac31b1056",
+            "library_id": "maven&#x3a;commons-logging&#x3a;commons-logging&#x3a;1.0.4&#x3a;",
+            "library": "Apache Commons Logging",
+            "vendor": "commons-logging",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;19 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;commons-logging-1.0.4.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "948a145e-813d-4d08-98d3-7795976aec7d",
+          "title": "jackson-datatype-jdk8-2.11.0.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "cca91d6375258fd7ff2a6abb7bf91eef492bd606",
+            "library_id": "maven&#x3a;com.fasterxml.jackson.datatype&#x3a;jackson-datatype-jdk8&#x3a;2.11.0&#x3a;",
+            "library": "Jackson datatype&#x3a; jdk8",
+            "vendor": "com.fasterxml.jackson.datatype",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;19 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;jackson-datatype-jdk8-2.11.0.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "97f0fb05-af1a-4a15-bb80-89dc2ac6f707",
+          "title": "org.apache.sling.api-2.0.2-incubator.jar",
+          "desc": "The Sling API defines an extension to the Servlet API 2.4 to&#xa;        provide access to content and unified access to request&#xa;        parameters hiding the differences between the different methods&#xa;        of transferring parameters from client to server. Note that the&#xa;        Sling API bundle does not include the Servlet API but instead&#xa;        requires the API to be provided by the Servlet container in&#xa;        which the Sling framework is running or by another bundle.",
+          "impact": 0.43,
+          "refs": [],
+          "tags": {
+            "sha1": "b984f6288bb695b49d5eed9e3fcc3d75d5fe5e9f",
+            "library_id": "maven&#x3a;org.apache.sling&#x3a;org.apache.sling.api&#x3a;2.0.2-incubator&#x3a;",
+            "library": "Apache Sling API",
+            "vendor": "org.apache.sling",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
           },
           "source_location": {
             "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;org.apache.sling.api-2.0.2-incubator.jar"
@@ -2127,23 +3811,71 @@
           "results": [
             {
               "status": "failed",
-              "code_desc": "component_id: 97f0fb05-af1a-4a15-bb80-89dc2ac6f707;sha1: b984f6288bb695b49d5eed9e3fcc3d75d5fe5e9f\nmax_cvss_score: 4.3\nversion: 2.0.2-incubator\nlibrary: Apache Sling API\nvendor: org.apache.sling\ndescription: The Sling API defines an extension to the Servlet API 2.4 to&#xa;        provide access to content and unified access to request&#xa;        parameters hiding the differences between the different methods&#xa;        of transferring parameters from client to server. Note that the&#xa;        Sling API bundle does not include the Servlet API but instead&#xa;        requires the API to be provided by the Servlet container in&#xa;        which the Sling framework is running or by another bundle.\nadded_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;org.apache.sling.api-2.0.2-incubator.jar",
+              "code_desc": "cve_id: CVE-2015-2944\ncvss_score: 4.3\nseverity: 3\ncwe_id: CWE-79\nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncve_summary: Multiple cross-site scripting &#x28;XSS&#x29; vulnerabilities in Apache Sling API before 2.2.2 and Apache Sling Servlets Post before 2.1.2 allow remote attackers to inject arbitrary web script or HTML via the URI, related to &#x28;1&#x29; org&#x2f;apache&#x2f;sling&#x2f;api&#x2f;servlets&#x2f;HtmlResponse and &#x28;2&#x29; org&#x2f;apache&#x2f;sling&#x2f;servlets&#x2f;post&#x2f;HtmlResponse.\nseverity_desc: Medium\nmitigation: false\nvulnerability_affects_policy_compliance: false",
               "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
             }
           ]
         },
         {
-          "id": "CVE-2015-4852",
-          "title": "CVE-2015-4852",
-          "desc": "Apache Commons includes a class called InvokerTransformer. An application is vulnerable to a deserialization attack if this class is available on the classpath and the application deserializes untrusted or user-supplied data. It&#x27;s not necessary to actually use InvokerTransfomer to be vulnerable. With these two criteria satisfied, an attacker may construct a gadget chain using classes in the component to execute arbitrary code. The chain relies on the class InvokerTransformer in the org.apache.commons.collections.functors package to invoke methods during the deserialization process.&#xa;&#xa;The fix prevents deserialization of InvokerTransformer by default unless it&#x27;s specifically enabled.&#xa;&#xa;CVE-2015-4852, CVE-2015-6420, CVE-2015-7501, and CVE-2015-7450 are all related to this artifact.",
-          "impact": 0.7,
+          "id": "994959a9-c6e3-49f0-82c6-c283583e23ba",
+          "title": "tomcat-juli-9.0.37.jar",
+          "desc": "",
+          "impact": 0,
           "refs": [],
           "tags": {
-            "cwe": "CWE-77",
+            "sha1": "",
+            "library_id": "maven&#x3a;org.apache.tomcat&#x3a;tomcat-juli&#x3a;9.0.37&#x3a;",
+            "library": "tomcat-juli",
+            "vendor": "org.apache.tomcat",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
             "nist": [
               "SI-2",
               "RA-5"
-            ]
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;tomcat-embed-core-9.0.36.jar&#x3a;tomcat-juli-9.0.37.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "9fdb0cb9-3f05-4fb3-b221-cd97bdacc307",
+          "title": "commons-collections4-4.0.jar",
+          "desc": "The Apache Commons Collections package contains types that extend and augment the Java Collections Framework.",
+          "impact": 0.75,
+          "refs": [],
+          "tags": {
+            "sha1": "da217367fd25e88df52ba79e47658d4cf928b0d1",
+            "library_id": "maven&#x3a;org.apache.commons&#x3a;commons-collections4&#x3a;4.0&#x3a;",
+            "library": "Apache Commons Collections",
+            "vendor": "org.apache.commons",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
           },
           "source_location": {
             "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;commons-collections4-4.0.jar"
@@ -2151,47 +3883,53 @@
           "results": [
             {
               "status": "failed",
-              "code_desc": "component_id: 9fdb0cb9-3f05-4fb3-b221-cd97bdacc307;sha1: da217367fd25e88df52ba79e47658d4cf928b0d1\nmax_cvss_score: 7.5\nversion: 4.0\nlibrary: Apache Commons Collections\nvendor: org.apache.commons\ndescription: The Apache Commons Collections package contains types that extend and augment the Java Collections Framework.\nadded_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;commons-collections4-4.0.jar",
+              "code_desc": "cve_id: CVE-2015-4852\ncvss_score: 7.5\nseverity: 4\ncwe_id: CWE-77\nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncve_summary: Apache Commons includes a class called InvokerTransformer. An application is vulnerable to a deserialization attack if this class is available on the classpath and the application deserializes untrusted or user-supplied data. It&#x27;s not necessary to actually use InvokerTransfomer to be vulnerable. With these two criteria satisfied, an attacker may construct a gadget chain using classes in the component to execute arbitrary code. The chain relies on the class InvokerTransformer in the org.apache.commons.collections.functors package to invoke methods during the deserialization process.&#xa;&#xa;The fix prevents deserialization of InvokerTransformer by default unless it&#x27;s specifically enabled.&#xa;&#xa;CVE-2015-4852, CVE-2015-6420, CVE-2015-7501, and CVE-2015-7450 are all related to this artifact.\nseverity_desc: High\nmitigation: false\nvulnerability_affects_policy_compliance: false",
               "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
-            }
-          ]
-        },
-        {
-          "id": "CVE-2015-6420",
-          "title": "CVE-2015-6420",
-          "desc": "Apache Commons Collections &#x28;ACC&#x29; library is vulnerable to arbitrary code execution. The vulnerability is possible because it directly uses ACC, or contains ACC, in the classpath, allowing a malicious user to inject and execute arbitrary code upon deserialization.",
-          "impact": 0.7,
-          "refs": [],
-          "tags": {
-            "cwe": "CWE-502",
-            "nist": [
-              "SI-2",
-              "RA-5"
-            ]
-          },
-          "source_location": {
-            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;commons-collections4-4.0.jar"
-          },
-          "results": [
+            },
             {
               "status": "failed",
-              "code_desc": "component_id: 9fdb0cb9-3f05-4fb3-b221-cd97bdacc307;sha1: da217367fd25e88df52ba79e47658d4cf928b0d1\nmax_cvss_score: 7.5\nversion: 4.0\nlibrary: Apache Commons Collections\nvendor: org.apache.commons\ndescription: The Apache Commons Collections package contains types that extend and augment the Java Collections Framework.\nadded_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;commons-collections4-4.0.jar",
+              "code_desc": "cve_id: CVE-2015-6420\ncvss_score: 7.5\nseverity: 4\ncwe_id: CWE-502\nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncve_summary: Apache Commons Collections &#x28;ACC&#x29; library is vulnerable to arbitrary code execution. The vulnerability is possible because it directly uses ACC, or contains ACC, in the classpath, allowing a malicious user to inject and execute arbitrary code upon deserialization.\nseverity_desc: High\nmitigation: false\nvulnerability_affects_policy_compliance: false",
               "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
             }
           ]
         },
         {
-          "id": "CVE-2015-0886",
-          "title": "CVE-2015-0886",
-          "desc": "Integer overflow in the crypt_raw method in the key-stretching implementation in jBCrypt before 0.4 makes it easier for remote attackers to determine cleartext values of password hashes via a brute-force attack against hashes associated with the maximum exponent.",
+          "id": "a05bbd80-250f-4a54-b4fe-cc8d11957d25",
+          "title": "jbcrypt-0.3m.jar",
+          "desc": "jBCrypt is a Java implementation of OpenBSD&#x27;s Blowfish password hashing code, as described in A Future-Adaptable Password Scheme by Niels Provos and David Mazi&#xe8;res, by Damien Miller.",
           "impact": 0.5,
           "refs": [],
           "tags": {
-            "cwe": "",
+            "sha1": "fe2d9c5f23767d681a7e38fc8986b812400ec583",
+            "library_id": "maven&#x3a;org.mindrot&#x3a;jbcrypt&#x3a;0.3m&#x3a;",
+            "library": "jBCrypt",
+            "vendor": "org.mindrot",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
             "nist": [
               "SI-2",
               "RA-5"
-            ]
+            ],
+            "licenses": {
+              "license": [
+                {
+                  "name": "BSD 3-Clause &#x22;New&#x22; or &#x22;Revised&#x22; License",
+                  "spdx_id": "BSD-3-Clause",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;BSD-3-Clause.html",
+                  "risk_rating": "2",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                },
+                {
+                  "name": "ISC License",
+                  "spdx_id": "ISC",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;ISC.html",
+                  "risk_rating": "2",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                }
+              ]
+            }
           },
           "source_location": {
             "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;jbcrypt-0.3m.jar"
@@ -2199,23 +3937,38 @@
           "results": [
             {
               "status": "failed",
-              "code_desc": "component_id: a05bbd80-250f-4a54-b4fe-cc8d11957d25;sha1: fe2d9c5f23767d681a7e38fc8986b812400ec583\nmax_cvss_score: 5.0\nversion: 0.3m\nlibrary: jBCrypt\nvendor: org.mindrot\ndescription: jBCrypt is a Java implementation of OpenBSD&#x27;s Blowfish password hashing code, as described in A Future-Adaptable Password Scheme by Niels Provos and David Mazi&#xe8;res, by Damien Miller.\nadded_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;jbcrypt-0.3m.jar",
+              "code_desc": "cve_id: CVE-2015-0886\ncvss_score: 5.0\nseverity: 3\ncwe_id: \nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncve_summary: Integer overflow in the crypt_raw method in the key-stretching implementation in jBCrypt before 0.4 makes it easier for remote attackers to determine cleartext values of password hashes via a brute-force attack against hashes associated with the maximum exponent.\nseverity_desc: Medium\nmitigation: false\nvulnerability_affects_policy_compliance: false",
               "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
             }
           ]
         },
         {
-          "id": "CVE-2017-2582",
-          "title": "CVE-2017-2582",
-          "desc": "keycloak-saml-core is vulnerable to sensitive information disclosure. The attack exists because SAML messages are being parsed by replacing the string to obtain the attribute values with the system property in &#x60;StaxParserUtil&#x60; class. Therefore, attacker can just parse the chosen system property name through the SAML request ID field and can get the response with system property value in &#x60;InResponseTo&#x60; filed .",
-          "impact": 0.3,
+          "id": "a71a1300-9a17-45dd-81a6-bd4ec5dd18d9",
+          "title": "keycloak-saml-core-1.8.1.Final.jar",
+          "desc": "",
+          "impact": 0.64,
           "refs": [],
           "tags": {
-            "cwe": "CWE-200",
+            "sha1": "73cebee358d4738326d4540ea496eefa1e5ad05f",
+            "library_id": "maven&#x3a;org.keycloak&#x3a;keycloak-saml-core&#x3a;1.8.1.Final&#x3a;",
+            "library": "Keycloak SAML Core",
+            "vendor": "org.keycloak",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;19 UTC",
             "nist": [
               "SI-2",
               "RA-5"
-            ]
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
           },
           "source_location": {
             "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;keycloak-saml-core-1.8.1.Final.jar"
@@ -2223,71 +3976,299 @@
           "results": [
             {
               "status": "failed",
-              "code_desc": "component_id: a71a1300-9a17-45dd-81a6-bd4ec5dd18d9;sha1: 73cebee358d4738326d4540ea496eefa1e5ad05f\nmax_cvss_score: 6.4\nversion: 1.8.1.Final\nlibrary: Keycloak SAML Core\nvendor: org.keycloak\ndescription: \nadded_date: 2021-12-29 22&#x3a;18&#x3a;19 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;keycloak-saml-core-1.8.1.Final.jar",
+              "code_desc": "cve_id: CVE-2017-2582\ncvss_score: 4.0\nseverity: 2\ncwe_id: CWE-200\nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;19 UTC\ncve_summary: keycloak-saml-core is vulnerable to sensitive information disclosure. The attack exists because SAML messages are being parsed by replacing the string to obtain the attribute values with the system property in &#x60;StaxParserUtil&#x60; class. Therefore, attacker can just parse the chosen system property name through the SAML request ID field and can get the response with system property value in &#x60;InResponseTo&#x60; filed .\nseverity_desc: Low\nmitigation: false\nvulnerability_affects_policy_compliance: false",
               "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
-            }
-          ]
-        },
-        {
-          "id": "CVE-2017-2646",
-          "title": "CVE-2017-2646",
-          "desc": "keycloak-saml-core is vulnerable to denial of service &#x28;DoS&#x29; attacks. The vulnerability exists due to the mishandling of a &#x60;Logout&#x60; request with an &#x60;Extensions&#x60; in the middle of the request.",
-          "impact": 0.5,
-          "refs": [],
-          "tags": {
-            "cwe": "CWE-400",
-            "nist": [
-              "SI-2",
-              "RA-5"
-            ]
-          },
-          "source_location": {
-            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;keycloak-saml-core-1.8.1.Final.jar"
-          },
-          "results": [
+            },
             {
               "status": "failed",
-              "code_desc": "component_id: a71a1300-9a17-45dd-81a6-bd4ec5dd18d9;sha1: 73cebee358d4738326d4540ea496eefa1e5ad05f\nmax_cvss_score: 6.4\nversion: 1.8.1.Final\nlibrary: Keycloak SAML Core\nvendor: org.keycloak\ndescription: \nadded_date: 2021-12-29 22&#x3a;18&#x3a;19 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;keycloak-saml-core-1.8.1.Final.jar",
+              "code_desc": "cve_id: CVE-2017-2646\ncvss_score: 5.0\nseverity: 3\ncwe_id: CWE-400\nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;19 UTC\ncve_summary: keycloak-saml-core is vulnerable to denial of service &#x28;DoS&#x29; attacks. The vulnerability exists due to the mishandling of a &#x60;Logout&#x60; request with an &#x60;Extensions&#x60; in the middle of the request.\nseverity_desc: Medium\nmitigation: false\nvulnerability_affects_policy_compliance: false",
               "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
-            }
-          ]
-        },
-        {
-          "id": "SRCCLR-SID-2367",
-          "title": "SRCCLR-SID-2367",
-          "desc": "Keycloak saml-core is vulnerable to malicious SAML assertion insertion. This vulnerability is due to the fact that the assertions are not verified as signed before being accepted.",
-          "impact": 0.7,
-          "refs": [],
-          "tags": {
-            "cwe": "",
-            "nist": [
-              "SI-2",
-              "RA-5"
-            ]
-          },
-          "source_location": {
-            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;keycloak-saml-core-1.8.1.Final.jar"
-          },
-          "results": [
+            },
             {
               "status": "failed",
-              "code_desc": "component_id: a71a1300-9a17-45dd-81a6-bd4ec5dd18d9;sha1: 73cebee358d4738326d4540ea496eefa1e5ad05f\nmax_cvss_score: 6.4\nversion: 1.8.1.Final\nlibrary: Keycloak SAML Core\nvendor: org.keycloak\ndescription: \nadded_date: 2021-12-29 22&#x3a;18&#x3a;19 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;keycloak-saml-core-1.8.1.Final.jar",
+              "code_desc": "cve_id: SRCCLR-SID-2367\ncvss_score: 6.4\nseverity: 4\ncwe_id: \nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;19 UTC\ncve_summary: Keycloak saml-core is vulnerable to malicious SAML assertion insertion. This vulnerability is due to the fact that the assertions are not verified as signed before being accepted.\nseverity_desc: High\nmitigation: false\nvulnerability_affects_policy_compliance: false",
               "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
             }
           ]
         },
         {
-          "id": "CVE-2020-13934",
-          "title": "CVE-2020-13934",
-          "desc": "apache tomcat is vulnerable to denial of service. The HTTP&#x2f;1.1 processor is not released after an upgrade to HTTP&#x2f;2, allowing an attacker to cause a denial of service condition due to an &#x60;OutOfMemoryException&#x60; by sending a large number of upgrade requests.",
-          "impact": 0.5,
+          "id": "af04dc46-3a04-4c38-a0b0-dc438f6d3e53",
+          "title": "org.apache.servicemix.bundles.spring-aop-5.2.7.RELEASE_1.jar",
+          "desc": "",
+          "impact": 0,
           "refs": [],
           "tags": {
-            "cwe": "",
+            "sha1": "",
+            "library_id": "maven&#x3a;org.apache.servicemix.bundles&#x3a;org.apache.servicemix.bundles.spring-aop&#x3a;5.2.7.RELEASE_1&#x3a;",
+            "library": "org.apache.servicemix.bundles.spring-aop",
+            "vendor": "org.apache.servicemix.bundles",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
             "nist": [
               "SI-2",
               "RA-5"
-            ]
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;spring-aop-5.2.7.RELEASE.jar&#x3a;org.apache.servicemix.bundles.spring-aop-5.2.7.RELEASE_1.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "b2fe525b-676f-4cfb-a9e5-898a840923f3",
+          "title": "spring-webmvc-5.2.7.RELEASE.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "dcd97bcb0a2aa33f272b0031e4771134e327d942",
+            "library_id": "maven&#x3a;org.springframework&#x3a;spring-webmvc&#x3a;5.2.7.RELEASE&#x3a;",
+            "library": "Spring Web MVC",
+            "vendor": "org.springframework",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;spring-webmvc-5.2.7.RELEASE.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "b710849d-bda8-4518-a5fb-d73c8554bc7e",
+          "title": "activation-1.1.jar",
+          "desc": "JavaBeans Activation Framework &#x28;JAF&#x29; is a standard extension to the Java platform that lets you take advantage of standard services to&#x3a; determine the type of an arbitrary piece of data&#x3b; encapsulate access to it&#x3b; discover the operations available on it&#x3b; and instantiate the appropriate bean to perform the operation&#x28;s&#x29;.",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "e6cb541461c2834bdea3eb920f1884d1eb508b50",
+            "library_id": "maven&#x3a;javax.activation&#x3a;activation&#x3a;1.1&#x3a;",
+            "library": "JavaBeans&#x28;TM&#x29; Activation Framework",
+            "vendor": "javax.activation",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;19 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": [
+                {
+                  "name": "Common Development and Distribution License 1.0",
+                  "spdx_id": "CDDL-1.0",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;CDDL-1.0.html",
+                  "risk_rating": "3",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                },
+                {
+                  "name": "CeCILL Free Software License Agreement v1.0",
+                  "spdx_id": "CECILL-1.0",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;CECILL-1.0.html",
+                  "risk_rating": "3",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                }
+              ]
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;activation-1.1.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "b9352d09-4d50-4f03-9e6d-3a0209047cc3",
+          "title": "spring-boot-autoconfigure-2.3.1.RELEASE.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "6d679d6ba26235a0e81ca1d58f9c1024d9427411",
+            "library_id": "maven&#x3a;org.springframework.boot&#x3a;spring-boot-autoconfigure&#x3a;2.3.1.RELEASE&#x3a;",
+            "library": "spring-boot-autoconfigure",
+            "vendor": "org.springframework.boot",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;spring-boot-autoconfigure-2.3.1.RELEASE.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "b9545edb-70de-4de0-ac0a-022f90ddd1d5",
+          "title": "maven-model-2.0.jar",
+          "desc": "Maven Model",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "fa69aef20d04737d916ea79957ccacc4ff41aa55",
+            "library_id": "maven&#x3a;org.apache.maven&#x3a;maven-model&#x3a;2.0&#x3a;",
+            "library": "Maven Model",
+            "vendor": "org.apache.maven",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;maven-model-2.0.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "bb0ca070-f19a-40ce-a058-c7f855b56643",
+          "title": "classworlds-1.1-alpha-2.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "05adf2e681c57d7f48038b602f3ca2254ee82d47",
+            "library_id": "maven&#x3a;classworlds&#x3a;classworlds&#x3a;1.1-alpha-2&#x3a;",
+            "library": "classworlds",
+            "vendor": "classworlds",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": [
+                {
+                  "name": "BSD 4-Clause &#x22;Original&#x22; or &#x22;Old&#x22; License &#x28;BSD-4-Clause&#x29;",
+                  "spdx_id": "BSD-4-Clause",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;BSD-4-Clause.html",
+                  "risk_rating": "2",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                },
+                {
+                  "name": "MIT License",
+                  "spdx_id": "MIT",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;MIT.html",
+                  "risk_rating": "2",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                }
+              ]
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;classworlds-1.1-alpha-2.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "bf9c6956-425a-45b1-8c48-c6cddbc41cec",
+          "title": "maven-plugin-api-2.0.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "163ff2bc46c56d26e37e82a2cd79408c394a01e2",
+            "library_id": "maven&#x3a;org.apache.maven&#x3a;maven-plugin-api&#x3a;2.0&#x3a;",
+            "library": "Maven Plugin API",
+            "vendor": "org.apache.maven",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;maven-plugin-api-2.0.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "c08a27c6-e9a8-4a4d-8696-221ff9d1c6be",
+          "title": "tomcat-embed-core-9.0.36.jar",
+          "desc": "",
+          "impact": 0.58,
+          "refs": [],
+          "tags": {
+            "sha1": "cf6574dd9c4764e60c548b69da52fc07a5a0a9bd",
+            "library_id": "maven&#x3a;org.apache.tomcat.embed&#x3a;tomcat-embed-core&#x3a;9.0.36&#x3a;",
+            "library": "tomcat-embed-core",
+            "vendor": "org.apache.tomcat.embed",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
           },
           "source_location": {
             "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;tomcat-embed-core-9.0.36.jar"
@@ -2295,191 +4276,106 @@
           "results": [
             {
               "status": "failed",
-              "code_desc": "component_id: c08a27c6-e9a8-4a4d-8696-221ff9d1c6be;sha1: cf6574dd9c4764e60c548b69da52fc07a5a0a9bd\nmax_cvss_score: 5.8\nversion: 9.0.36\nlibrary: tomcat-embed-core\nvendor: org.apache.tomcat.embed\ndescription: \nadded_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;tomcat-embed-core-9.0.36.jar",
+              "code_desc": "cve_id: CVE-2020-13934\ncvss_score: 5.0\nseverity: 3\ncwe_id: \nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncve_summary: apache tomcat is vulnerable to denial of service. The HTTP&#x2f;1.1 processor is not released after an upgrade to HTTP&#x2f;2, allowing an attacker to cause a denial of service condition due to an &#x60;OutOfMemoryException&#x60; by sending a large number of upgrade requests.\nseverity_desc: Medium\nmitigation: false\nvulnerability_affects_policy_compliance: false",
               "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
-            }
-          ]
-        },
-        {
-          "id": "CVE-2020-13943",
-          "title": "CVE-2020-13943",
-          "desc": "tomcat-coyote is vulnerable to authorization bypass. The vulnerability exists as requests could contain HTTP headers of a previous request rather than the intended headers, if a HTTP&#x2f;2 client has exceeded the agreed maximum number of concurrent streams for a connection.",
-          "impact": 0.3,
-          "refs": [],
-          "tags": {
-            "cwe": "",
-            "nist": [
-              "SI-2",
-              "RA-5"
-            ]
-          },
-          "source_location": {
-            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;tomcat-embed-core-9.0.36.jar"
-          },
-          "results": [
+            },
             {
               "status": "failed",
-              "code_desc": "component_id: c08a27c6-e9a8-4a4d-8696-221ff9d1c6be;sha1: cf6574dd9c4764e60c548b69da52fc07a5a0a9bd\nmax_cvss_score: 5.8\nversion: 9.0.36\nlibrary: tomcat-embed-core\nvendor: org.apache.tomcat.embed\ndescription: \nadded_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;tomcat-embed-core-9.0.36.jar",
+              "code_desc": "cve_id: CVE-2020-13943\ncvss_score: 4.0\nseverity: 2\ncwe_id: \nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncve_summary: tomcat-coyote is vulnerable to authorization bypass. The vulnerability exists as requests could contain HTTP headers of a previous request rather than the intended headers, if a HTTP&#x2f;2 client has exceeded the agreed maximum number of concurrent streams for a connection.\nseverity_desc: Low\nmitigation: false\nvulnerability_affects_policy_compliance: false",
               "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
-            }
-          ]
-        },
-        {
-          "id": "CVE-2020-17527",
-          "title": "CVE-2020-17527",
-          "desc": "tomcat is vulnerable to denial of service. Re-use of an HTTP request header value from the previous stream received on an HTTP&#x2f;2 connection for the request associated with the subsequent stream would most likely lead to an error and the closure of the HTTP&#x2f;2 connection. It is also possible that information could leak between requests.",
-          "impact": 0.5,
-          "refs": [],
-          "tags": {
-            "cwe": "",
-            "nist": [
-              "SI-2",
-              "RA-5"
-            ]
-          },
-          "source_location": {
-            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;tomcat-embed-core-9.0.36.jar"
-          },
-          "results": [
+            },
             {
               "status": "failed",
-              "code_desc": "component_id: c08a27c6-e9a8-4a4d-8696-221ff9d1c6be;sha1: cf6574dd9c4764e60c548b69da52fc07a5a0a9bd\nmax_cvss_score: 5.8\nversion: 9.0.36\nlibrary: tomcat-embed-core\nvendor: org.apache.tomcat.embed\ndescription: \nadded_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;tomcat-embed-core-9.0.36.jar",
+              "code_desc": "cve_id: CVE-2020-17527\ncvss_score: 5.0\nseverity: 3\ncwe_id: \nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncve_summary: tomcat is vulnerable to denial of service. Re-use of an HTTP request header value from the previous stream received on an HTTP&#x2f;2 connection for the request associated with the subsequent stream would most likely lead to an error and the closure of the HTTP&#x2f;2 connection. It is also possible that information could leak between requests.\nseverity_desc: Medium\nmitigation: false\nvulnerability_affects_policy_compliance: false",
               "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
-            }
-          ]
-        },
-        {
-          "id": "CVE-2021-24122",
-          "title": "CVE-2021-24122",
-          "desc": "apache tomcat is vulnerable to information disclosure. Security constraints can be bypassed to obtain and view JSP source code in certain configurations, when serving resources from a network location using the NTFS file system. The vulnerability is caused by the insufficient validation for the &#x60;&#x3a;&#x60; character in the file path.",
-          "impact": 0.5,
-          "refs": [],
-          "tags": {
-            "cwe": "",
-            "nist": [
-              "SI-2",
-              "RA-5"
-            ]
-          },
-          "source_location": {
-            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;tomcat-embed-core-9.0.36.jar"
-          },
-          "results": [
+            },
             {
               "status": "failed",
-              "code_desc": "component_id: c08a27c6-e9a8-4a4d-8696-221ff9d1c6be;sha1: cf6574dd9c4764e60c548b69da52fc07a5a0a9bd\nmax_cvss_score: 5.8\nversion: 9.0.36\nlibrary: tomcat-embed-core\nvendor: org.apache.tomcat.embed\ndescription: \nadded_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;tomcat-embed-core-9.0.36.jar",
+              "code_desc": "cve_id: CVE-2021-24122\ncvss_score: 4.3\nseverity: 3\ncwe_id: \nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncve_summary: apache tomcat is vulnerable to information disclosure. Security constraints can be bypassed to obtain and view JSP source code in certain configurations, when serving resources from a network location using the NTFS file system. The vulnerability is caused by the insufficient validation for the &#x60;&#x3a;&#x60; character in the file path.\nseverity_desc: Medium\nmitigation: false\nvulnerability_affects_policy_compliance: false",
               "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
-            }
-          ]
-        },
-        {
-          "id": "CVE-2021-25122",
-          "title": "CVE-2021-25122",
-          "desc": "tomcat-coyote is vulnerable to information leakage. When responding to new h2c connection requests, a request mix-up occurs with h2c as the request headers and a limited amount of request body is duplicated from one request to another, resulting in the request being seen by another user.",
-          "impact": 0.5,
-          "refs": [],
-          "tags": {
-            "cwe": "",
-            "nist": [
-              "SI-2",
-              "RA-5"
-            ]
-          },
-          "source_location": {
-            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;tomcat-embed-core-9.0.36.jar"
-          },
-          "results": [
+            },
             {
               "status": "failed",
-              "code_desc": "component_id: c08a27c6-e9a8-4a4d-8696-221ff9d1c6be;sha1: cf6574dd9c4764e60c548b69da52fc07a5a0a9bd\nmax_cvss_score: 5.8\nversion: 9.0.36\nlibrary: tomcat-embed-core\nvendor: org.apache.tomcat.embed\ndescription: \nadded_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;tomcat-embed-core-9.0.36.jar",
+              "code_desc": "cve_id: CVE-2021-25122\ncvss_score: 5.0\nseverity: 3\ncwe_id: \nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncve_summary: tomcat-coyote is vulnerable to information leakage. When responding to new h2c connection requests, a request mix-up occurs with h2c as the request headers and a limited amount of request body is duplicated from one request to another, resulting in the request being seen by another user.\nseverity_desc: Medium\nmitigation: false\nvulnerability_affects_policy_compliance: false",
               "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
-            }
-          ]
-        },
-        {
-          "id": "CVE-2021-25329",
-          "title": "CVE-2021-25329",
-          "desc": "tomcat9 is vulnerable to remote code execution &#x28;RCE&#x29;. The vulnerability exists through the incomplete fix for CVE-2020-9484, with a configuration edge case that was highly unlikely to be used.",
-          "impact": 0.5,
-          "refs": [],
-          "tags": {
-            "cwe": "",
-            "nist": [
-              "SI-2",
-              "RA-5"
-            ]
-          },
-          "source_location": {
-            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;tomcat-embed-core-9.0.36.jar"
-          },
-          "results": [
+            },
             {
               "status": "failed",
-              "code_desc": "component_id: c08a27c6-e9a8-4a4d-8696-221ff9d1c6be;sha1: cf6574dd9c4764e60c548b69da52fc07a5a0a9bd\nmax_cvss_score: 5.8\nversion: 9.0.36\nlibrary: tomcat-embed-core\nvendor: org.apache.tomcat.embed\ndescription: \nadded_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;tomcat-embed-core-9.0.36.jar",
+              "code_desc": "cve_id: CVE-2021-25329\ncvss_score: 4.4\nseverity: 3\ncwe_id: \nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncve_summary: tomcat9 is vulnerable to remote code execution &#x28;RCE&#x29;. The vulnerability exists through the incomplete fix for CVE-2020-9484, with a configuration edge case that was highly unlikely to be used.\nseverity_desc: Medium\nmitigation: false\nvulnerability_affects_policy_compliance: false",
               "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
-            }
-          ]
-        },
-        {
-          "id": "CVE-2021-30640",
-          "title": "CVE-2021-30640",
-          "desc": "tomcat-catalina is vulnerable to access restriction bypass. Lack of proper sanitization of user provided parameter or configuration data provided by an administrator accept authentication using variations of their user name and&#x2f;or to bypass some of the protection provided by the LockOut Realm.&#xa;&#xa;",
-          "impact": 0.5,
-          "refs": [],
-          "tags": {
-            "cwe": "",
-            "nist": [
-              "SI-2",
-              "RA-5"
-            ]
-          },
-          "source_location": {
-            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;tomcat-embed-core-9.0.36.jar"
-          },
-          "results": [
+            },
             {
               "status": "failed",
-              "code_desc": "component_id: c08a27c6-e9a8-4a4d-8696-221ff9d1c6be;sha1: cf6574dd9c4764e60c548b69da52fc07a5a0a9bd\nmax_cvss_score: 5.8\nversion: 9.0.36\nlibrary: tomcat-embed-core\nvendor: org.apache.tomcat.embed\ndescription: \nadded_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;tomcat-embed-core-9.0.36.jar",
+              "code_desc": "cve_id: CVE-2021-30640\ncvss_score: 5.8\nseverity: 3\ncwe_id: \nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncve_summary: tomcat-catalina is vulnerable to access restriction bypass. Lack of proper sanitization of user provided parameter or configuration data provided by an administrator accept authentication using variations of their user name and&#x2f;or to bypass some of the protection provided by the LockOut Realm.&#xa;&#xa;\nseverity_desc: Medium\nmitigation: false\nvulnerability_affects_policy_compliance: false",
               "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
-            }
-          ]
-        },
-        {
-          "id": "CVE-2021-33037",
-          "title": "CVE-2021-33037",
-          "desc": "tomcat-coyote is vulnerable request smuggling.  Incorrect way of parsing of the HTTP transfer-encoding request header causes request smuggling when it is used with a reverse proxy and if the client declared it would only accept an HTTP&#x2f;1.0 response.",
-          "impact": 0.5,
-          "refs": [],
-          "tags": {
-            "cwe": "",
-            "nist": [
-              "SI-2",
-              "RA-5"
-            ]
-          },
-          "source_location": {
-            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;tomcat-embed-core-9.0.36.jar"
-          },
-          "results": [
+            },
             {
               "status": "failed",
-              "code_desc": "component_id: c08a27c6-e9a8-4a4d-8696-221ff9d1c6be;sha1: cf6574dd9c4764e60c548b69da52fc07a5a0a9bd\nmax_cvss_score: 5.8\nversion: 9.0.36\nlibrary: tomcat-embed-core\nvendor: org.apache.tomcat.embed\ndescription: \nadded_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;tomcat-embed-core-9.0.36.jar",
+              "code_desc": "cve_id: CVE-2021-33037\ncvss_score: 5.0\nseverity: 3\ncwe_id: \nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncve_summary: tomcat-coyote is vulnerable request smuggling.  Incorrect way of parsing of the HTTP transfer-encoding request header causes request smuggling when it is used with a reverse proxy and if the client declared it would only accept an HTTP&#x2f;1.0 response.\nseverity_desc: Medium\nmitigation: false\nvulnerability_affects_policy_compliance: false",
               "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
             }
           ]
         },
         {
-          "id": "CVE-2021-29425",
-          "title": "CVE-2021-29425",
-          "desc": "commons-io is vulnerable to directory traversal. Invoking the method &#x60;FileNameUtils.normalize&#x60; with a malicious input string would potentially allow access to files within the parent directory.",
-          "impact": 0.5,
+          "id": "c4aa313a-7457-4444-9df3-1bd931ed88d6",
+          "title": "log4j-api-2.13.3.jar",
+          "desc": "",
+          "impact": 0,
           "refs": [],
           "tags": {
-            "cwe": "",
+            "sha1": "ec1508160b93d274b1add34419b897bae84c6ca9",
+            "library_id": "maven&#x3a;org.apache.logging.log4j&#x3a;log4j-api&#x3a;2.13.3&#x3a;",
+            "library": "Apache Log4j API",
+            "vendor": "org.apache.logging.log4j",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
             "nist": [
               "SI-2",
               "RA-5"
-            ]
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;log4j-api-2.13.3.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "c7ce22bf-c9d5-4465-9fb7-5aedd8261079",
+          "title": "commons-io-2.4.jar",
+          "desc": "The Commons IO library contains utility classes, stream implementations, file filters, &#xa;file comparators, endian transformation classes, and much more.",
+          "impact": 0.58,
+          "refs": [],
+          "tags": {
+            "sha1": "b1b6ea3b7e4aa4f492509a4952029cd8e48019ad",
+            "library_id": "maven&#x3a;commons-io&#x3a;commons-io&#x3a;2.4&#x3a;",
+            "library": "Apache Commons IO",
+            "vendor": "commons-io",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;19 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
           },
           "source_location": {
             "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;commons-io-2.4.jar"
@@ -2487,47 +4383,109 @@
           "results": [
             {
               "status": "failed",
-              "code_desc": "component_id: c7ce22bf-c9d5-4465-9fb7-5aedd8261079;sha1: b1b6ea3b7e4aa4f492509a4952029cd8e48019ad\nmax_cvss_score: 5.8\nversion: 2.4\nlibrary: Apache Commons IO\nvendor: commons-io\ndescription: The Commons IO library contains utility classes, stream implementations, file filters, &#xa;file comparators, endian transformation classes, and much more.\nadded_date: 2021-12-29 22&#x3a;18&#x3a;19 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;commons-io-2.4.jar",
+              "code_desc": "cve_id: CVE-2021-29425\ncvss_score: 5.8\nseverity: 3\ncwe_id: \nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;19 UTC\ncve_summary: commons-io is vulnerable to directory traversal. Invoking the method &#x60;FileNameUtils.normalize&#x60; with a malicious input string would potentially allow access to files within the parent directory.\nseverity_desc: Medium\nmitigation: false\nvulnerability_affects_policy_compliance: false",
               "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
-            }
-          ]
-        },
-        {
-          "id": "SRCCLR-SID-5295",
-          "title": "SRCCLR-SID-5295",
-          "desc": "commons-io is vulnerable to remote code execution &#x28;RCE&#x29; attacks. These attacks are possible because the library doesn&#x27;t restrict the classes which can be accepted when deserializing a binary.",
-          "impact": 0.5,
-          "refs": [],
-          "tags": {
-            "cwe": "",
-            "nist": [
-              "SI-2",
-              "RA-5"
-            ]
-          },
-          "source_location": {
-            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;commons-io-2.4.jar"
-          },
-          "results": [
+            },
             {
               "status": "failed",
-              "code_desc": "component_id: c7ce22bf-c9d5-4465-9fb7-5aedd8261079;sha1: b1b6ea3b7e4aa4f492509a4952029cd8e48019ad\nmax_cvss_score: 5.8\nversion: 2.4\nlibrary: Apache Commons IO\nvendor: commons-io\ndescription: The Commons IO library contains utility classes, stream implementations, file filters, &#xa;file comparators, endian transformation classes, and much more.\nadded_date: 2021-12-29 22&#x3a;18&#x3a;19 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;commons-io-2.4.jar",
+              "code_desc": "cve_id: SRCCLR-SID-5295\ncvss_score: 5.1\nseverity: 3\ncwe_id: \nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;19 UTC\ncve_summary: commons-io is vulnerable to remote code execution &#x28;RCE&#x29; attacks. These attacks are possible because the library doesn&#x27;t restrict the classes which can be accepted when deserializing a binary.\nseverity_desc: Medium\nmitigation: false\nvulnerability_affects_policy_compliance: false",
               "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
             }
           ]
         },
         {
-          "id": "CVE-2016-1000031",
-          "title": "CVE-2016-1000031",
-          "desc": "Apache Commons FileUpload before 1.3.3 DiskFileItem File Manipulation Remote Code Execution",
-          "impact": 0.7,
+          "id": "c8eddd7c-a541-4367-82a3-1ce00d4526b1",
+          "title": "ecj-3.18.0.jar",
+          "desc": "Eclipse Compiler for Java&#x28;TM&#x29;",
+          "impact": 0,
           "refs": [],
           "tags": {
-            "cwe": "CWE-284",
+            "sha1": "4d5d0911b30db24c8eb844702c8adf8e434314ff",
+            "library_id": "maven&#x3a;org.eclipse.jdt&#x3a;ecj&#x3a;3.18.0&#x3a;",
+            "library": "Eclipse Compiler for Java&#x28;TM&#x29;",
+            "vendor": "org.eclipse.jdt",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
             "nist": [
               "SI-2",
               "RA-5"
-            ]
+            ],
+            "licenses": {
+              "license": {
+                "name": "Eclipse Public License 2.0",
+                "spdx_id": "EPL-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;EPL-2.0.html",
+                "risk_rating": "3",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;ecj-3.18.0.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "c8f4b14a-fd9f-485f-b06b-95ce0e42b6a2",
+          "title": "slf4j-api-1.7.30.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "b5a4b6d16ab13e34a88fae84c35cd5d68cac922c",
+            "library_id": "maven&#x3a;org.slf4j&#x3a;slf4j-api&#x3a;1.7.30&#x3a;",
+            "library": "SLF4J API Module",
+            "vendor": "org.slf4j",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "MIT License",
+                "spdx_id": "MIT",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;MIT.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;slf4j-api-1.7.30.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "c9daab8d-4347-44b0-ae8f-3d9a6060193f",
+          "title": "commons-fileupload-1.3.2.jar",
+          "desc": "The Apache Commons FileUpload component provides a simple yet flexible means of adding support for multipart&#xa;    file upload functionality to servlets and web applications.",
+          "impact": 0.75,
+          "refs": [],
+          "tags": {
+            "sha1": "5d7491ed6ebd02b6a8d2305f8e6b7fe5dbd95f72",
+            "library_id": "maven&#x3a;commons-fileupload&#x3a;commons-fileupload&#x3a;1.3.2&#x3a;",
+            "library": "Apache Commons FileUpload",
+            "vendor": "commons-fileupload",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;19 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
           },
           "source_location": {
             "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;commons-fileupload-1.3.2.jar"
@@ -2535,23 +4493,138 @@
           "results": [
             {
               "status": "failed",
-              "code_desc": "component_id: c9daab8d-4347-44b0-ae8f-3d9a6060193f;sha1: 5d7491ed6ebd02b6a8d2305f8e6b7fe5dbd95f72\nmax_cvss_score: 7.5\nversion: 1.3.2\nlibrary: Apache Commons FileUpload\nvendor: commons-fileupload\ndescription: The Apache Commons FileUpload component provides a simple yet flexible means of adding support for multipart&#xa;    file upload functionality to servlets and web applications.\nadded_date: 2021-12-29 22&#x3a;18&#x3a;19 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;commons-fileupload-1.3.2.jar",
+              "code_desc": "cve_id: CVE-2016-1000031\ncvss_score: 7.5\nseverity: 4\ncwe_id: CWE-284\nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;19 UTC\ncve_summary: Apache Commons FileUpload before 1.3.3 DiskFileItem File Manipulation Remote Code Execution\nseverity_desc: High\nmitigation: false\nvulnerability_affects_policy_compliance: false",
               "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
             }
           ]
         },
         {
-          "id": "CVE-2018-1002200",
-          "title": "CVE-2018-1002200",
-          "desc": "plexus-archiver before 3.6.0 is vulnerable to directory traversal, allowing attackers to write to arbitrary files via a ..&#x2f; &#x28;dot dot slash&#x29; in an archive entry that is mishandled during extraction. This vulnerability is also known as &#x27;Zip-Slip&#x27;.",
-          "impact": 0.5,
+          "id": "ca8c30b8-db2a-4378-8700-5c971d4a3257",
+          "title": "jakarta.annotation-api-1.3.5.jar",
+          "desc": "",
+          "impact": 0,
           "refs": [],
           "tags": {
-            "cwe": "CWE-22",
+            "sha1": "59eb84ee0d616332ff44aba065f3888cf002cd2d",
+            "library_id": "maven&#x3a;jakarta.annotation&#x3a;jakarta.annotation-api&#x3a;1.3.5&#x3a;",
+            "library": "Jakarta Annotations API",
+            "vendor": "jakarta.annotation",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
             "nist": [
               "SI-2",
               "RA-5"
-            ]
+            ],
+            "licenses": {
+              "license": [
+                {
+                  "name": "Eclipse Public License 2.0",
+                  "spdx_id": "EPL-2.0",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;EPL-2.0.html",
+                  "risk_rating": "3",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                },
+                {
+                  "name": "GNU General Public License with Classpath Exceptions version 2.0",
+                  "spdx_id": "GPL-2.0-with-classpath-exception",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;GPL-2.0-with-classpath-exception.html",
+                  "risk_rating": "4",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                }
+              ]
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;jakarta.annotation-api-1.3.5.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "cf0f4e71-354e-4d78-adb6-4d6155418e16",
+          "title": "commons-codec-1.14.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "3cb1181b2141a7e752f5bdc998b7ef1849f726cf",
+            "library_id": "maven&#x3a;commons-codec&#x3a;commons-codec&#x3a;1.14&#x3a;",
+            "library": "Apache Commons Codec",
+            "vendor": "commons-codec",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;19 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;commons-codec-1.14.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "d3d7a9ab-12fd-41a3-a344-7e30c4d07dbd",
+          "title": "maven-archiver-2.0.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "e68a6b39a72aa99bab1e28083e400bb72e9a2da3",
+            "library_id": "maven&#x3a;org.apache.maven&#x3a;maven-archiver&#x3a;2.0&#x3a;",
+            "library": "Apache Maven Archiver",
+            "vendor": "org.apache.maven",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;19 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;maven-archiver-2.0.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "d3ff7550-8371-4531-97c7-c20d70b6e537",
+          "title": "plexus-archiver-1.0-alpha-3.jar",
+          "desc": "",
+          "impact": 0.43,
+          "refs": [],
+          "tags": {
+            "sha1": "0f9ac8399aae46521a8d50703e68e1849722580e",
+            "library_id": "maven&#x3a;org.codehaus.plexus&#x3a;plexus-archiver&#x3a;1.0-alpha-3&#x3a;",
+            "library": "Plexus Archiver Component",
+            "vendor": "org.codehaus.plexus",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": ""
           },
           "source_location": {
             "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;plexus-archiver-1.0-alpha-3.jar"
@@ -2559,23 +4632,71 @@
           "results": [
             {
               "status": "failed",
-              "code_desc": "component_id: d3ff7550-8371-4531-97c7-c20d70b6e537;sha1: 0f9ac8399aae46521a8d50703e68e1849722580e\nmax_cvss_score: 4.3\nversion: 1.0-alpha-3\nlibrary: Plexus Archiver Component\nvendor: org.codehaus.plexus\ndescription: \nadded_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;plexus-archiver-1.0-alpha-3.jar",
+              "code_desc": "cve_id: CVE-2018-1002200\ncvss_score: 4.3\nseverity: 3\ncwe_id: CWE-22\nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncve_summary: plexus-archiver before 3.6.0 is vulnerable to directory traversal, allowing attackers to write to arbitrary files via a ..&#x2f; &#x28;dot dot slash&#x29; in an archive entry that is mishandled during extraction. This vulnerability is also known as &#x27;Zip-Slip&#x27;.\nseverity_desc: Medium\nmitigation: false\nvulnerability_affects_policy_compliance: false",
               "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
             }
           ]
         },
         {
-          "id": "CVE-2021-42340",
-          "title": "CVE-2021-42340",
-          "desc": "tomcat-websocket is vulnerable to denial of service &#x28;DoS&#x29; attacks. An out of memory &#x28;OOM&#x29; occurs as the internal upgrade handler doesn&#x27;t close the associated web connection on destroy causing an application crash.",
-          "impact": 0.5,
+          "id": "d59b6b9c-0c8a-49b4-b4fb-460bde0608e9",
+          "title": "maven-artifact-2.0.jar",
+          "desc": "",
+          "impact": 0,
           "refs": [],
           "tags": {
-            "cwe": "",
+            "sha1": "7a8be3d404ff84f3fc329204a5ff42e321e1b1ca",
+            "library_id": "maven&#x3a;org.apache.maven&#x3a;maven-artifact&#x3a;2.0&#x3a;",
+            "library": "Maven Artifact",
+            "vendor": "org.apache.maven",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
             "nist": [
               "SI-2",
               "RA-5"
-            ]
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;maven-artifact-2.0.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "d6ad47d1-6990-4a6d-b248-aa8cb1a968c1",
+          "title": "tomcat-websocket-9.0.36.jar",
+          "desc": "",
+          "impact": 0.5,
+          "refs": [],
+          "tags": {
+            "sha1": "",
+            "library_id": "maven&#x3a;org.apache.tomcat&#x3a;tomcat-websocket&#x3a;9.0.36&#x3a;",
+            "library": "tomcat-websocket",
+            "vendor": "org.apache.tomcat",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;19 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
           },
           "source_location": {
             "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;tomcat-embed-websocket-9.0.36.jar&#x3a;tomcat-websocket-9.0.36.jar"
@@ -2583,23 +4704,408 @@
           "results": [
             {
               "status": "failed",
-              "code_desc": "component_id: d6ad47d1-6990-4a6d-b248-aa8cb1a968c1;sha1: \nmax_cvss_score: 5.0\nversion: 9.0.36\nlibrary: tomcat-websocket\nvendor: org.apache.tomcat\ndescription: \nadded_date: 2021-12-29 22&#x3a;18&#x3a;19 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;tomcat-embed-websocket-9.0.36.jar&#x3a;tomcat-websocket-9.0.36.jar",
+              "code_desc": "cve_id: CVE-2020-13935\ncvss_score: 5.0\nseverity: 3\ncwe_id: \nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;19 UTC\ncve_summary: apache tomcat is vulnerable to denial of service. An infinite loop to occurs when invalid payload lengths are parsed. An attacker is able to cause a denial of service condition in the application via malicious WebSocket frames with invalid payload lengths.\nseverity_desc: Medium\nmitigation: false\nvulnerability_affects_policy_compliance: false",
+              "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
+            },
+            {
+              "status": "failed",
+              "code_desc": "cve_id: CVE-2021-42340\ncvss_score: 5.0\nseverity: 3\ncwe_id: \nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;19 UTC\ncve_summary: tomcat-websocket is vulnerable to denial of service &#x28;DoS&#x29; attacks. An out of memory &#x28;OOM&#x29; occurs as the internal upgrade handler doesn&#x27;t close the associated web connection on destroy causing an application crash.\nseverity_desc: Medium\nmitigation: false\nvulnerability_affects_policy_compliance: false",
               "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
             }
           ]
         },
         {
-          "id": "CVE-2020-5421",
-          "title": "CVE-2020-5421",
-          "desc": "spring-web is vulnerable to Reflected File Download &#x28;RFD&#x29; attack. An incomplete fix of CVE-2015-5211 allows an attacker to bypass the protection against RFD attack via the &#x60;jsessionid&#x60; path parameter.&#xa;&#xa;",
-          "impact": 0.3,
+          "id": "d7da02ab-ef18-4e19-a9d3-cebc46975778",
+          "title": "jackson-core-2.11.0.jar",
+          "desc": "",
+          "impact": 0,
           "refs": [],
           "tags": {
-            "cwe": "",
+            "sha1": "f84302e14648f9f63c0c73951054aeb2ff0b810a",
+            "library_id": "maven&#x3a;com.fasterxml.jackson.core&#x3a;jackson-core&#x3a;2.11.0&#x3a;",
+            "library": "Jackson-core",
+            "vendor": "com.fasterxml.jackson.core",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
             "nist": [
               "SI-2",
               "RA-5"
-            ]
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;jackson-core-2.11.0.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "da356a8c-2a4f-4ae6-8e3b-6e343832bd2a",
+          "title": "spring-jcl-5.2.7.RELEASE.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "72282e1f89c58284632220437b5a1e8066c53d7d",
+            "library_id": "maven&#x3a;org.springframework&#x3a;spring-jcl&#x3a;5.2.7.RELEASE&#x3a;",
+            "library": "Spring Commons Logging Bridge",
+            "vendor": "org.springframework",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;spring-jcl-5.2.7.RELEASE.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "da8ad165-d5a1-4651-9897-d074b84ae47f",
+          "title": "mail-1.4.7.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "9add058589d5d85adeb625859bf2c5eeaaedf12d",
+            "library_id": "maven&#x3a;javax.mail&#x3a;mail&#x3a;1.4.7&#x3a;",
+            "library": "JavaMail API &#x28;compat&#x29;",
+            "vendor": "javax.mail",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": [
+                {
+                  "name": "BSD 3-Clause &#x22;New&#x22; or &#x22;Revised&#x22; License",
+                  "spdx_id": "BSD-3-Clause",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;BSD-3-Clause.html",
+                  "risk_rating": "2",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                },
+                {
+                  "name": "Common Development and Distribution License 1.0",
+                  "spdx_id": "CDDL-1.0",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;CDDL-1.0.html",
+                  "risk_rating": "3",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                },
+                {
+                  "name": "CeCILL Free Software License Agreement v1.0",
+                  "spdx_id": "CECILL-1.0",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;CECILL-1.0.html",
+                  "risk_rating": "3",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                },
+                {
+                  "name": "Eclipse Distribution License &#x28;EDL&#x29;",
+                  "spdx_id": "EDL",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;www.eclipse.org&#x2f;org&#x2f;documents&#x2f;edl-v10.php",
+                  "risk_rating": "2",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                },
+                {
+                  "name": "Eclipse Public License 2.0",
+                  "spdx_id": "EPL-2.0",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;EPL-2.0.html",
+                  "risk_rating": "3",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                },
+                {
+                  "name": "GNU General Public License with Classpath Exceptions version 2.0",
+                  "spdx_id": "GPL-2.0-with-classpath-exception",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;GPL-2.0-with-classpath-exception.html",
+                  "risk_rating": "4",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                }
+              ]
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;mail-1.4.7.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "e3dcb8c9-9d7d-4f2c-832c-fb638c4b5761",
+          "title": "spring-boot-starter-logging-2.3.1.RELEASE.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "03f242a91ffddf7485fde1367e1354c7e13024c8",
+            "library_id": "maven&#x3a;org.springframework.boot&#x3a;spring-boot-starter-logging&#x3a;2.3.1.RELEASE&#x3a;",
+            "library": "spring-boot-starter-logging",
+            "vendor": "org.springframework.boot",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;spring-boot-starter-logging-2.3.1.RELEASE.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "e4889cf9-7ffc-4de7-b65f-e9a3568b304e",
+          "title": "snakeyaml-1.26.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "a78a8747147d2c5807683e76ec2b633e95c14fe9",
+            "library_id": "maven&#x3a;org.yaml&#x3a;snakeyaml&#x3a;1.26&#x3a;",
+            "library": "SnakeYAML",
+            "vendor": "org.yaml",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;snakeyaml-1.26.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "e5ecc7cd-f1f1-469d-92d5-4a081b2bd69d",
+          "title": "smtp-1.4.7.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "",
+            "library_id": "maven&#x3a;com.sun.mail&#x3a;smtp&#x3a;1.4.7&#x3a;",
+            "library": "Jakarta Mail API smtp provider",
+            "vendor": "com.sun.mail",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;19 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": [
+                {
+                  "name": "Common Development and Distribution License 1.0",
+                  "spdx_id": "CDDL-1.0",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;CDDL-1.0.html",
+                  "risk_rating": "3",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                },
+                {
+                  "name": "CeCILL Free Software License Agreement v1.0",
+                  "spdx_id": "CECILL-1.0",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;CECILL-1.0.html",
+                  "risk_rating": "3",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                },
+                {
+                  "name": "GNU General Public License v2.0 only",
+                  "spdx_id": "GPL-2.0",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;GPL-2.0.html",
+                  "risk_rating": "4",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                },
+                {
+                  "name": "GNU General Public License with Classpath Exceptions version 2.0",
+                  "spdx_id": "GPL-2.0-with-classpath-exception",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;GPL-2.0-with-classpath-exception.html",
+                  "risk_rating": "4",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                }
+              ]
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;mail-1.4.7.jar&#x3a;smtp-1.4.7.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "e8e5529c-07b3-46e9-a6b3-59a8152b8265",
+          "title": "maven-project-2.0.jar",
+          "desc": "This library is used to not only read Maven project object model files, but to assemble inheritence&#xa;    and to retrieve remote models as required.",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "ab4f37a40999caefc6cd65863dcacc591572171a",
+            "library_id": "maven&#x3a;org.apache.maven&#x3a;maven-project&#x3a;2.0&#x3a;",
+            "library": "Maven Project Builder",
+            "vendor": "org.apache.maven",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;19 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;maven-project-2.0.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "ec7cced4-487b-4c4c-b2c0-f6d1fc9a935f",
+          "title": "tomcat-el-api-9.0.36.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "",
+            "library_id": "maven&#x3a;org.apache.tomcat&#x3a;tomcat-el-api&#x3a;9.0.36&#x3a;",
+            "library": "tomcat-el-api",
+            "vendor": "org.apache.tomcat",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;21 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib-provided&#x2f;tomcat-embed-el-9.0.36.jar&#x3a;tomcat-el-api-9.0.36.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "edd26e9d-0c8f-4e6e-96c3-67603d61499c",
+          "title": "jackson-databind-2.11.0.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "8f5aaf3878b0647ff3a16610af53b1a5c05d9f15",
+            "library_id": "maven&#x3a;com.fasterxml.jackson.core&#x3a;jackson-databind&#x3a;2.11.0&#x3a;",
+            "library": "jackson-databind",
+            "vendor": "com.fasterxml.jackson.core",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;jackson-databind-2.11.0.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "ee9b8868-dd77-47d1-8019-7b21861a87f4",
+          "title": "spring-web-5.2.7.RELEASE.jar",
+          "desc": "",
+          "impact": 0.45999999999999996,
+          "refs": [],
+          "tags": {
+            "sha1": "050a27c77e1731f3b7af5c2ae7caf6fe59bcc309",
+            "library_id": "maven&#x3a;org.springframework&#x3a;spring-web&#x3a;5.2.7.RELEASE&#x3a;",
+            "library": "Spring Web",
+            "vendor": "org.springframework",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
           },
           "source_location": {
             "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;spring-web-5.2.7.RELEASE.jar"
@@ -2607,47 +5113,43 @@
           "results": [
             {
               "status": "failed",
-              "code_desc": "component_id: ee9b8868-dd77-47d1-8019-7b21861a87f4;sha1: 050a27c77e1731f3b7af5c2ae7caf6fe59bcc309\nmax_cvss_score: 4.6\nversion: 5.2.7.RELEASE\nlibrary: Spring Web\nvendor: org.springframework\ndescription: \nadded_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;spring-web-5.2.7.RELEASE.jar",
+              "code_desc": "cve_id: CVE-2020-5421\ncvss_score: 3.6\nseverity: 2\ncwe_id: \nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncve_summary: spring-web is vulnerable to Reflected File Download &#x28;RFD&#x29; attack. An incomplete fix of CVE-2015-5211 allows an attacker to bypass the protection against RFD attack via the &#x60;jsessionid&#x60; path parameter.&#xa;&#xa;\nseverity_desc: Low\nmitigation: false\nvulnerability_affects_policy_compliance: false",
               "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
-            }
-          ]
-        },
-        {
-          "id": "CVE-2021-22118",
-          "title": "CVE-2021-22118",
-          "desc": "spring-web is vulnerable to privilege escalation. Creating or recreating the temporary storage directory creates multiple instances collision which allows a locally authenticated malicious user to read or modify files being uploaded or overwrite arbitrary files with multipart request data.",
-          "impact": 0.5,
-          "refs": [],
-          "tags": {
-            "cwe": "",
-            "nist": [
-              "SI-2",
-              "RA-5"
-            ]
-          },
-          "source_location": {
-            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;spring-web-5.2.7.RELEASE.jar"
-          },
-          "results": [
+            },
             {
               "status": "failed",
-              "code_desc": "component_id: ee9b8868-dd77-47d1-8019-7b21861a87f4;sha1: 050a27c77e1731f3b7af5c2ae7caf6fe59bcc309\nmax_cvss_score: 4.6\nversion: 5.2.7.RELEASE\nlibrary: Spring Web\nvendor: org.springframework\ndescription: \nadded_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;spring-web-5.2.7.RELEASE.jar",
+              "code_desc": "cve_id: CVE-2021-22118\ncvss_score: 4.6\nseverity: 3\ncwe_id: \nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncve_summary: spring-web is vulnerable to privilege escalation. Creating or recreating the temporary storage directory creates multiple instances collision which allows a locally authenticated malicious user to read or modify files being uploaded or overwrite arbitrary files with multipart request data.\nseverity_desc: Medium\nmitigation: false\nvulnerability_affects_policy_compliance: false",
               "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
             }
           ]
         },
         {
-          "id": "CVE-2017-1000487",
-          "title": "CVE-2017-1000487",
-          "desc": "Plexus-utils before 3.0.16 is vulnerable to command injection because it does not correctly process the contents of double quoted strings.",
-          "impact": 0.7,
+          "id": "eebcd29b-5d6b-4c58-b15b-897448f67f4f",
+          "title": "plexus-utils-1.0.4.jar",
+          "desc": "",
+          "impact": 0.75,
           "refs": [],
           "tags": {
-            "cwe": "CWE-77",
+            "sha1": "60783e4623f2e44063cf2d43d9fbacb2816855c2",
+            "library_id": "maven&#x3a;org.codehaus.plexus&#x3a;plexus-utils&#x3a;1.0.4&#x3a;",
+            "library": "Plexus Common Utilities",
+            "vendor": "org.codehaus.plexus",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
             "nist": [
               "SI-2",
               "RA-5"
-            ]
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 1.1",
+                "spdx_id": "Apache-1.1",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-1.1.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
           },
           "source_location": {
             "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;plexus-utils-1.0.4.jar"
@@ -2655,13 +5157,221 @@
           "results": [
             {
               "status": "failed",
-              "code_desc": "component_id: eebcd29b-5d6b-4c58-b15b-897448f67f4f;sha1: 60783e4623f2e44063cf2d43d9fbacb2816855c2\nmax_cvss_score: 7.5\nversion: 1.0.4\nlibrary: Plexus Common Utilities\nvendor: org.codehaus.plexus\ndescription: \nadded_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncomponent_affects_policy_compliance: falsefile_path: verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;plexus-utils-1.0.4.jar",
+              "code_desc": "cve_id: CVE-2017-1000487\ncvss_score: 7.5\nseverity: 4\ncwe_id: CWE-77\nfirst_found_date: 2021-12-29 22&#x3a;18&#x3a;20 UTC\ncve_summary: Plexus-utils before 3.0.16 is vulnerable to command injection because it does not correctly process the contents of double quoted strings.\nseverity_desc: High\nmitigation: false\nvulnerability_affects_policy_compliance: false",
               "start_time": "2021-12-29 22&#x3a;16&#x3a;36 UTC"
             }
           ]
+        },
+        {
+          "id": "f4bb26b8-67cb-4128-86a9-cadd07bf9ef6",
+          "title": "javax.activation-api-1.2.0.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "85262acf3ca9816f9537ca47d5adeabaead7cb16",
+            "library_id": "maven&#x3a;javax.activation&#x3a;javax.activation-api&#x3a;1.2.0&#x3a;",
+            "library": "JavaBeans Activation Framework API jar",
+            "vendor": "javax.activation",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;21 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": [
+                {
+                  "name": "Common Development and Distribution License 1.0",
+                  "spdx_id": "CDDL-1.0",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;CDDL-1.0.html",
+                  "risk_rating": "3",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                },
+                {
+                  "name": "CeCILL Free Software License Agreement v1.0",
+                  "spdx_id": "CECILL-1.0",
+                  "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;CECILL-1.0.html",
+                  "risk_rating": "3",
+                  "mitigation": "false",
+                  "license_affects_policy_compliance": "false"
+                }
+              ]
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;javax.activation-api-1.2.0.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "f5eb3ae0-bbc8-422a-a186-1f6575c4af6a",
+          "title": "wagon-provider-api-1.0-alpha-5.jar",
+          "desc": "Tools to manage artifacts and deployment",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "30d03be3128389dae0419701b1cb4b3034e1cabc",
+            "library_id": "maven&#x3a;org.apache.maven.wagon&#x3a;wagon-provider-api&#x3a;1.0-alpha-5&#x3a;",
+            "library": "Apache Maven Wagon &#x3a;&#x3a; API",
+            "vendor": "org.apache.maven.wagon",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;wagon-provider-api-1.0-alpha-5.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "f617d7be-e92d-42f9-8cfd-2ce03ad8a7e2",
+          "title": "spring-expression-5.2.7.RELEASE.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "c98d7b10f959f9bedfbbbd4d723cf7a1f17a1f71",
+            "library_id": "maven&#x3a;org.springframework&#x3a;spring-expression&#x3a;5.2.7.RELEASE&#x3a;",
+            "library": "Spring Expression Language &#x28;SpEL&#x29;",
+            "vendor": "org.springframework",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;spring-expression-5.2.7.RELEASE.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "fb8e54c1-dd82-4897-87dc-2c4ac4f4830f",
+          "title": "spring-aop-5.2.7.RELEASE.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "9cf69f8e888091684c05f0a287bb638502e90725",
+            "library_id": "maven&#x3a;org.springframework&#x3a;spring-aop&#x3a;5.2.7.RELEASE&#x3a;",
+            "library": "Spring AOP",
+            "vendor": "org.springframework",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;spring-aop-5.2.7.RELEASE.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "fcd10677-f7e1-4a35-874b-e2b5c1475400",
+          "title": "spring-boot-loader-2.3.1.RELEASE.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "",
+            "library_id": "maven&#x3a;org.springframework.boot&#x3a;spring-boot-loader&#x3a;2.3.1.RELEASE&#x3a;",
+            "library": "spring-boot-loader",
+            "vendor": "org.springframework.boot",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x3a;spring-boot-loader-2.3.1.RELEASE.jar"
+          },
+          "results": []
+        },
+        {
+          "id": "fe7a7b24-afac-44ca-b650-54ef440328d7",
+          "title": "spring-context-5.2.7.RELEASE.jar",
+          "desc": "",
+          "impact": 0,
+          "refs": [],
+          "tags": {
+            "sha1": "7fd9c4ea311a5d9ab92770be7fc93cc53db334f9",
+            "library_id": "maven&#x3a;org.springframework&#x3a;spring-context&#x3a;5.2.7.RELEASE&#x3a;",
+            "library": "Spring Context",
+            "vendor": "org.springframework",
+            "component_affects_policy_compliance": "",
+            "added_date": "2021-12-29 22&#x3a;18&#x3a;20 UTC",
+            "nist": [
+              "SI-2",
+              "RA-5"
+            ],
+            "licenses": {
+              "license": {
+                "name": "Apache License 2.0",
+                "spdx_id": "Apache-2.0",
+                "license_url": "https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html",
+                "risk_rating": "2",
+                "mitigation": "false",
+                "license_affects_policy_compliance": "false"
+              }
+            }
+          },
+          "source_location": {
+            "ref": "verademo.war&#x23;zip&#x3a;WEB-INF&#x2f;lib&#x2f;spring-context-5.2.7.RELEASE.jar"
+          },
+          "results": []
         }
       ],
-      "sha256": "a7d7cb22649bd295cf929d2bebfaa306a900b2ad187a064346de158160281eff"
+      "sha256": "5ff531df33b7cbbeb95f853c84c1e1c227a1c9dcfe219e29c7f724e4e1db480d"
     }
   ]
 }


### PR DESCRIPTION
Current mapper does not address all use cases,  changing it back to include licenses and be formatted closer to original xml is important for our team. 