### PR TITLE
updateTenableContentSecurityPolicy

### DIFF
--- a/apps/backend/config/app_config.ts
+++ b/apps/backend/config/app_config.ts
@@ -35,6 +35,24 @@ export default class AppConfig {
     return process.env[key] || this.envConfig[key];
   }
 
+  getSplunkHostUrl(): string {
+    const splunk_host_url = this.get('SPLUNK_HOST_URL');
+    if (splunk_host_url !== undefined) {
+      return splunk_host_url;
+    } else {
+      return '';
+    }
+  }
+
+  getTenableHostUrl(): string {
+    const tenable_host_url = this.get('TENABLE_HOST_URL');
+    if (tenable_host_url !== undefined) {
+      return tenable_host_url;
+    } else {
+      return '';
+    }
+  }
+
   getDatabaseName(): string {
     const databaseName = this.get('DATABASE_NAME');
     const nodeEnvironment = this.get('NODE_ENV');

--- a/apps/backend/src/config/config.service.ts
+++ b/apps/backend/src/config/config.service.ts
@@ -57,8 +57,18 @@ export class ConfigService {
       oidcName: this.get('OIDC_NAME') || '',
       ldap: this.get('LDAP_ENABLED')?.toLocaleLowerCase() === 'true' || false,
       registrationEnabled: this.isRegistrationAllowed(),
-      localLoginEnabled: this.isLocalLoginAllowed()
+      localLoginEnabled: this.isLocalLoginAllowed(),
+      tenableHostUrl: this.getTenableHostUrl(),
+      splunkHostUrl: this.getSplunkHostUrl()
     });
+  }
+
+  getSplunkHostUrl(): string {
+    return this.appConfig.getSplunkHostUrl();
+  }
+
+  getTenableHostUrl(): string {
+    return this.appConfig.getTenableHostUrl();
   }
 
   getDbConfig(): SequelizeOptions {

--- a/apps/backend/src/config/dto/startup-settings.dto.ts
+++ b/apps/backend/src/config/dto/startup-settings.dto.ts
@@ -11,6 +11,8 @@ export class StartupSettingsDto implements IStartupSettings {
   readonly ldap: boolean;
   readonly registrationEnabled: boolean;
   readonly localLoginEnabled: boolean;
+  readonly tenableHostUrl: string;
+  readonly splunkHostUrl: string;
 
   constructor(settings: IStartupSettings) {
     this.apiKeysEnabled = settings.apiKeysEnabled;
@@ -23,5 +25,7 @@ export class StartupSettingsDto implements IStartupSettings {
     this.ldap = settings.ldap;
     this.registrationEnabled = settings.registrationEnabled;
     this.localLoginEnabled = settings.localLoginEnabled;
+    this.tenableHostUrl = settings.tenableHostUrl;
+    this.splunkHostUrl = settings.splunkHostUrl;
   }
 }

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -15,6 +15,7 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   const configService = app.get<ConfigService>(ConfigService);
   app.enableShutdownHooks();
+  app.enableCors();
   app.use(helmet());
   app.use(
     helmet.contentSecurityPolicy({
@@ -40,7 +41,9 @@ async function bootstrap() {
         'connect-src': [
           "'self'",
           'https://api.github.com',
-          'https://sts.amazonaws.com'
+          'https://sts.amazonaws.com',
+          configService.getTenableHostUrl(),
+          configService.getSplunkHostUrl()
         ]
       }
     })

--- a/apps/frontend/src/components/global/upload_tabs/tenable/AuthStep.vue
+++ b/apps/frontend/src/components/global/upload_tabs/tenable/AuthStep.vue
@@ -2,6 +2,7 @@
   <div>
     <v-form>
       <v-text-field
+        ref="access_Key"
         v-model="accesskey"
         label="Access Token (Key)"
         for="accesskey_field"
@@ -9,6 +10,7 @@
         data-cy="tenableaccesskey"
       />
       <v-text-field
+        ref="secret_Key"
         v-model="secretkey"
         label="Secret Token (Key)"
         for="secretkey_field"
@@ -18,6 +20,7 @@
         data-cy="tenablesecretkey"
       />
       <v-text-field
+        ref="hostname_value"
         v-model="hostname"
         label="Hostname"
         for="hostname_field"
@@ -70,12 +73,38 @@ export default class AuthStep extends Vue {
   secretkey = '';
   hostname = '';
 
+  $refs!: {
+    access_Key: HTMLInputElement;
+    secret_Key: HTMLAnchorElement;
+    hostname_value: HTMLAnchorElement;
+  };
+
   // Form required field rule
   reqRule = requireFieldRule;
 
   async login(): Promise<void> {
+    if (!this.accesskey) {
+      SnackbarModule.failure('The Access Token (key) is required');
+      this.$refs.access_Key.focus();
+      return;
+    } else if (!this.secretkey) {
+      SnackbarModule.failure('The Secret Token (key) is required');
+      this.$refs.secret_Key.focus();
+      return;
+    } else if (!this.hostname) {
+      SnackbarModule.failure('The Tenable.Sc URL is required');
+      this.$refs.hostname_value.focus();
+      return;
+    }
+
+    // If the protocol (https) is missing add it
     if (!/^https?:\/\//.test(this.hostname)) {
       this.hostname = `https://${this.hostname}`;
+    }
+
+    // If the SSL/TLS port is missing add default 443
+    if (!this.hostname.split(':')[2]) {
+      this.hostname = `${this.hostname}:443`;
     }
 
     const config: AuthInfo = {

--- a/apps/frontend/src/components/global/upload_tabs/tenable/TenableReader.vue
+++ b/apps/frontend/src/components/global/upload_tabs/tenable/TenableReader.vue
@@ -41,7 +41,7 @@
           </span>
           <br />
           <span>
-            For connection instructions and further information, check here:
+            For connection instructions and further information, consult:
           </span>
           <v-btn
             target="_blank"

--- a/apps/frontend/src/store/server.ts
+++ b/apps/frontend/src/store/server.ts
@@ -35,6 +35,8 @@ export interface IServerState {
   ldap: boolean;
   localLoginEnabled: boolean;
   userInfo: IUser;
+  tenableHostUrl: string | undefined;
+  splunkHostUrl: string | undefined;
 }
 
 interface LoginData {
@@ -63,6 +65,8 @@ class Server extends VuexModule implements IServerState {
   enabledOAuth: string[] = [];
   allUsers: ISlimUser[] = [];
   oidcName = '';
+  tenableHostUrl: string = '';
+  splunkHostUrl: string = '';
   /** Our currently granted JWT token */
   token = '';
   /** Provide a sane default for userInfo in order to avoid having to null check it all the time */
@@ -106,6 +110,8 @@ class Server extends VuexModule implements IServerState {
     this.oidcName = settings.oidcName;
     this.ldap = settings.ldap;
     this.localLoginEnabled = settings.localLoginEnabled;
+    this.tenableHostUrl = settings.tenableHostUrl;
+    this.splunkHostUrl = settings.splunkHostUrl;
   }
 
   @Mutation

--- a/apps/frontend/src/utilities/tenable_util.ts
+++ b/apps/frontend/src/utilities/tenable_util.ts
@@ -1,5 +1,6 @@
 import Zip from 'adm-zip';
 import axios, {AxiosInstance} from 'axios';
+import {ServerModule} from '@/store/server';
 import {createWinstonLogger} from '../../../../libs/hdf-converters/src/utils/global';
 
 /** represents the information of the current used */
@@ -49,7 +50,7 @@ export class TenableUtil {
         () =>
           reject(
             new Error(
-              'Login timed out. Please check your CORS configuration or validate you have inputted the correct domain'
+              'Login timed out. Please ensure the provided credentials, domain values are valid and try again.'
             )
           ),
         5000
@@ -64,26 +65,65 @@ export class TenableUtil {
             resolve(response.request.finished);
           })
           .catch((error) => {
-            try {
-              if (error.code == 'ENOTFOUND') {
-                reject(
-                  `Host: ${this.hostConfig.host_url} not found, check the Host Name (URL) or the network`
-                );
-              } else if (error.response.data.error_code == 74) {
-                reject('Incorrect Access or Secret key');
-              } else {
-                reject(error.response.data.error_msg);
-              }
-            } catch (e) {
-              reject(
-                `Possible network connection blocked by CORS policy. Received error: ${error}`
-              );
-            }
+            reject(this.getRejectConnectionMessage(error));
           });
       } catch (e) {
         reject(`Unknown error: ${e}`);
       }
     });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getRejectConnectionMessage(error: any): String {
+    let rejectMsg = '';
+
+    if (error.response) {
+      // The request was made and the server responded with a status code
+      // that falls out of the range of 2xx
+
+      if (error.response.data.error_code == 74) {
+        rejectMsg = 'Incorrect Access or Secret key';
+      } else {
+        rejectMsg = `${error.name} : ${error.response.data.error_msg}`;
+      }
+    } else if (error.request) {
+      // The request was made but no response was received.
+      // `error.request` is an instance of XMLHttpRequest in the
+      // browser and an instance of http.ClientRequest in node.js
+
+      if (error.code == 'ERR_NETWORK') {
+        // Check if the tenable url was provided - Content Security Policy (CSP)
+        const tenableUrl = ServerModule.tenableHostUrl;
+        if (tenableUrl) {
+          // If the URL is listed in the allows domains
+          // (.env variable TENABLE_HOST_URL) check if they match
+          if (!error.config.baseURL.includes(tenableUrl)) {
+            rejectMsg = `Hostname: ${error.config.baseURL} violates the Content Security Policy (CSP). The host allowed by the CSP is: ${tenableUrl}`;
+          } else {
+            // CSP url didn't match, check for port match - reject appropriately
+            const portNumber = parseInt(this.hostConfig.host_url.split(':')[2]);
+            if (portNumber != 443) {
+              rejectMsg = `Invalid SSL/TSL port number used: ${portNumber} must be 443.`;
+            } else {
+              rejectMsg =
+                'Access blocked by CORS, enable CORS on the browser and try again. See Help for additional instructions';
+            }
+          }
+        } else {
+          // The URL is not listed in the allows domains (CSP)
+          rejectMsg =
+            'The Content Security Policy directive environment variable "TENABLE_HOST_URL" not configured. See Help for additional instructions.';
+        }
+      } else if (error.code == 'ENOTFOUND') {
+        rejectMsg = `Host: ${error.config.baseURL} not found, check the Hostname (URL) or the network.`;
+      } else {
+        rejectMsg = `${error.name} : ${error.message}`;
+      }
+    } else {
+      // Something happened in setting up the request that triggered an Error
+      rejectMsg = `${error.name} : ${error.message}`;
+    }
+    return rejectMsg;
   }
 
   /**
@@ -98,7 +138,7 @@ export class TenableUtil {
         () =>
           reject(
             new Error(
-              'Login timed out. Please check your CORS configuration or validate you have inputted the correct domain'
+              'Login timed out. Please ensure the provided credentials and domain values are valid.'
             )
           ),
         5000
@@ -113,11 +153,7 @@ export class TenableUtil {
             resolve(response.data.response.usable);
           })
           .catch((error) => {
-            if (error.response.data.error_code == 74) {
-              reject('Incorrect Access or Secret key');
-            } else {
-              reject(error.response.data.error_msg);
-            }
+            reject(error.name + ': ' + error.message);
           });
       } catch (e) {
         reject(e);
@@ -140,7 +176,7 @@ export class TenableUtil {
         () =>
           reject(
             new Error(
-              'Login timed out. Please check your CORS configuration or validate you have inputted the correct domain'
+              'Login timed out. Please check your CORS configuration and validate that the hostname is correct.'
             )
           ),
         5000

--- a/libs/interfaces/config/startup-settings.interface.ts
+++ b/libs/interfaces/config/startup-settings.interface.ts
@@ -9,4 +9,6 @@ export interface IStartupSettings {
   readonly ldap: boolean;
   readonly registrationEnabled: boolean;
   readonly localLoginEnabled: boolean;
+  readonly tenableHostUrl: string;
+  readonly splunkHostUrl: string;
 }


### PR DESCRIPTION
Added tenable url to the Heimdall Content Security Policy - this allows cross-domain calls from Heimdall to a defined Tenable URL.

Please review the .env requirements [here](https://github.com/mitre/heimdall2/wiki/Environment-Variables-Configuration#external-interfaces). Additionally the browser must allow for CORS, [see here for how to configure](https://github.com/mitre/heimdall2/wiki/Heimdall-Interface-Connections#tenablesc-cors-configuration)

Fixes Issue: #6127 