### PR TITLE
GoSec Mapper `impact` Fix

### DIFF
--- a/libs/hdf-converters/sample_jsons/gosec_mapper/gosec-hdf-withraw.json
+++ b/libs/hdf-converters/sample_jsons/gosec_mapper/gosec-hdf-withraw.json
@@ -129,6 +129,130 @@
           "Golang errors": {}
         }
       }
-    ]
+    ],
+    "raw": {
+      "Golang errors": {},
+      "Issues": [
+        {
+          "severity": "MEDIUM",
+          "confidence": "HIGH",
+          "cwe": {
+            "id": "22",
+            "url": "https://cwe.mitre.org/data/definitions/22.html"
+          },
+          "rule_id": "G304",
+          "details": "Potential file inclusion via variable",
+          "file": "C:\\Users\\AGILLUM\\OneDrive - The MITRE Corporation\\Documents\\Code\\grype-0.34.4\\internal\\file\\tar.go",
+          "code": "82: \t\tcase tar.TypeReg:\n83: \t\t\tf, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))\n84: \t\t\tif err != nil {\n",
+          "line": "83",
+          "column": "14",
+          "nosec": false,
+          "suppressions": null
+        },
+        {
+          "severity": "MEDIUM",
+          "confidence": "HIGH",
+          "cwe": {
+            "id": "22",
+            "url": "https://cwe.mitre.org/data/definitions/22.html"
+          },
+          "rule_id": "G304",
+          "details": "Potential file inclusion via variable",
+          "file": "C:\\Users\\AGILLUM\\OneDrive - The MITRE Corporation\\Documents\\Code\\grype-0.34.4\\grype\\presenter\\template\\presenter.go",
+          "code": "51: \n52: \ttemplateContents, err := os.ReadFile(expandedPathToTemplateFile)\n53: \tif err != nil {\n",
+          "line": "52",
+          "column": "27",
+          "nosec": false,
+          "suppressions": null
+        },
+        {
+          "severity": "MEDIUM",
+          "confidence": "HIGH",
+          "cwe": {
+            "id": "22",
+            "url": "https://cwe.mitre.org/data/definitions/22.html"
+          },
+          "rule_id": "G304",
+          "details": "Potential file inclusion via variable",
+          "file": "C:\\Users\\AGILLUM\\OneDrive - The MITRE Corporation\\Documents\\Code\\grype-0.34.4\\grype\\pkg\\syft_sbom_provider.go",
+          "code": "95: func isPossibleSBOM(userInput string) bool {\n96: \tf, err := os.Open(userInput)\n97: \tif err != nil {\n",
+          "line": "96",
+          "column": "12",
+          "nosec": false,
+          "suppressions": null
+        },
+        {
+          "severity": "MEDIUM",
+          "confidence": "HIGH",
+          "cwe": {
+            "id": "22",
+            "url": "https://cwe.mitre.org/data/definitions/22.html"
+          },
+          "rule_id": "G304",
+          "details": "Potential file inclusion via variable",
+          "file": "C:\\Users\\AGILLUM\\OneDrive - The MITRE Corporation\\Documents\\Code\\grype-0.34.4\\grype\\pkg\\syft_sbom_provider.go",
+          "code": "86: \n87: \tsbom, err := os.Open(expandedPath)\n88: \tif err != nil {\n",
+          "line": "87",
+          "column": "15",
+          "nosec": false,
+          "suppressions": null
+        },
+        {
+          "severity": "MEDIUM",
+          "confidence": "HIGH",
+          "cwe": {
+            "id": "22",
+            "url": "https://cwe.mitre.org/data/definitions/22.html"
+          },
+          "rule_id": "G304",
+          "details": "Potential file inclusion via variable",
+          "file": "C:\\Users\\AGILLUM\\OneDrive - The MITRE Corporation\\Documents\\Code\\grype-0.34.4\\cmd\\report_writer.go",
+          "code": "18: \tdefault:\n19: \t\treportFile, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)\n20: \n",
+          "line": "19",
+          "column": "22",
+          "nosec": false,
+          "suppressions": null
+        },
+        {
+          "severity": "MEDIUM",
+          "confidence": "HIGH",
+          "cwe": {
+            "id": "276",
+            "url": "https://cwe.mitre.org/data/definitions/276.html"
+          },
+          "rule_id": "G302",
+          "details": "Expect file permissions to be 0600 or less",
+          "file": "C:\\Users\\AGILLUM\\OneDrive - The MITRE Corporation\\Documents\\Code\\grype-0.34.4\\cmd\\report_writer.go",
+          "code": "18: \tdefault:\n19: \t\treportFile, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)\n20: \n",
+          "line": "19",
+          "column": "22",
+          "nosec": false,
+          "suppressions": null
+        },
+        {
+          "severity": "MEDIUM",
+          "confidence": "HIGH",
+          "cwe": {
+            "id": "276",
+            "url": "https://cwe.mitre.org/data/definitions/276.html"
+          },
+          "rule_id": "G301",
+          "details": "Expect directory permissions to be 0750 or less",
+          "file": "C:\\Users\\AGILLUM\\OneDrive - The MITRE Corporation\\Documents\\Code\\grype-0.34.4\\internal\\file\\tar.go",
+          "code": "76: \t\t\tif _, err := os.Stat(target); err != nil {\n77: \t\t\t\tif err := os.MkdirAll(target, 0755); err != nil {\n78: \t\t\t\t\treturn fmt.Errorf(\"failed to mkdir (%s): %w\", target, err)\n",
+          "line": "77",
+          "column": "15",
+          "nosec": false,
+          "suppressions": null
+        }
+      ],
+      "Stats": {
+        "files": 199,
+        "lines": 12401,
+        "nosec": 0,
+        "found": 7
+      },
+      "GosecVersion": "dev"
+    }
   }
 }

--- a/libs/hdf-converters/test/mappers/forward/gosec_mapper.spec.ts
+++ b/libs/hdf-converters/test/mappers/forward/gosec_mapper.spec.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import {GoSecMapper} from '../../../src/gosec-mapper';
 import {omitVersions} from '../../utils';
+
 describe('gosec_mapper', () => {
   it('Successfully converts gosec reports', () => {
     const mapper = new GoSecMapper(
@@ -10,10 +11,42 @@ describe('gosec_mapper', () => {
       )
     );
 
+    // fs.writeFileSync(
+    //   'sample_jsons/gosec_mapper/gosec-hdf.json',
+    //   JSON.stringify(mapper.toHdf(), null, 2)
+    // );
+
     expect(omitVersions(mapper.toHdf())).toEqual(
       omitVersions(
         JSON.parse(
           fs.readFileSync('sample_jsons/gosec_mapper/gosec-hdf.json', {
+            encoding: 'utf-8'
+          })
+        )
+      )
+    );
+  });
+});
+
+describe('gosec_mapper_withraw', () => {
+  it('Successfully converts withRaw flagged gosec reports', () => {
+    const mapper = new GoSecMapper(
+      fs.readFileSync(
+        'sample_jsons/gosec_mapper/sample_input_report/Grype_gosec_results.json',
+        {encoding: 'utf-8'}
+      ),
+      true
+    );
+
+    // fs.writeFileSync(
+    //   'sample_jsons/gosec_mapper/gosec-hdf-withraw.json',
+    //   JSON.stringify(mapper.toHdf(), null, 2)
+    // );
+
+    expect(omitVersions(mapper.toHdf())).toEqual(
+      omitVersions(
+        JSON.parse(
+          fs.readFileSync('sample_jsons/gosec_mapper/gosec-hdf-withraw.json', {
             encoding: 'utf-8'
           })
         )


### PR DESCRIPTION
- Fix `impact` to refer to GoSec's `severity` field.
- Other minor adjustments to mapper.