### PR TITLE
Package.json Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Heimdall's frontend container image is distributed on [DockerHub](https://hub.do
    # For Windows
    ./setup-docker-env.bat
    ```
+   
    > [!TIP]
    > If you would like to further configure your Docker-based Heimdall deployment, edit the .env file located in the root directory generated after running the `setup-docker-env.sh` or `setup-docker-env.bat` scripts
 

--- a/README.md
+++ b/README.md
@@ -441,7 +441,8 @@ If you would like to change Heimdall to your needs, you can use Heimdall's 'Deve
 
 You can also open the apps/backend/.env file in a text editor and set additional optional configuration values. For more info on configuration values see [Environment Variables Configuration](https://github.com/mitre/heimdall2/wiki/Environment-Variables-Configuration).
 
-__NOTE: The .env file in the root repository is for the dockerized instance of the Heimdall application. Running a local build will use the .env file in the `apps/backend` directory.__
+> [!NOTE]
+> The .env file in the root repository is for the dockerized instance of the Heimdall application. Running a local build will use the .env file in the `apps/backend` directory.
 
 6. Create the database:
 
@@ -518,7 +519,8 @@ The application includes an End-to-End (E2E) frontend and Backend tests (built u
 
 The first command will start an instance of Heimdall Server and exposes additional routes required to allow the tests to run. The second will open the Cypress UI which will run the tests any time code changes are made.
 
-_NOTE: When running the tests locally, tests that integrate with external services such as LDAP or Splunk will fail without having that external service running and configured. If these failures occur locally and local development does not impact the code relevant to those tests, you may consider permitting these failing tests locally and check that they pass in the pipeline in lieu of standing up local services only for testing purposes._
+> [!NOTE] 
+> When running the tests locally, tests that integrate with external services such as LDAP or Splunk will fail without having that external service running and configured. If these failures occur locally and local development does not impact the code relevant to those tests, you may consider permitting these failing tests locally and check that they pass in the pipeline in lieu of standing up local services only for testing purposes.
 
 ### Creating a Release
 

--- a/README.md
+++ b/README.md
@@ -181,9 +181,9 @@ Heimdall's frontend container image is distributed on [DockerHub](https://hub.do
    # For Windows
    ./setup-docker-env.bat
    ```
-   
-   > [!TIP]
-   > If you would like to further configure your Docker-based Heimdall deployment, edit the .env file located in the root directory generated after running the `setup-docker-env.sh` or `setup-docker-env.bat` scripts
+
+> [!TIP]
+> If you would like to further configure your Docker-based Heimdall deployment, edit the .env file located in the root directory generated after running the `setup-docker-env.sh` or `setup-docker-env.bat` scripts
 
 6. Heimdall might need certificates to access the open internet or internal resources (ex. an LDAP server).  Please convert any certificates into PEM files and place them in `./certs/` where they will be automatically ingested.  Alternatively, you can place a shell script that will retrieve those certs in that directory, and modify the `command` attribute underneath the `certs` service in the `docker-compose.yml` to run that script.
   ```bash

--- a/README.md
+++ b/README.md
@@ -180,8 +180,9 @@ Heimdall's frontend container image is distributed on [DockerHub](https://hub.do
    
    # For Windows
    ./setup-docker-env.bat
-   # If you would like to further configure your Heimdall docker instance, edit the .env file located in the root directory generated after running the previous line
    ```
+   > [!TIP] 
+   > If you would like to further configure your Docker-based Heimdall deployment, edit the .env file located in the root directory generated after running the `setup-docker-env.sh` or `setup-docker-env.bat` scripts
 
 6. Heimdall might need certificates to access the open internet or internal resources (ex. an LDAP server).  Please convert any certificates into PEM files and place them in `./certs/` where they will be automatically ingested.  Alternatively, you can place a shell script that will retrieve those certs in that directory, and modify the `command` attribute underneath the `certs` service in the `docker-compose.yml` to run that script.
   ```bash

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ If you would like to change Heimdall to your needs, you can use Heimdall's 'Deve
 You can also open the apps/backend/.env file in a text editor and set additional optional configuration values. For more info on configuration values see [Environment Variables Configuration](https://github.com/mitre/heimdall2/wiki/Environment-Variables-Configuration).
 
 > [!NOTE]
-> The .env file in the root repository is for the dockerized instance of the Heimdall application. Running a local build will use the .env file in the `apps/backend` directory.
+> The .env file in the root repository is for the Docker deployment of the Heimdall application. Running a local build will use the .env file in the `apps/backend` directory.
 
 6. Create the database:
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Heimdall's frontend container image is distributed on [DockerHub](https://hub.do
 5. Run the following commands in a terminal window from the Heimdall source directory. For more information on the .env file, visit [Environment Variables Configuration.](https://github.com/mitre/heimdall2/wiki/Environment-Variables-Configuration)
    ```bash
    ./setup-docker-env.sh
-   # If you would like to further configure your Heimdall instance, edit the .env file generated after running the previous line
+   # If you would like to further configure your Heimdall docker instance, edit the .env file located in the root directory generated after running the previous line
    ```
 
 6. Heimdall might need certificates to access the open internet or internal resources (ex. an LDAP server).  Please convert any certificates into PEM files and place them in `./certs/` where they will be automatically ingested.  Alternatively, you can place a shell script that will retrieve those certs in that directory, and modify the `command` attribute underneath the `certs` service in the `docker-compose.yml` to run that script.
@@ -436,6 +436,8 @@ If you would like to change Heimdall to your needs, you can use Heimdall's 'Deve
 5. Edit your apps/backend/.env file using the provided `setup-dev-env.sh or setup-dev-env.bat` script. Make sure to set a DATABASE_USERNAME and DATABASE_PASSWORD that match what you set for the PostgresDB in step 3.
 
 You can also open the apps/backend/.env file in a text editor and set additional optional configuration values. For more info on configuration values see [Environment Variables Configuration](https://github.com/mitre/heimdall2/wiki/Environment-Variables-Configuration).
+
+Note: the .env file in the root repository is for the dockerized instance of the Heimdall application.
 
 6. Create the database:
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,11 @@ Heimdall's frontend container image is distributed on [DockerHub](https://hub.do
 
 5. Run the following commands in a terminal window from the Heimdall source directory. For more information on the .env file, visit [Environment Variables Configuration.](https://github.com/mitre/heimdall2/wiki/Environment-Variables-Configuration)
    ```bash
+   # For Linux or Mac
    ./setup-docker-env.sh
+   
+   # For Windows
+   ./setup-docker-env.bat
    # If you would like to further configure your Heimdall docker instance, edit the .env file located in the root directory generated after running the previous line
    ```
 
@@ -437,7 +441,7 @@ If you would like to change Heimdall to your needs, you can use Heimdall's 'Deve
 
 You can also open the apps/backend/.env file in a text editor and set additional optional configuration values. For more info on configuration values see [Environment Variables Configuration](https://github.com/mitre/heimdall2/wiki/Environment-Variables-Configuration).
 
-Note: the .env file in the root repository is for the dockerized instance of the Heimdall application.
+__NOTE: The .env file in the root repository is for the dockerized instance of the Heimdall application. Running a local build will use the .env file in the `apps/backend` directory.__
 
 6. Create the database:
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Heimdall's frontend container image is distributed on [DockerHub](https://hub.do
    # For Windows
    ./setup-docker-env.bat
    ```
-   > [!TIP] 
+   > [!TIP]
    > If you would like to further configure your Docker-based Heimdall deployment, edit the .env file located in the root directory generated after running the `setup-docker-env.sh` or `setup-docker-env.bat` scripts
 
 6. Heimdall might need certificates to access the open internet or internal resources (ex. an LDAP server).  Please convert any certificates into PEM files and place them in `./certs/` where they will be automatically ingested.  Alternatively, you can place a shell script that will retrieve those certs in that directory, and modify the `command` attribute underneath the `certs` service in the `docker-compose.yml` to run that script.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint:ci": "lerna run lint:ci",
     "pack:all": "lerna exec yarn pack --scope inspecjs --scope @mitre/heimdall-lite --scope @mitre/hdf-converters --parallel",
     "start": "yarn backend start",
-    "start:dev": "./node_modules/.bin/dotenv -e .env -- lerna exec yarn run start:dev --ignore @heimdall/interfaces --ignore @mitre/hdf-converters  --ignore @heimdall/password-complexity --ignore @heimdall/cypress-tests --ignore inspecjs",
+    "start:dev": "./node_modules/.bin/dotenv -e apps/backend/.env -- lerna exec yarn run start:dev --ignore @heimdall/interfaces --ignore @mitre/hdf-converters  --ignore @heimdall/password-complexity --ignore @heimdall/cypress-tests --ignore inspecjs",
     "test:ui": "cypress run",
     "test:ui:open": "cypress open"
   },

--- a/setup-docker-env.bat
+++ b/setup-docker-env.bat
@@ -10,7 +10,6 @@ IF EXIST .env (
 )
 
 
-
 REM Set the PostgreSQL db password
 FINDSTR /C:"DATABASE_PASSWORD" .env > Nul
 IF !ERRORLEVEL! EQU 1 (
@@ -24,14 +23,14 @@ REM Set the JWT expire time
 SET jwtexpiretime=1d
 FINDSTR /C:"JWT_EXPIRE_TIME" .env > Nul
 IF !ERRORLEVEL! EQU 1 (
-  ECHO "JWT_EXPIRE_TIME" was not found within the .env file, generating secret..."
+  ECHO "JWT_EXPIRE_TIME" was not found within the .env file, generating secret...
   CALL :SET_JWT_EXPIRE_TIME
 )
 
 REM Generate the JWT SECRET (password)
 FINDSTR /C:"JWT_SECRET" .env > Nul
 IF !ERRORLEVEL! EQU 1 (
-  ECHO "JWT_SECRET" was not found within the .env file, generating secret..."
+  ECHO "JWT_SECRET" was not found within the .env file, generating secret...
   FOR /F "tokens=* USEBACKQ" %%F IN (`openssl rand -hex 64`) DO (
     ECHO JWT_SECRET=%%F >> .env
   )
@@ -42,7 +41,6 @@ REM Enable API keys
 FINDSTR /C:"API_KEY_SECRET" .env > Nul
 IF !ERRORLEVEL! EQU 1 (
   SET /P enableapikeys="API_KEY_SECRET was not found within the .env file. Enable API keys [Y/n]: "
-  ECHO HERE enableapikeys is !enableapikeys!
   IF /I "!enableapikeys!" EQU "Y" (
     FOR /F "tokens=* USEBACKQ" %%F IN (`openssl rand -hex 33`) DO (
       ECHO API_KEY_SECRET=%%F >> .env
@@ -65,7 +63,7 @@ IF EXIST ./nginx/certs/ssl_certificate.crt (
 	ECHO Be sure your production environment is configured to work with your self-signed certificate.
 	ECHO
 	ECHO "Generating certificate (Expires in 7 days)..."
-  openssl req -newkey rsa:4096 -x509 -sha256 -days 7 -nodes -out nginx/certs/ssl_certificate.crt -keyout nginx/certs/ssl_certificate_key.key -subj "/C=US/ST=SelfSigned/L=SelfSigned/O=SelfSigned/OU=SelfSigned
+  openssl req -newkey rsa:4096 -x509 -sha256 -days 7 -nodes -out nginx/certs/ssl_certificate.crt -keyout nginx/certs/ssl_certificate_key.key -subj "/C=US/ST=SelfSigned/L=SelfSigned/O=SelfSigned/OU=SelfSigned"
   ECHO Certificates were generated 
 )
 
@@ -74,7 +72,7 @@ REM Exit the batch process
 EXIT /B !ERRORLEVEL!
 
 REM ------------------------------------------------------------------------------------------
-REM Supporting function - Note: we use the function input function outside the IF %ERRORLEVEL%
+REM Supporting function - Note: we use the input function outside the IF %ERRORLEVEL%
 REM because the SET /P does not work as expected inside the IF %ERRORLEVEL% block
 
 :SET_JWT_EXPIRE_TIME

--- a/setup-docker-env.bat
+++ b/setup-docker-env.bat
@@ -1,0 +1,89 @@
+ECHO OFF
+SETLOCAL
+Setlocal EnableDelayedExpansion
+
+IF EXIST .env (
+	ECHO ".env already exists, if you would like to regenerate your secrets, please delete this file and re-run the script. WARNING: Re-running this script will cause the database password to be reset within the .env file, but the database will still be expecting the old password.  If this happens, you can 1) change DATABASE_PASSWORD in the .env file back to the old password, 2) connect to the database directly and reset the password to the newly generated one, or 3) remove the 'data/' folder (which will delete all data)."
+) ELSE (
+	ECHO ".env does not exist, creating..."
+  CD . > .env
+)
+
+
+
+REM Set the PostgreSQL db password
+FINDSTR /C:"DATABASE_PASSWORD" .env > Nul
+IF !ERRORLEVEL! EQU 1 (
+  ECHO "DATABASE_PASSWORD" was not found within the .env file, generating secret...
+  FOR /F "tokens=* USEBACKQ" %%F IN (`openssl rand -hex 33`) DO (
+    ECHO DATABASE_PASSWORD=%%F >> .env
+  )
+)
+
+REM Set the JWT expire time
+SET jwtexpiretime=1d
+FINDSTR /C:"JWT_EXPIRE_TIME" .env > Nul
+IF !ERRORLEVEL! EQU 1 (
+  ECHO "JWT_EXPIRE_TIME" was not found within the .env file, generating secret..."
+  CALL :SET_JWT_EXPIRE_TIME
+)
+
+REM Generate the JWT SECRET (password)
+FINDSTR /C:"JWT_SECRET" .env > Nul
+IF !ERRORLEVEL! EQU 1 (
+  ECHO "JWT_SECRET" was not found within the .env file, generating secret..."
+  FOR /F "tokens=* USEBACKQ" %%F IN (`openssl rand -hex 64`) DO (
+    ECHO JWT_SECRET=%%F >> .env
+  )
+)
+
+
+REM Enable API keys
+FINDSTR /C:"API_KEY_SECRET" .env > Nul
+IF !ERRORLEVEL! EQU 1 (
+  SET /P enableapikeys="API_KEY_SECRET was not found within the .env file. Enable API keys [Y/n]: "
+  ECHO HERE enableapikeys is !enableapikeys!
+  IF /I "!enableapikeys!" EQU "Y" (
+    FOR /F "tokens=* USEBACKQ" %%F IN (`openssl rand -hex 33`) DO (
+      ECHO API_KEY_SECRET=%%F >> .env
+    )
+  )
+)  
+
+REM Set NGINX Host, if required
+FINDSTR /C:"NGINX_HOST" .env > Nul
+IF %ERRORLEVEL% EQU 1 (
+  ECHO "NGINX_HOST" was not found within the .env file, set NGINX_HOST IP...
+  CALL :SET_NGINX_HOST
+)  
+
+REM Generate the SSL certificates
+IF EXIST ./nginx/certs/ssl_certificate.crt (
+  ECHO "SSL Certificate already exists. If you would like to regenerate your certificates, please delete the files in ./nginx/certs/ and re-run this script."
+) ELSE (
+	ECHO "SSL Certificate does not exist, creating self-signed certificate..."
+	ECHO Be sure your production environment is configured to work with your self-signed certificate.
+	ECHO
+	ECHO "Generating certificate (Expires in 7 days)..."
+  openssl req -newkey rsa:4096 -x509 -sha256 -days 7 -nodes -out nginx/certs/ssl_certificate.crt -keyout nginx/certs/ssl_certificate_key.key -subj "/C=US/ST=SelfSigned/L=SelfSigned/O=SelfSigned/OU=SelfSigned
+  ECHO Certificates were generated 
+)
+
+
+REM Exit the batch process
+EXIT /B !ERRORLEVEL!
+
+REM ------------------------------------------------------------------------------------------
+REM Supporting function - Note: we use the function input function outside the IF %ERRORLEVEL%
+REM because the SET /P does not work as expected inside the IF %ERRORLEVEL% block
+
+:SET_JWT_EXPIRE_TIME
+  SET /P jwtexpiretime="Enter JWT_EXPIRE_TIME ex. 1d or 25m (leave blank to use default [!jwtexpiretime!]): "
+  ECHO JWT_EXPIRE_TIME=!%jwtexpiretime! >> .env
+EXIT /B 0
+
+:SET_NGINX_HOST
+  SET nginxhost=127.0.0.1
+  SET /P nginxhost="Enter your FQDN/Hostname/IP Address (leave blank to use default [%nginxhost%]): "
+  ECHO NGINX_HOST=%nginxhost% >> .env
+EXIT /B 0


### PR DESCRIPTION
This modifies the package.json file to use the .env file located in ./apps/backend/ rather than the root directory. 

This also modifies the readme to be more explicit about which .env is being used and where it's located for both dockerized and locally hosted application builds.

Documentation was previously unclear and stated that the .env file in ./apps/backend/ is what is used for local builds even though it was actually pulling from the .env in the root directory?