### PR TITLE
Fix sequelize cli typescript compilation issue

### DIFF
--- a/apps/backend/config/app_config.ts
+++ b/apps/backend/config/app_config.ts
@@ -11,7 +11,7 @@ export default class AppConfig {
       this.envConfig = dotenv.parse(fs.readFileSync('.env'));
       console.log('Read config!');
     } catch (error) {
-      if (error.code === 'ENOENT') {
+      if ((error as Record<string,unknown>).code === 'ENOENT') {
         this.envConfig = {};
         // File probably does not exist
         console.log('Unable to read configuration file `.env`!');

--- a/apps/backend/config/app_config.ts
+++ b/apps/backend/config/app_config.ts
@@ -11,7 +11,7 @@ export default class AppConfig {
       this.envConfig = dotenv.parse(fs.readFileSync('.env'));
       console.log('Read config!');
     } catch (error) {
-      if ((error as Record<string,unknown>).code === 'ENOENT') {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
         this.envConfig = {};
         // File probably does not exist
         console.log('Unable to read configuration file `.env`!');

--- a/apps/backend/seeders/20200514154327-create-administrator.js
+++ b/apps/backend/seeders/20200514154327-create-administrator.js
@@ -16,7 +16,7 @@ module.exports = {
       envConfig = dotenv.parse(fs.readFileSync('.env'));
       console.log('Read config!');
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      if (error.code === 'ENOENT') {
         // File probably does not exist
         console.log('Unable to read configuration file `.env`!');
         console.log('Falling back to environment or undefined values!');

--- a/apps/backend/seeders/20200514154327-create-administrator.js
+++ b/apps/backend/seeders/20200514154327-create-administrator.js
@@ -16,7 +16,7 @@ module.exports = {
       envConfig = dotenv.parse(fs.readFileSync('.env'));
       console.log('Read config!');
     } catch (error) {
-      if (error.code === 'ENOENT') {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
         // File probably does not exist
         console.log('Unable to read configuration file `.env`!');
         console.log('Falling back to environment or undefined values!');


### PR DESCRIPTION
resolves #4064 

Fundamental problem was that the sequelize cli commands (and code) is only run on db migration, which isn't actually a part of our tests as far as I'm aware and is how this problem wasn't noted since I know I at least don't do a db migration frequently esp if there wasn't a backend change.  To make sure a similar problem doesn't occur again, we should modify/add a workflow action to test this.

Signed-off-by: HenryXiaoHX <hxiao@ucsd.edu>
Signed-off-by: Amndeep Singh Mann <amann@mitre.org>