### PR TITLE
only pull open vulnerabilities for sonarqube2hdf as closed vulnerabilities

### DIFF
--- a/libs/hdf-converters/src/sonarqube-mapper.ts
+++ b/libs/hdf-converters/src/sonarqube-mapper.ts
@@ -130,6 +130,7 @@ export class SonarQubeResults {
           params: {
             componentKeys: this.projectId,
             types: 'VULNERABILITY',
+            statuses: 'OPEN,REOPENED',
             p: page,
             ...(this.branchName && {branch: this.branchName}),
             ...(this.pullRequestID && {pullRequest: this.pullRequestID})

--- a/libs/hdf-converters/src/sonarqube-mapper.ts
+++ b/libs/hdf-converters/src/sonarqube-mapper.ts
@@ -130,7 +130,7 @@ export class SonarQubeResults {
           params: {
             componentKeys: this.projectId,
             types: 'VULNERABILITY',
-            statuses: 'OPEN,REOPENED',
+            statuses: 'OPEN,REOPENED,CONFIRMED,RESOLVED',
             p: page,
             ...(this.branchName && {branch: this.branchName}),
             ...(this.pullRequestID && {pullRequest: this.pullRequestID})

--- a/test/support/server/SonarQube.json
+++ b/test/support/server/SonarQube.json
@@ -1,5 +1,5 @@
 {
-  "/api/issues/search?componentKeys=xss&types=VULNERABILITY&p=1": {
+  "/api/issues/search?componentKeys=xss&types=VULNERABILITY&statuses=OPEN,REOPENED&p=1": {
     "total": 1,
     "p": 1,
     "ps": 100,
@@ -61,7 +61,7 @@
     ],
     "facets": []
   },
-  "/api/issues/search?componentKeys=libc_unix&types=VULNERABILITY&p=1&branch=release": {
+  "/api/issues/search?componentKeys=libc_unix&types=VULNERABILITY&statuses=OPEN,REOPENED&p=1&branch=release": {
     "total": 2,
     "p": 1,
     "ps": 100,
@@ -155,7 +155,7 @@
     ],
     "facets": []
   },
-  "/api/issues/search?componentKeys=libc_unix&types=VULNERABILITY&p=1&pullRequest=123": {
+  "/api/issues/search?componentKeys=libc_unix&types=VULNERABILITY&statuses=OPEN,REOPENED&p=1&pullRequest=123": {
     "total": 2,
     "p": 1,
     "ps": 100,

--- a/test/support/server/SonarQube.json
+++ b/test/support/server/SonarQube.json
@@ -1,5 +1,5 @@
 {
-  "/api/issues/search?componentKeys=xss&types=VULNERABILITY&statuses=OPEN,REOPENED&p=1": {
+  "/api/issues/search?componentKeys=xss&types=VULNERABILITY&statuses=OPEN,REOPENED,CONFIRMED,RESOLVED&p=1": {
     "total": 1,
     "p": 1,
     "ps": 100,
@@ -61,7 +61,7 @@
     ],
     "facets": []
   },
-  "/api/issues/search?componentKeys=libc_unix&types=VULNERABILITY&statuses=OPEN,REOPENED&p=1&branch=release": {
+  "/api/issues/search?componentKeys=libc_unix&types=VULNERABILITY&statuses=OPEN,REOPENED,CONFIRMED,RESOLVED&p=1&branch=release": {
     "total": 2,
     "p": 1,
     "ps": 100,
@@ -155,7 +155,7 @@
     ],
     "facets": []
   },
-  "/api/issues/search?componentKeys=libc_unix&types=VULNERABILITY&statuses=OPEN,REOPENED&p=1&pullRequest=123": {
+  "/api/issues/search?componentKeys=libc_unix&types=VULNERABILITY&statuses=OPEN,REOPENED,CONFIRMED,RESOLVED&p=1&pullRequest=123": {
     "total": 2,
     "p": 1,
     "ps": 100,


### PR DESCRIPTION
Issue
===

Sonarqube2hdf failing with bad request caused by pulling closed vulnerabilities. The source pulls **all** the vulnerabilities, then for each vulnerability pulls the source code associated with it.  Vulnerabilities which are closed  causes an error because the file it was in no longer exists. This is the cause of the  BAD REQUEST is requesting source that no longer exists.

Solution
======

Only pull open and reopened vulnerabilities, this will ensure that the files which the vulnerabilities exists will still exist.
