### PR TITLE
Updates for programmatic API creation use case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ apps/frontend/public/static/export/jquery.min.js
 !.yarn/sdks
 !.yarn/versions
 .pnp.*
+
+# Database Content
+data/*

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Given that Heimdall requires at least a database service, we use Docker and Dock
 
 1. Install Docker
 
-2. Download and extract the most recent Heimdall release from our [releases page](https://github.com/mitre/heimdall2/releases).
+2. Download and extract the most recent Heimdall release from our [releases page](https://github.com/mitre/heimdall2/releases). Alternatively, you can clone this repository and navigate to the `heimdall2` folder.
 
 3. Navigate to the base folder where `docker-compose.yml` is located
 

--- a/apps/backend/src/apikeys/apikey.controller.ts
+++ b/apps/backend/src/apikeys/apikey.controller.ts
@@ -62,11 +62,11 @@ export class ApiKeyController {
     let user;
 
     if (createApiKeyDto.userId) {
-      user = await this.usersService.findById(createApiKeyDto.userId)
+      user = await this.usersService.findById(createApiKeyDto.userId);
     } else if (createApiKeyDto.userEmail) {
-      user = await this.usersService.findByEmail(createApiKeyDto.userEmail)
+      user = await this.usersService.findByEmail(createApiKeyDto.userEmail);
     } else {
-      user = request.user
+      user = request.user;
     }
 
     ForbiddenError.from(abac).throwUnlessCan(Action.Update, user);

--- a/apps/backend/src/apikeys/apikey.controller.ts
+++ b/apps/backend/src/apikeys/apikey.controller.ts
@@ -58,11 +58,17 @@ export class ApiKeyController {
     @Body() createApiKeyDto: CreateApiKeyDto
   ): Promise<{id: string; apiKey: string}> {
     const abac = this.authz.abac.createForUser(request.user);
-    const user = createApiKeyDto.userId
-      ? await this.usersService.findById(createApiKeyDto.userId)
-      : createApiKeyDto.userEmail
-      ? await this.usersService.findByEmail(createApiKeyDto.userEmail)
-      : request.user;
+
+    let user;
+
+    if (createApiKeyDto.userId) {
+      user = await this.usersService.findById(createApiKeyDto.userId)
+    } else if (createApiKeyDto.userEmail) {
+      user = await this.usersService.findByEmail(createApiKeyDto.userEmail)
+    } else {
+      user = request.user
+    }
+
     ForbiddenError.from(abac).throwUnlessCan(Action.Update, user);
     if (request.user.creationMethod === 'local') {
       await this.authnService.testPassword(createApiKeyDto, request.user);

--- a/setup-docker-env.sh
+++ b/setup-docker-env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ -f .env ]; then
-	echo ".env already exists, if you would like to regenerate your secrets, please delete this file and re-run the script. Re-running this script will cause the database password to be reset within the .env file (This will not reset it in the database). If this happens, you can connect to the database directly and reset the password. Alternatively, you can remove the 'data/' folder (which will delete all data)."
+	echo ".env already exists, if you would like to regenerate your secrets, please delete this file and re-run the script. WARNING: Re-running this script will cause the database password to be reset within the .env file, but the database will still be expecting the old password.  If this happens, you can 1) change DATABASE_PASSWORD in the .env file back to the old password, 2) connect to the database directly and reset the password to the newly generated one, or 3) remove the 'data/' folder (which will delete all data)."
 	
 else
 	echo ".env does not exist, creating..."

--- a/setup-docker-env.sh
+++ b/setup-docker-env.sh
@@ -23,7 +23,7 @@ if ! grep -qF "JWT_SECRET" .env; then
 fi
 
 if ! grep -qF "API_KEY_SECRET" .env; then
-	read -p ".env does not contain API_KEY_SECRET, would you like to enable API Keys? [Y/n]" -n 1 -r
+	read -p ".env does not contain API_KEY_SECRET, would you like to enable API Keys? [Y/n]"
 	if [[ $REPLY =~ ^[Yy]$ ]]
 	then
 		echo "API_KEY_SECRET=$(openssl rand -hex 33)" >> .env

--- a/setup-docker-env.sh
+++ b/setup-docker-env.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 if [ -f .env ]; then
-	echo ".env already exists, if you would like to regenerate your secrets, please delete this file and re-run the script."
+	echo ".env already exists, if you would like to regenerate your secrets, please delete this file and re-run the script. Re-running this script will cause the database password to be reset within the .env file (This will not reset it in the database). If this happens, you can connect to the database directly and reset the password. Alternatively, you can remove the 'data/' folder (which will delete all data)."
+	
 else
 	echo ".env does not exist, creating..."
 	(umask 066; touch .env)


### PR DESCRIPTION
These changes stemmed from needing to document how to create an API Key programmatically. In doing so, we found some updates to documentation and ease of use necessary.

For reference, the new wiki to instruct how to create the API Key programmatically is [here](https://github.com/mitre/heimdall2/wiki/Programmatic-API-Key-Generation)

- Edited the error message for the setup-docker-env script if the .env file already exists
- Updated setup-docker-env script to accept "y" then enter for API Key generation
- Added in changes from Camden's branch to allow the user to be referenced by email instead of just userId