### PR TITLE
Updated COPY commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,43 +11,37 @@ USER 0
 COPY package.json yarn.lock lerna.json tsconfig.json .prettierrc ./
 COPY apps ./apps
 COPY libs ./libs
-RUN chmod 0500 -R apps libs
 RUN apk add python3 make g++
 RUN sed -i s^https://registry.yarnpkg.com^$YARNREPO^g yarn.lock
 RUN yarn --frozen-lockfile --production --network-timeout 600000
 
 RUN yarn run build
-RUN chown -R node apps libs package.json
-RUN chmod 0400 package.json libs/interfaces/package.json tsconfig.json .prettierrc
-RUN chmod 0500 -R apps libs
 
 ### Production image
 
 FROM $BASE_CONTAINER as app
 
 WORKDIR /app
-
-COPY package.json ./
-COPY --from=builder /src/apps/backend/package.json apps/backend/
-COPY --from=builder /src/apps/frontend/package.json apps/frontend/
-COPY --from=builder /src/libs/interfaces/package.json libs/interfaces/
-COPY --from=builder /src/libs/password-complexity/ libs/password-complexity/
-COPY --from=builder /src/apps/backend/node_modules apps/backend/node_modules
-COPY --from=builder /src/apps/backend/dist apps/backend/dist
-COPY --from=builder /src/dist/ dist/
-COPY --from=builder /src/apps/backend/.sequelizerc /app/apps/backend/
-COPY --from=builder /src/apps/backend/db /app/apps/backend/db
-COPY --from=builder /src/apps/backend/config /app/apps/backend/config
-COPY --from=builder /src/apps/backend/migrations /app/apps/backend/migrations
-COPY --from=builder /src/apps/backend/seeders /app/apps/backend/seeders
-RUN chown node package.json libs libs/interfaces libs/interfaces/package.json libs/password-complexity apps/backend/node_modules apps/backend/seeders apps/backend/config apps/backend/db apps/backend/migrations apps/backend/seeders apps/backend/package.json apps/backend apps/frontend apps/frontend/package.json
-RUN chmod 0400 libs/interfaces/package.json apps/frontend/package.json
+#Note for posterity: the permissions setting is to ensure that the user cannot modify the files accidentally and can't be read, executed or changed by another account.
+#Removing these permissions doesn't improve image size or performance meaningfully, but keeping them adds a potential safeguard.
+COPY --chown= --chmod=0400 package.json ./
+COPY --from=builder --chown= --chmod=0400 /src/apps/frontend/package.json apps/frontend/
+COPY --from=builder --chown= --chmod=0400 /src/libs/interfaces/package.json libs/interfaces/
+COPY --from=builder --chown= --chmod=0500 /src/libs/password-complexity/ libs/password-complexity/
+COPY --from=builder --chown= --chmod=0500 /src/apps/backend/package.json apps/backend/
+COPY --from=builder --chown= --chmod=0500 /src/apps/backend/node_modules apps/backend/node_modules
+COPY --from=builder --chown= --chmod=0500 /src/apps/backend/dist apps/backend/dist
+COPY --from=builder --chown= /src/dist/ dist/
+COPY --from=builder --chown= --chmod=0500 /src/apps/backend/.sequelizerc /app/apps/backend/
+COPY --from=builder --chown= --chmod=0500 /src/apps/backend/db /app/apps/backend/db
+COPY --from=builder --chown= --chmod=0500 /src/apps/backend/config /app/apps/backend/config
+COPY --from=builder --chown= --chmod=0500 /src/apps/backend/migrations /app/apps/backend/migrations
+COPY --from=builder --chown= --chmod=0500 /src/apps/backend/seeders /app/apps/backend/seeders
 
 
 EXPOSE 3000
 
-COPY cmd.sh /usr/local/bin/
-RUN chmod 755 /usr/local/bin/cmd.sh
+COPY --chmod=755 cmd.sh /usr/local/bin/
 
 USER node
 


### PR DESCRIPTION
Added the built-in chmod/chown flags to improve build time. Removed standalone chmod and chown RUN commands, and removed all chmod/chown operations from the builder container. Will and I elected to keep the chmod and chown commands in the app stage of the image because they serve as a precautionary measure, and removing them makes no positive or negative impact on performance or space, and do not impact the legibility of the file.

On my machine, this improved build time from 2604 seconds to 309 - an 88 percent decrease. Pending further testing on other machines, as mine appeared to run it dramatically slower than others.

Dockerfile.lite still needs to be updated accordingly.