### PR TITLE
made a change that fixes a bug for when sca tags are absent

### DIFF
--- a/libs/hdf-converters/src/veracode-mapper.ts
+++ b/libs/hdf-converters/src/veracode-mapper.ts
@@ -425,9 +425,15 @@ export class VeracodeMapper extends BaseConverter {
         components: {
           path: 'detailedreport.software_composition_analysis.vulnerable_components',
           transformer: (value: Record<string, unknown>) =>
-            (_.get(value, 'component') as Record<string, unknown>[]).map(
-              (component: Record<string, unknown>) => componentPass(component)
-            )
+          {
+            if (_.get(value, 'component') as Record<string, unknown>[]){
+              return (_.get(value, 'component') as Record<string, unknown>[]).map(
+                (component: Record<string, unknown>) => componentPass(component)
+            )}
+            else{
+              return ''
+            }
+          }
         },
         auxiliary_data: [
           {

--- a/libs/hdf-converters/src/veracode-mapper.ts
+++ b/libs/hdf-converters/src/veracode-mapper.ts
@@ -424,14 +424,15 @@ export class VeracodeMapper extends BaseConverter {
       passthrough: {
         components: {
           path: 'detailedreport.software_composition_analysis.vulnerable_components',
-          transformer: (value: Record<string, unknown>) =>
-          {
-            if (_.get(value, 'component') as Record<string, unknown>[]){
-              return (_.get(value, 'component') as Record<string, unknown>[]).map(
-                (component: Record<string, unknown>) => componentPass(component)
-            )}
-            else{
-              return ''
+          transformer: (value: Record<string, unknown>) => {
+            if (_.get(value, 'component') as Record<string, unknown>[]) {
+              return (
+                _.get(value, 'component') as Record<string, unknown>[]
+              ).map((component: Record<string, unknown>) =>
+                componentPass(component)
+              );
+            } else {
+              return '';
             }
           }
         },


### PR DESCRIPTION
Our team found a bug that when a veracode xml file is imput without a sca section, the fie file errors out due to the .map happening on a nonexistant field, this code remedies that