### PR TITLE
Update msft-secure-score-mapper.ts

### DIFF
--- a/libs/hdf-converters/src/msft-secure-score-mapper.ts
+++ b/libs/hdf-converters/src/msft-secure-score-mapper.ts
@@ -115,7 +115,8 @@ export class MsftSecureScoreMapper extends BaseConverter {
                   return this.getProfiles(data.controlName || '')
                     .filter((profile) => profile.userImpact !== undefined)
                     .map((profile) => profile.userImpact);
-                }
+                },
+               nist: ['SA-11', 'RA-5']
               }
             },
             source_location: {},


### PR DESCRIPTION
Adding a default nist tag so it doesn't show up as "UM-1" in Heimdall. For now.