### PR TITLE
Fips compliance

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -19,6 +19,7 @@
     "start": "node dist/src/main",
     "start:debug": "nest start --debug --watch",
     "start:dev": "nest start --watch",
+    "start:fips": "node --force-fips dist/src/main",
     "test": "jest --silent",
     "test:ci-cov": "jest --silent --coverage --runInBand",
     "test:cov": "jest --silent --coverage",

--- a/cmd.sh
+++ b/cmd.sh
@@ -2,4 +2,4 @@
 set -e
 yarn backend sequelize-cli db:migrate
 yarn backend sequelize-cli db:seed:all
-yarn backend start
+yarn backend start:fips

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,10 +10,13 @@ services:
       - POSTGRES_DB=heimdall-server-production
       - POSTGRES_PASSWORD=${DATABASE_PASSWORD}
       - PGDATA=/var/lib/postgresql/data/pgdata
+      - POSTGRES_HOST_AUTH_METHOD="scram-sha-256"
+      - POSTGRES_INITDB_ARGS=--auth-host=scram-sha-256
     expose:
       - "5432"
   server:
-    image: mitre/heimdall2:release-latest
+    build: .
+      # image: mitre/heimdall2:release-latest
     restart: unless-stopped
     environment:
       - NODE_ENV=production


### PR DESCRIPTION
Resolves #4145

- [x] OS is FIPS compliant: RHEL's UBI8 docker container satisfies this and is accredited
- [x] Node is FIPS compliant: The UBI8 container variant that we're using built node with the options required to be fips compliant
- [x] Run Node in FIPS compliant mode: You can pass in the flag to enable or force FIPS compliance.  Using force to avoid the possibility of FIPS mode being disabled
- [x] Connect to the Postgres DB using a FIPS compliant algorithm: Postgres v<=13 by default uses a password authentication method (https://www.postgresql.org/docs/13/auth-password.html ; https://hub.docker.com/_/postgres then look for POSTGRES_HOST_AUTH_METHOD) that uses md5.  MD5 is not a FIPS compliant algorithm.  Force Postgres to start up in and use SHA256 instead.
- [ ] (Optional) Swap out the Postgres in the docker-compose to be a variant that is FIPS compliant: Marked as optional since the user ought to supply a FIPS compliant Postgres, but would be useful for testing.
- [ ] Replace usages of the bcrypt algorithm (i.e. what is used by bcryptjs, which is the cryptography library we're currently using) or any other non-FIPS approved algorithm with FIPS approved algorithms: The higher numbered SHA family is usually recommended (https://csrc.nist.gov/projects/cryptographic-module-validation-program/sp-800-140-series-supplemental-information/sp800-140c).  Could roll our own simple utility functions using nodejs and WebCryptoApi native functionality, but ideally we leverage a cross-platform library.
- [ ] (Optional) Swap out the NGINX in the docker-compose to be a variant that is FIPS compliant: Marked as optional since the user ought to supply a FIPS compliant reverse proxy, but would be useful for testing.
- [ ] Exhaustively test to make sure that we don't run into any issues: there doesn't seem to be a way to statically check that we're FIPS compliant, so need to address runtime issues as they show up.
  - [ ] Test components as per https://github.com/mitre/heimdall2/issues/4145#issuecomment-1633233086 - probably will break this subtask out into more subtasks
  - [ ] Set up FIPS compliant testing VM (so that the host, applications, and browser are all running in FIPS compliant mode)
  - [ ] Automate testing: Cypress sucks, let's do the swap to Playwright