### PR TITLE
fix wordwrap for api key modal

### DIFF
--- a/apps/frontend/src/components/generic/InputDialog.vue
+++ b/apps/frontend/src/components/generic/InputDialog.vue
@@ -5,7 +5,9 @@
     </template>
 
     <v-card>
-      <v-card-title class="headline">{{ title }}</v-card-title>
+      <v-card-title class="headline" style="word-break: break-word">{{
+        title
+      }}</v-card-title>
       <v-card-text>
         <v-text-field
           v-model="value"


### PR DESCRIPTION
resolves #4465 

v-card-titles have their css for word-break set to break-all (i.e. on any character).  changed it to break-word so that it doesn't look as awkward