### PR TITLE
Swapped adm-zip out for zip.js

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -58,7 +58,7 @@
     "@vue/cli-service": "^5.0.8",
     "@vue/eslint-config-prettier": "^7.0.0",
     "@vue/eslint-config-typescript": "^13.0.0",
-    "adm-zip": "^0.5.10",
+    "@zip.js/zip.js": "^2.7.47",
     "apexcharts": "^3.10.1",
     "axios": "^1.3.5",
     "chroma-js": "^2.1.0",
@@ -113,7 +113,6 @@
     "xml-js": "^1.6.11"
   },
   "devDependencies": {
-    "@types/adm-zip": "^0.5.0",
     "@types/chai": "^4.2.5",
     "@types/chai-as-promised": "^7.1.2",
     "@types/jest": "^27.0.0",
@@ -128,7 +127,7 @@
     "vue-jest": "^3.0.7"
   },
   "engines": {
-    "node": "^18.19.0"
+    "node": ">=18.19.0"
   },
   "branch": "/blob/master/",
   "changelog": "/releases",

--- a/apps/frontend/src/types/adm-zip/index.d.ts
+++ b/apps/frontend/src/types/adm-zip/index.d.ts
@@ -1,1 +1,0 @@
-declare module 'adm-zip';

--- a/apps/frontend/src/utilities/tenable_util.ts
+++ b/apps/frontend/src/utilities/tenable_util.ts
@@ -1,6 +1,14 @@
-import Zip from 'adm-zip';
 import axios, {AxiosInstance} from 'axios';
 import {createWinstonLogger} from '../../../../libs/hdf-converters/src/utils/global';
+
+let zip: any;
+try {
+  (async () => {
+    zip = await import('@zip.js/zip.js');
+  })();
+} catch (e) {
+  console.log(`zip module import failed: ${e}`);
+}
 
 /** represents the information of the current used */
 export interface AuthInfo {
@@ -44,7 +52,7 @@ export class TenableUtil {
 
   async loginToTenable(): Promise<boolean> {
     logger.info(`Connecting to Tenable Client`);
-    return new Promise((resolve, reject) => {
+    return new Promise(async (resolve, reject) => {
       setTimeout(
         () =>
           reject(
@@ -56,32 +64,25 @@ export class TenableUtil {
       );
 
       try {
-        this.axios_instance({
+        const response = await this.axios_instance({
           method: 'get',
           url: '/rest/currentUser'
-        })
-          .then((response) => {
-            resolve(response.request.finished);
-          })
-          .catch((error) => {
-            try {
-              if (error.code == 'ENOTFOUND') {
-                reject(
-                  `Host: ${this.hostConfig.host_url} not found, check the Host Name (URL) or the network`
-                );
-              } else if (error.response.data.error_code == 74) {
-                reject('Incorrect Access or Secret key');
-              } else {
-                reject(error.response.data.error_msg);
-              }
-            } catch (e) {
-              reject(
-                `Possible network connection blocked by CORS policy. Received error: ${error}`
-              );
-            }
-          });
-      } catch (e) {
-        reject(`Unknown error: ${e}`);
+        });
+        resolve(response.request.finished);
+      } catch (error) {
+        if (error?.code === 'ENOTFOUND') {
+          reject(
+            `Host: ${this.hostConfig.host_url} not found, check the Host Name (URL) or the network`
+          );
+        } else if (error?.response?.data?.error_code === 74) {
+          reject('Incorrect Access or Secret key');
+        } else if (error?.response?.data?.error_msg) {
+          reject(error.response.data.error_msg);
+        } else {
+          reject(
+            `Possible network connection blocked by CORS policy. Received error: ${error}`
+          );
+        }
       }
     });
   }
@@ -93,7 +94,7 @@ export class TenableUtil {
    */
   async getScans(startTime: number, endTime: number): Promise<[]> {
     logger.info(`Getting scans from Tenable Client`);
-    return new Promise((resolve, reject) => {
+    return new Promise(async (resolve, reject) => {
       setTimeout(
         () =>
           reject(
@@ -105,22 +106,21 @@ export class TenableUtil {
       );
 
       try {
-        this.axios_instance({
+        const response = await this.axios_instance({
           method: 'get',
           url: `/rest/scanResult?fields=name,description,details,scannedIPs,totalChecks,startTime,finishTime,status&startTime=${startTime}&endTime=${endTime}`
-        })
-          .then((response) => {
-            resolve(response.data.response.usable);
-          })
-          .catch((error) => {
-            if (error.response.data.error_code == 74) {
-              reject('Incorrect Access or Secret key');
-            } else {
-              reject(error.response.data.error_msg);
-            }
-          });
-      } catch (e) {
-        reject(e);
+        });
+        resolve(response.data.response.usable);
+      } catch (error) {
+        if (error?.response?.data?.error_code === 74) {
+          reject('Incorrect Access or Secret key');
+        } else if (error?.response?.data?.error_msg) {
+          reject(error.response.data.error_msg);
+        } else {
+          reject(
+            `Possible network connection blocked by CORS policy. Received error: ${error}`
+          );
+        }
       }
     });
   }
@@ -135,7 +135,7 @@ export class TenableUtil {
    */
   async getVulnerabilities(scanId: string): Promise<string> {
     logger.info(`Getting vulnerabilities from Tenable Client`);
-    return new Promise((resolve, reject) => {
+    return new Promise(async (resolve, reject) => {
       setTimeout(
         () =>
           reject(
@@ -147,24 +147,18 @@ export class TenableUtil {
       );
 
       try {
-        this.axios_instance({
+        const response = await this.axios_instance({
           method: 'post',
           url: `rest/scanResult/${scanId}/download?downloadType=v2`,
           responseType: 'arraybuffer'
-        })
-          .then((response) => {
-            // Unzip response in memory
-            try {
-              const zip = new Zip(Buffer.from(response.data));
-              const zipEntries = zip.getEntries();
-              resolve(zip.readAsText(zipEntries[0]));
-            } catch (unzipErr) {
-              reject(unzipErr);
-            }
-          })
-          .catch((error) => {
-            reject(error);
-          });
+        });
+        const zipReader = new zip.ZipReader(
+          new zip.BlobReader(Buffer.from(response.data))
+        );
+        const zipEntries = await zipReader.getEntries();
+        const contents = await zipEntries[0].getData(new zip.TextWriter());
+        await zipReader.close();
+        resolve(contents);
       } catch (e) {
         reject(e);
       }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "vue-template-compiler": "^2.7.16"
   },
   "engines": {
-    "node": "^18.19.0"
+    "node": ">=18.19.0"
   },
   "version": "0.0.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4040,13 +4040,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/adm-zip@^0.5.0":
-  version "0.5.5"
-  resolved "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.5.tgz#4588042726aa5f351d7ea88232e4a952f60e7c1a"
-  integrity sha512-YCGstVMjc4LTY5uK9/obvxBya93axZOVOyf2GSUulADzmLhYE45u2nAssCs/fWBs1Ifq5Vat75JTPwd5XZoPJw==
-  dependencies:
-    "@types/node" "*"
-
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.14":
   version "7.20.5"
   resolved "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz#3df15f27ba85319caa07ba08d0721889bb39c017"
@@ -5684,6 +5677,11 @@
   resolved "https://registry.npmjs.org/@yr/monotone-cubic-spline/-/monotone-cubic-spline-1.0.3.tgz#7272d89f8e4f6fb7a1600c28c378cc18d3b577b9"
   integrity sha512-FQXkOta0XBSUPHndIKON2Y9JeQz5ZeMqLYZVVK93FliNBFm7LNMIZmY6FrMEB9XPcDbE2bekMbZD6kzDkxwYjA==
 
+"@zip.js/zip.js@^2.7.47":
+  version "2.7.47"
+  resolved "https://registry.yarnpkg.com/@zip.js/zip.js/-/zip.js-2.7.47.tgz#bc3ec3d3b191f2331450242edfa06dfac08082cc"
+  integrity sha512-jmtJMA3/Jl4rMzo/DZ79s6g0CJ1AZcNAO6emTy/vHfIKAB/iiFY7PLs6KmbRTJ+F8GnK2eCLnjQfCCneRxXgzg==
+
 "@zkochan/js-yaml@0.0.6":
   version "0.0.6"
   resolved "https://registry.npmjs.org/@zkochan/js-yaml/-/js-yaml-0.0.6.tgz#975f0b306e705e28b8068a07737fa46d3fc04826"
@@ -5781,11 +5779,6 @@ address@^1.1.2:
   version "1.2.2"
   resolved "https://registry.npmjs.org/address/-/address-1.2.2.tgz#2b5248dac5485a6390532c6a517fda2e3faac89e"
   integrity sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==
-
-adm-zip@^0.5.10:
-  version "0.5.12"
-  resolved "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.12.tgz#87786328e91d54b37358d8a50f954c4cd73ba60b"
-  integrity sha512-6TVU49mK6KZb4qG6xWaaM4C7sA/sgUMLy/JYMOzkcp3BvVLpW0fXDFQiIzAuxFCt/2+xD7fNIiPFAoLZPhVNLQ==
 
 agent-base@6:
   version "6.0.2"
@@ -16934,7 +16927,7 @@ pretty@2.0.0, pretty@^2.0.0:
     extend-shallow "^2.0.1"
     js-beautify "^1.6.12"
 
-prismjs@1.29.0, prismjs@^1.23.0, prismjs@^1.29.0:
+prismjs@^1.23.0, prismjs@^1.29.0:
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.29.0.tgz#f113555a8fa9b57c35e637bba27509dcf802dd12"
   integrity sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==


### PR DESCRIPTION
`adm-zip` was causing issues such as the following

```
 warning  in ../../node_modules/adm-zip/util/fileSystem.js

Module not found: Error: Can't resolve 'original-fs' in '/Users/amann/work/auto/dependency-track-mapper/heimdall2/node_modules/adm-zip/util'
```

which was causing heimdall to have runtime errors and not display itself properly.  This had been throwing warnings before but had started to actually cause this runtime problem when making other changes so I decided to fix it.

Easiest thing to do was to replace it wholesale.  Sidebenefit is that I found `zip.js` which has built-in types so we have that benefit.

The only problem is that it is not a commonjs dependency so we have to do a dynamic import which is a bit ugly due to the lack of top level await that we're currently suffering from.  I'm working on getting us able to use that functionality, but that shouldn't be a blocker for this pr.

Also I cleaned up the files we touched a little bit.