### PR TITLE
Fix Ironbank Deployment Pipeline Error

### DIFF
--- a/.github/workflows/release-server-to-docker.yml
+++ b/.github/workflows/release-server-to-docker.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Get Docker SHA
         shell: bash
         id: get-docker-sha
-        run: echo "DOCKER_SHA=$(docker manifest inspect --verbose docker.io/mitre/heimdall2:${{ steps.format-tag.outputs.replaced }} | jq -r '.Descriptor.digest')" >> $GITHUB_ENV
+        run: echo "DOCKER_SHA=$(docker inspect --format='{{index .RepoDigests 0}}' mitre/heimdall2:${{ steps.format-tag.outputs.replaced }} | cut -d '@' -f 2" >> $GITHUB_ENV
       - name: Sophos Factory pipeline
         uses: sophos/factory-run-pipeline@v2
         with:


### PR DESCRIPTION
Ironbank deployment pipeline gives an error during the lint-and-image-inspect job:
```
$ python3 "${PIPELINE_REPO_DIR}/stages/validate-container-repository/lint/validate_hardening_manifest.py"
| hardening_manifest           | INFO     | Validating schema
| hardening_manifest           | INFO     | This task will exit if not completed within 2 minutes
| hardening_manifest           | ERROR    | Hardening Manifest failed jsonschema validation
| hardening_manifest           | ERROR    | Verify Hardening Manifest content
| hardening_manifest           | ERROR    | {'tag': 'mitre/heimdall2:2.10.4', 'url': 'docker://docker.io/mitre/heimdall2@'} is not valid under any of the given schemas
```

which indicates that the url is missing the SHA commit hash at the end. Code has been adjusted to correctlyed grab this value and has been tested.