### PR TITLE
Fix error message incorrectly showing up for overlay profile results

### DIFF
--- a/apps/frontend/src/components/cards/controltable/ControlRowDetails.vue
+++ b/apps/frontend/src/components/cards/controltable/ControlRowDetails.vue
@@ -189,7 +189,7 @@ export default class ControlRowDetails extends mixins(HtmlSanitizeMixin) {
   }
 
   get errorMessage(): string {
-    return this.control.hdf.segments?.length == 0
+    return this.control.root.hdf.segments?.length == 0
       ? "The control didn't return any results.  Check with the author of the profile to ensure the code is correct."
       : '';
   }


### PR DESCRIPTION
Resolves #5418 

Still showing up in actual profile error situations

Sample file from original issue: https://github.com/mitre/heimdall2/issues/5226

![image](https://github.com/mitre/heimdall2/assets/2015821/13b87e18-0215-4d86-9a3a-a12f34fad16d)

No longer showing up in overlays

Sample file from new issue: https://github.com/mitre/heimdall2/issues/5418

![image](https://github.com/mitre/heimdall2/assets/2015821/f4cb9347-a635-4ffd-bea8-1c1fab0c6884)