### PR TITLE
Add option to normalize export ckl profile name

### DIFF
--- a/apps/frontend/src/components/global/ExportCKLModal.vue
+++ b/apps/frontend/src/components/global/ExportCKLModal.vue
@@ -258,7 +258,6 @@
         </v-btn>
       </v-card-actions>
     </v-card>
-    <!-- </v-container> -->
   </v-dialog>
 </template>
 
@@ -313,7 +312,7 @@ export default class ExportCKLModal extends Vue {
   showingModal = false;
   formatProfileTitle = false;
   updatingProfileTitle = false;
-  originalProfileTitle = new Map<Number, string>();
+  originalProfileTitle = new Map<number, string>();
   roles = Object.values(Role);
   types = Object.values(Assettype);
   techareas = Object.values(Techarea);

--- a/apps/frontend/src/components/global/ExportCKLModal.vue
+++ b/apps/frontend/src/components/global/ExportCKLModal.vue
@@ -19,6 +19,8 @@
         <v-col cols="2">
           <v-checkbox
             v-model="formatProfileTitle"
+            v-b-tooltip.hover
+            title="Attempts to format the profile title into a proper CKL title name"
             class="mx-2"
             label="Format Profile Title"
           />
@@ -559,6 +561,7 @@ export default class ExportCKLModal extends Vue {
 
     // Find if we need to format the name
     let index = 0;
+    // Only format for UCs where the name ends with values contained in the baselineArray
     const baselineArray = ['stig-baseline', 'cis-baseline', 'srg-baseline'];
     for (const baseline of baselineArray) {
       if (name.indexOf(baseline) > 0) {

--- a/apps/frontend/src/components/global/ExportCKLModal.vue
+++ b/apps/frontend/src/components/global/ExportCKLModal.vue
@@ -12,7 +12,9 @@
     <v-card>
       <v-row no-gutters>
         <v-col cols="10">
-          <v-card-title class="headline"> Export as DISA Checklist </v-card-title>
+          <v-card-title class="headline">
+            Export as DISA Checklist
+          </v-card-title>
         </v-col>
         <v-col cols="2">
           <v-checkbox

--- a/apps/frontend/src/components/global/ExportCKLModal.vue
+++ b/apps/frontend/src/components/global/ExportCKLModal.vue
@@ -311,7 +311,6 @@ export default class ExportCKLModal extends Vue {
 
   showingModal = false;
   formatProfileTitle = false;
-  updatingProfileTitle = false;
   originalProfileTitle = new Map<number, string>();
   roles = Object.values(Role);
   types = Object.values(Assettype);
@@ -570,9 +569,8 @@ export default class ExportCKLModal extends Vue {
 
     // We need to format the name
     if (index > 0) {
-      this.updatingProfileTitle = true;
       const originalTitleIndex = fileIndex + profileIndex;
-      // Preserver the old name
+      // Preserve the old name
       if (!this.originalProfileTitle.has(originalTitleIndex)) {
         this.originalProfileTitle.set(originalTitleIndex, name);
       }

--- a/apps/frontend/src/components/global/ExportCKLModal.vue
+++ b/apps/frontend/src/components/global/ExportCKLModal.vue
@@ -312,6 +312,7 @@ export default class ExportCKLModal extends Vue {
 
   showingModal = false;
   formatProfileTitle = false;
+  updatingProfileTitle = false;
   originalProfileTitle = new Map<Number, string>();
   roles = Object.values(Role);
   types = Object.values(Assettype);
@@ -560,16 +561,17 @@ export default class ExportCKLModal extends Vue {
 
     // Find if we need to format the name
     let index = 0;
-    const searchArray = ['stig-baseline', 'cis-baseline', 'srg-baseline'];
-    for (let i = 0; i < searchArray.length; i++) {
-      if (name.indexOf(searchArray[i]) > 0) {
-        index = name.indexOf(searchArray[i]);
+    const baselineArray = ['stig-baseline', 'cis-baseline', 'srg-baseline'];
+    for (const baseline of baselineArray) {
+      if (name.indexOf(baseline) > 0) {
+        index = name.indexOf(baseline);
         break;
       }
     }
 
     // We need to format the name
     if (index > 0) {
+      this.updatingProfileTitle = true;
       const originalTitleIndex = fileIndex + profileIndex;
       // Preserver the old name
       if (!this.originalProfileTitle.has(originalTitleIndex)) {
@@ -577,7 +579,7 @@ export default class ExportCKLModal extends Vue {
       }
       // Get the name value up to the index, replace dashes with spaces
       newName = name.substring(0, index).split('-').join(' ');
-      // Convert the letter of the name into uppercase
+      // Convert the first letter of each word into uppercase
       newName = newName.replace(/(?:^\w|[A-Z]|\b\w)/g, function (word) {
         return word.toUpperCase();
       });
@@ -586,6 +588,7 @@ export default class ExportCKLModal extends Vue {
 
     // Update the file title for the profile being processed
     this.files[fileIndex].profiles[profileIndex].title = newName;
+
     return newName;
   }
 

--- a/apps/frontend/src/components/global/ExportJson.vue
+++ b/apps/frontend/src/components/global/ExportJson.vue
@@ -3,7 +3,7 @@
     <template #activator="{on}">
       <IconLinkItem
         key="export_json"
-        text="Export as HDF JSON"
+        text="Export as OHDF JSON"
         icon="mdi-code-json"
         @click="export_json()"
         v-on="on"

--- a/apps/frontend/src/components/global/ExportJson.vue
+++ b/apps/frontend/src/components/global/ExportJson.vue
@@ -3,7 +3,7 @@
     <template #activator="{on}">
       <IconLinkItem
         key="export_json"
-        text="Export as JSON"
+        text="Export as HDF JSON"
         icon="mdi-code-json"
         @click="export_json()"
         v-on="on"


### PR DESCRIPTION
Provide a checkbox that normalizes (proper formats) the profile title (name). Also fixes issue # #2375

Example, if the name is: `redhat-enterprise-linux-8-stig-baseline`
It normalizes to:  'Redhat Enterprise Linux 8 Security Technical Implementation Guide`

### Logic ###
Process exchanges profile titles that end with 'stig-baseline', 'cis-baseline', 'srg-baseline' to Security Technical Implementation Guide and capitalizes all preceding words removing the dashes.

Without applying title formatting:
![image](https://github.com/mitre/heimdall2/assets/13986875/1e025a1e-f7d9-4ad9-be77-5fca1a85cf9b)

After applying title formatting:
![image](https://github.com/mitre/heimdall2/assets/13986875/a35bd107-ba65-469b-a658-033184bf31ee)

