### PR TITLE
Added env var for disabling update checks

### DIFF
--- a/apps/backend/.env-example
+++ b/apps/backend/.env-example
@@ -25,6 +25,7 @@ ONE_SESSION_PER_USER=<If users are only allowed to be logged in on one browser, 
 CLASSIFICATION_BANNER_TEXT=<If a sensitivity classification banner should be shown to users, for example FOUO (if nothing is provided, no banner is shown)>
 CLASSIFICATION_BANNER_TEXT_COLOR=<The color of the text on the sensitivity classification banner, if enabled (defaults to white)>
 CLASSIFICATION_BANNER_COLOR=<The color of the sensitivity classification banner, if enabled (defaults to red)>
+DISABLE_UPDATE_CHECK=<Disable checking GitHub for an updated version of Heimdall2 (defaults to false)>
 
 
 # Oauth Client IDs and Secrets, If a variable does not have client id values assigned then the feature is disabled.

--- a/apps/backend/src/config/config.service.ts
+++ b/apps/backend/src/config/config.service.ts
@@ -56,7 +56,8 @@ export class ConfigService {
       oidcName: this.get('OIDC_NAME') || '',
       ldap: this.get('LDAP_ENABLED')?.toLocaleLowerCase() === 'true' || false,
       registrationEnabled: this.isRegistrationAllowed(),
-      localLoginEnabled: this.isLocalLoginAllowed()
+      localLoginEnabled: this.isLocalLoginAllowed(),
+      disableUpdateCheck: !!this.get('DISABLE_UPDATE_CHECK')
     });
   }
 

--- a/apps/backend/src/config/dto/startup-settings.dto.ts
+++ b/apps/backend/src/config/dto/startup-settings.dto.ts
@@ -10,6 +10,7 @@ export class StartupSettingsDto implements IStartupSettings {
   readonly ldap: boolean;
   readonly registrationEnabled: boolean;
   readonly localLoginEnabled: boolean;
+  readonly disableUpdateCheck: boolean;
 
   constructor(settings: IStartupSettings) {
     this.banner = settings.banner;
@@ -21,5 +22,6 @@ export class StartupSettingsDto implements IStartupSettings {
     this.ldap = settings.ldap;
     this.registrationEnabled = settings.registrationEnabled;
     this.localLoginEnabled = settings.localLoginEnabled;
+    this.disableUpdateCheck = settings.disableUpdateCheck;
   }
 }

--- a/apps/frontend/src/store/app_info.ts
+++ b/apps/frontend/src/store/app_info.ts
@@ -7,6 +7,7 @@ import {
   Mutation,
   VuexModule
 } from 'vuex-module-decorators';
+import {ServerModule} from './server';
 
 /** Configure this to match data set in vue.config.ts */
 declare const process: {
@@ -54,7 +55,7 @@ export class AppInfo extends VuexModule implements IAppInfoState {
 
   @Action
   public async CheckForUpdates() {
-    if (this.checkedForUpdates === false) {
+    if (!ServerModule.disableUpdateCheck && this.checkedForUpdates === false) {
       // Call axios.create() to skip the default interceptors setup in main.ts
       axios
         .create()

--- a/apps/frontend/src/store/server.ts
+++ b/apps/frontend/src/store/server.ts
@@ -35,6 +35,7 @@ export interface IServerState {
   ldap: boolean;
   localLoginEnabled: boolean;
   userInfo: IUser;
+  disableUpdateCheck: boolean;
 }
 
 interface LoginData {
@@ -53,6 +54,7 @@ class Server extends VuexModule implements IServerState {
   classificationBannerColor = '';
   classificationBannerText = '';
   classificationBannerTextColor = '';
+  disableUpdateCheck = false;
   ldap = false;
   serverUrl = '';
   serverMode = false;
@@ -104,6 +106,7 @@ class Server extends VuexModule implements IServerState {
     this.oidcName = settings.oidcName;
     this.ldap = settings.ldap;
     this.localLoginEnabled = settings.localLoginEnabled;
+    this.disableUpdateCheck = settings.disableUpdateCheck;
   }
 
   @Mutation

--- a/libs/interfaces/config/startup-settings.interface.ts
+++ b/libs/interfaces/config/startup-settings.interface.ts
@@ -8,4 +8,5 @@ export interface IStartupSettings {
   readonly ldap: boolean;
   readonly registrationEnabled: boolean;
   readonly localLoginEnabled: boolean;
+  readonly disableUpdateCheck: boolean;
 }


### PR DESCRIPTION
This PR addes an environment config item for disabling checks for Heimdall2 updates.

This is useful in cases where Heimdall2 is being used as a component of a larger system, and that system's maintainers do not wish this update banner to appear for end users.

It also is useful in airgapped usecases where Heimdall2 may not have access to GitHub to check for a newer version.
