### PR TITLE
Update okta.strategy.ts to work with passport-openidconnect 0.1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_CONTAINER=registry.access.redhat.com/ubi8/nodejs-18-minimal:1
 
-FROM $BASE_CONTAINER as builder
+FROM $BASE_CONTAINER AS builder
 
 ARG NODE_ENV=production
 ENV NODE_ENV=$NODE_ENV
@@ -29,7 +29,7 @@ COPY apps ./apps
 COPY libs ./libs
 RUN yarn build
 
-FROM $BASE_CONTAINER as app
+FROM $BASE_CONTAINER AS app
 
 EXPOSE 3000
 

--- a/apps/backend/src/authn/oidc.strategy.ts
+++ b/apps/backend/src/authn/oidc.strategy.ts
@@ -43,6 +43,7 @@ export class OidcStrategy extends PassportStrategy(Strategy, 'oidc') {
         //changed from 4-arity function to 9-arity, because 'profile' in 4-arity was not providing required data
         //by changing to 9-arity we can access the data we need from the 'uiProfile' parameter
         //the lack of needed data in 4-arity function may be a bug
+        // NOTE: Some variables are not used in this function, but they are required to be present in the function signature. These are indicated with an underscore prefix.
         _issuer: string,
         uiProfile: OIDCProfile,
         _idProfile: object,

--- a/apps/backend/src/authn/okta.strategy.ts
+++ b/apps/backend/src/authn/okta.strategy.ts
@@ -44,6 +44,7 @@ export class OktaStrategy extends PassportStrategy(Strategy, 'okta') {
         scope: 'openid email profile'
       },
       async function (
+        // Like in oidc.strategy.ts, we changed the arity of the function to 9 to access the data we need from 'uiProfile' due to updates in the passport-openidconnect library which otherwise caused failures in the authentication process
         _issuer: string,
         uiProfile: OktaProfile,
         _idProfile: object,

--- a/apps/backend/src/authn/okta.strategy.ts
+++ b/apps/backend/src/authn/okta.strategy.ts
@@ -41,7 +41,7 @@ export class OktaStrategy extends PassportStrategy(Strategy, 'okta') {
         clientID: configService.get('OKTA_CLIENTID') || 'disabled',
         clientSecret: configService.get('OKTA_CLIENTSECRET') || 'disabled',
         callbackURL: `${configService.get('EXTERNAL_URL')}/authn/okta/callback`,
-        scope: 'openid email profile',
+        scope: 'openid email profile'
       },
       async function (
         _issuer: string,
@@ -56,8 +56,7 @@ export class OktaStrategy extends PassportStrategy(Strategy, 'okta') {
         done: any
       ) {
         const userData = uiProfile._json;
-        const {given_name, family_name, email, email_verified} =
-          userData;
+        const {given_name, family_name, email, email_verified} = userData;
         if (email_verified) {
           const user = await authnService.validateOrCreateUser(
             email,

--- a/apps/backend/src/authn/okta.strategy.ts
+++ b/apps/backend/src/authn/okta.strategy.ts
@@ -45,6 +45,7 @@ export class OktaStrategy extends PassportStrategy(Strategy, 'okta') {
       },
       async function (
         // Like in oidc.strategy.ts, we changed the arity of the function to 9 to access the data we need from 'uiProfile' due to updates in the passport-openidconnect library which otherwise caused failures in the authentication process
+        // NOTE: Some variables are not used in this function, but they are required to be present in the function signature. These are indicated with an underscore prefix.
         _issuer: string,
         uiProfile: OktaProfile,
         _idProfile: object,

--- a/apps/frontend/src/views/Login.vue
+++ b/apps/frontend/src/views/Login.vue
@@ -89,7 +89,7 @@ export default class Login extends Vue {
   checkForAuthenticationError() {
     if (this.$cookies.get('authenticationError')) {
       SnackbarModule.failure(
-        `Sorry, an problem occurred while signing you in. The reason given was: ${this.$cookies.get(
+        `Sorry, a problem occurred while signing you in. The reason given was: ${this.$cookies.get(
           'authenticationError'
         )}`
       );


### PR DESCRIPTION
Closes: #5719 

To test:
1. Setup Okta development server
2. Integrated local heimdall build with Okta dev server via App integrations
3. Stored the client id, client secret, external url, and okta domain as env variables for heimdall
4. Built Heimdall using the docker build to allow for https (http does not work with the okta integration)
5. Created users in okta and assigned them to Heimdall, had to assign them a username for it to work correctly)
6. Also had to disable GP to test the integration successfully

Added documentation here for testing Okta integration - https://github.com/mitre/heimdall2/wiki/Heimdall-Authentication-Methods#testing