### PR TITLE
arrayTransformer requires pathVal

### DIFF
--- a/libs/hdf-converters/src/base-converter.ts
+++ b/libs/hdf-converters/src/base-converter.ts
@@ -319,23 +319,24 @@ export class BaseConverter {
             pathVal = pathTransform(pathVal, file);
           }
           if (Array.isArray(pathVal)) {
-            v = pathVal.map((element: Record<string, unknown>) => {
-              return _.omit(this.convertInternal(element, lookupPath), [
-                'path',
-                'transformer',
-                'arrayTransformer',
-                'key',
-                'pathTransform'
-              ]) as unknown as T;
-            }) as any;
-            if (arrayTransformer !== undefined) {
+            if (arrayTransformer === undefined) {
+              v = pathVal.map((element: Record<string, unknown>) => {
+                return _.omit(this.convertInternal(element, lookupPath), [
+                  'path',
+                  'transformer',
+                  'arrayTransformer',
+                  'key',
+                  'pathTransform'
+                ]) as unknown as T;
+              }) as any;
+            } else {
               if (Array.isArray(arrayTransformer)) {
                 v = arrayTransformer[0].apply(arrayTransformer[1], [
-                  v,
+                  pathVal,
                   this.data
                 ]);
               } else {
-                v = arrayTransformer.apply(null, [v, this.data]) as any;
+                v = arrayTransformer.apply(null, [pathVal, this.data]) as any;
               }
             }
             if (key !== undefined) {


### PR DESCRIPTION
Like transform, arrayTransformer expects pathVal.

If the pathVal is run through convertInternal, the data is removed from it, resulting in arrayTransformer getting an array of the expected length but with all empty elements.

@Amndeep7 this explains why `refs` is always a list of empty objects in https://github.com/mitre/heimdall2/pull/4480