### PR TITLE
Update Checklist Mapper Import to Allow Multiple Mac Addresses

### DIFF
--- a/libs/hdf-converters/sample_jsons/checklist_mapper/multiple_mac_addresses_metadata.json
+++ b/libs/hdf-converters/sample_jsons/checklist_mapper/multiple_mac_addresses_metadata.json
@@ -1,0 +1,287 @@
+{
+  "platform": {
+    "name": "Heimdall Tools",
+    "release": "2.11.3"
+  },
+  "version": "2.11.3",
+  "statistics": {},
+  "profiles": [
+    {
+      "name": "Cisco_ASA_FW_STIG",
+      "version": "1",
+      "title": "Cisco ASA Firewall Security Technical Implementation Guide",
+      "summary": "This Security Technical Implementation Guide is published as a tool to improve the security of Department of Defense (DOD) information systems. The requirements are derived from the National Institute of Standards and Technology (NIST) 800-53 and related documents. Comments or proposed revisions to this document should be sent via email to the following address: disa.stig_spt@mail.mil.",
+      "license": "terms-of-use",
+      "supports": [],
+      "attributes": [],
+      "groups": [],
+      "status": "loaded",
+      "controls": [
+        {
+          "tags": {
+            "gtitle": "SRG-NET-000019-FW-000003",
+            "rid": "SV-239852r665842_rule",
+            "gid": "V-239852",
+            "stig_id": "CASA-FW-000010",
+            "cci": [
+              "CCI-001414"
+            ],
+            "nist": [
+              "AC-4"
+            ],
+            "severity": "high",
+            "weight": "10.0",
+            "STIGRef": "Cisco ASA Firewall Security Technical Implementation Guide :: Version 1, Release: 4 Benchmark Date: 27 Apr 2023"
+          },
+          "refs": [],
+          "source_location": {},
+          "title": "The Cisco ASA must be configured to filter outbound traffic, allowing only authorized ports and services.",
+          "id": "V-239852",
+          "desc": "Information flow control regulates where information is allowed to travel within a network and between interconnected networks. Blocking or restricting detected harmful or suspicious communications between interconnected networks enforces approved authorizations for controlling the flow of traffic.\n\nThe firewall that filters traffic outbound to interconnected networks with different security policies must be configured to permit or block traffic based on organization-defined traffic authorizations.",
+          "descriptions": [
+            {
+              "data": "Review the ASA configuration to determine if it only permits outbound traffic using authorized ports and services.\n\nStep 1: Verify that an ingress ACL has been applied to all internal interfaces as shown in the example below.\n\n interface GigabitEthernet0/0\n nameif INSIDE\n security-level 100\n ip address 10.1.11.1 255.255.255.0\n…\n…\n…\naccess-group INSIDE _IN in interface INSIDE \n\nStep 2: Verify that the ingress ACL only allows outbound traffic using authorized ports and services as shown in the example below.\n\naccess-list INSIDE _IN extended permit tcp any any eq www \naccess-list INSIDE _IN extended permit tcp any any eq https \naccess-list INSIDE _IN extended permit tcp any any eq …\naccess-list INSIDE _IN extended deny ip any any log\n\nIf the ASA is not configured to only allow outbound traffic using authorized ports and services, this is a finding.",
+              "label": "check"
+            },
+            {
+              "data": "Step 1: Configure the ingress ACL similar to the example below.\n\nASA(config)# access-list INSIDE_INextended permit tcp any any eq https\nASA(config)# access-list INSIDE_INextended permit tcp any any eq http\nASA(config)# access-list INSIDE_INextended permit tcp any any eq …\nASA(config)# access-list INSIDE_INextended deny ip any any log      \n\nStep 2: Apply the ACL inbound on all internal interfaces as shown in the example below.\n\nASA(config)# access-group INSIDE_IN in interface INSIDE\nASA(config)# end",
+              "label": "fix"
+            }
+          ],
+          "impact": 0.7,
+          "code": "{\n  \"status\": \"Not Reviewed\",\n  \"findingdetails\": \"\",\n  \"comments\": \"\",\n  \"severityoverride\": \"\",\n  \"severityjustification\": \"\",\n  \"vulnNum\": \"V-239852\",\n  \"severity\": \"high\",\n  \"groupTitle\": \"SRG-NET-000019-FW-000003\",\n  \"ruleId\": \"SV-239852r665842_rule\",\n  \"ruleVer\": \"CASA-FW-000010\",\n  \"ruleTitle\": \"The Cisco ASA must be configured to filter outbound traffic, allowing only authorized ports and services.\",\n  \"vulnDiscuss\": \"Information flow control regulates where information is allowed to travel within a network and between interconnected networks. Blocking or restricting detected harmful or suspicious communications between interconnected networks enforces approved authorizations for controlling the flow of traffic.\\n\\nThe firewall that filters traffic outbound to interconnected networks with different security policies must be configured to permit or block traffic based on organization-defined traffic authorizations.\",\n  \"iaControls\": \"\",\n  \"checkContent\": \"Review the ASA configuration to determine if it only permits outbound traffic using authorized ports and services.\\n\\nStep 1: Verify that an ingress ACL has been applied to all internal interfaces as shown in the example below.\\n\\n interface GigabitEthernet0/0\\n nameif INSIDE\\n security-level 100\\n ip address 10.1.11.1 255.255.255.0\\n…\\n…\\n…\\naccess-group INSIDE _IN in interface INSIDE \\n\\nStep 2: Verify that the ingress ACL only allows outbound traffic using authorized ports and services as shown in the example below.\\n\\naccess-list INSIDE _IN extended permit tcp any any eq www \\naccess-list INSIDE _IN extended permit tcp any any eq https \\naccess-list INSIDE _IN extended permit tcp any any eq …\\naccess-list INSIDE _IN extended deny ip any any log\\n\\nIf the ASA is not configured to only allow outbound traffic using authorized ports and services, this is a finding.\",\n  \"fixText\": \"Step 1: Configure the ingress ACL similar to the example below.\\n\\nASA(config)# access-list INSIDE_INextended permit tcp any any eq https\\nASA(config)# access-list INSIDE_INextended permit tcp any any eq http\\nASA(config)# access-list INSIDE_INextended permit tcp any any eq …\\nASA(config)# access-list INSIDE_INextended deny ip any any log      \\n\\nStep 2: Apply the ACL inbound on all internal interfaces as shown in the example below.\\n\\nASA(config)# access-group INSIDE_IN in interface INSIDE\\nASA(config)# end\",\n  \"falsePositives\": \"\",\n  \"falseNegatives\": \"\",\n  \"documentable\": \"false\",\n  \"mitigations\": \"\",\n  \"potentialImpact\": \"\",\n  \"thirdPartyTools\": \"\",\n  \"mitigationControl\": \"\",\n  \"responsibility\": \"\",\n  \"securityOverrideGuidance\": \"\",\n  \"checkContentRef\": \"M\",\n  \"weight\": \"10.0\",\n  \"class\": \"Unclass\",\n  \"stigRef\": \"Cisco ASA Firewall Security Technical Implementation Guide :: Version 1, Release: 4 Benchmark Date: 27 Apr 2023\",\n  \"targetKey\": \"5339\",\n  \"stigUuid\": \"54b4701f-19a1-4d5b-9497-5be85f995362\",\n  \"legacyId\": \"; \",\n  \"cciRef\": \"CCI-001414\"\n}",
+          "results": [
+            {
+              "status": "skipped",
+              "code_desc": "",
+              "start_time": ""
+            }
+          ]
+        },
+        {
+          "tags": {
+            "gtitle": "SRG-NET-000019-FW-000004",
+            "rid": "SV-239853r665845_rule",
+            "gid": "V-239853",
+            "stig_id": "CASA-FW-000020",
+            "cci": [
+              "CCI-001414"
+            ],
+            "nist": [
+              "AC-4"
+            ],
+            "severity": "medium",
+            "weight": "10.0",
+            "STIGRef": "Cisco ASA Firewall Security Technical Implementation Guide :: Version 1, Release: 4 Benchmark Date: 27 Apr 2023"
+          },
+          "refs": [],
+          "source_location": {},
+          "title": "The Cisco ASA must immediately use updates made to policy enforcement mechanisms such as firewall rules, security policies, and security zones.",
+          "id": "V-239853",
+          "desc": "Information flow policies regarding dynamic information flow control include, for example, allowing or disallowing information flows based on changes to the Ports, Protocols, Services Management (PPSM) Category Assurance Levels (CAL) list, vulnerability assessments, or mission conditions. Changing conditions include changes in the threat environment and detection of potentially harmful or adverse events.",
+          "descriptions": [
+            {
+              "data": "By default, when you change a rule-based policy such as access rules, the changes become effective immediately. With transactional model configured, the rules are not active until after compilation.\n\nReview the ASA configuration and verify that the following command is not configured.\n\nasp rule-engine transactional-commit access-group\n\nIf transactional-commit access-group has been configured, this is a finding.",
+              "label": "check"
+            },
+            {
+              "data": "Remove the command asp rule-engine transactional-commit access-group\n\nASA(config)# no asp rule-engine transactional-commit access-group",
+              "label": "fix"
+            }
+          ],
+          "impact": 0.5,
+          "code": "{\n  \"status\": \"Not Reviewed\",\n  \"findingdetails\": \"\",\n  \"comments\": \"\",\n  \"severityoverride\": \"\",\n  \"severityjustification\": \"\",\n  \"vulnNum\": \"V-239853\",\n  \"severity\": \"medium\",\n  \"groupTitle\": \"SRG-NET-000019-FW-000004\",\n  \"ruleId\": \"SV-239853r665845_rule\",\n  \"ruleVer\": \"CASA-FW-000020\",\n  \"ruleTitle\": \"The Cisco ASA must immediately use updates made to policy enforcement mechanisms such as firewall rules, security policies, and security zones.\",\n  \"vulnDiscuss\": \"Information flow policies regarding dynamic information flow control include, for example, allowing or disallowing information flows based on changes to the Ports, Protocols, Services Management (PPSM) Category Assurance Levels (CAL) list, vulnerability assessments, or mission conditions. Changing conditions include changes in the threat environment and detection of potentially harmful or adverse events.\",\n  \"iaControls\": \"\",\n  \"checkContent\": \"By default, when you change a rule-based policy such as access rules, the changes become effective immediately. With transactional model configured, the rules are not active until after compilation.\\n\\nReview the ASA configuration and verify that the following command is not configured.\\n\\nasp rule-engine transactional-commit access-group\\n\\nIf transactional-commit access-group has been configured, this is a finding.\",\n  \"fixText\": \"Remove the command asp rule-engine transactional-commit access-group\\n\\nASA(config)# no asp rule-engine transactional-commit access-group\",\n  \"falsePositives\": \"\",\n  \"falseNegatives\": \"\",\n  \"documentable\": \"false\",\n  \"mitigations\": \"\",\n  \"potentialImpact\": \"\",\n  \"thirdPartyTools\": \"\",\n  \"mitigationControl\": \"\",\n  \"responsibility\": \"\",\n  \"securityOverrideGuidance\": \"\",\n  \"checkContentRef\": \"M\",\n  \"weight\": \"10.0\",\n  \"class\": \"Unclass\",\n  \"stigRef\": \"Cisco ASA Firewall Security Technical Implementation Guide :: Version 1, Release: 4 Benchmark Date: 27 Apr 2023\",\n  \"targetKey\": \"5339\",\n  \"stigUuid\": \"54b4701f-19a1-4d5b-9497-5be85f995362\",\n  \"legacyId\": \"; \",\n  \"cciRef\": \"CCI-001414\"\n}",
+          "results": [
+            {
+              "status": "skipped",
+              "code_desc": "",
+              "start_time": ""
+            }
+          ]
+        },
+        {
+          "tags": {
+            "gtitle": "SRG-NET-000061-FW-000001",
+            "rid": "SV-239854r665848_rule",
+            "gid": "V-239854",
+            "stig_id": "CASA-FW-000030",
+            "cci": [
+              "CCI-000067"
+            ],
+            "nist": [
+              "AC-17 (1)"
+            ],
+            "severity": "medium",
+            "weight": "10.0",
+            "STIGRef": "Cisco ASA Firewall Security Technical Implementation Guide :: Version 1, Release: 4 Benchmark Date: 27 Apr 2023"
+          },
+          "refs": [],
+          "source_location": {},
+          "title": "The Cisco ASA must be configured to restrict VPN traffic according to organization-defined filtering rules.",
+          "id": "V-239854",
+          "desc": "Remote access devices (such as those providing remote access to network devices and information systems) that lack automated capabilities increase risk and make remote user access management difficult at best.\n\nRemote access is access to DoD non-public information systems by an authorized user (or an information system) communicating through an external, non-organization-controlled network.\n\nAutomated monitoring of remote access sessions allows organizations to detect cyberattacks and also ensure ongoing compliance with remote access policies by auditing connection activities of remote access capabilities from a variety of information system components (e.g., servers, workstations, notebook computers, smart phones, and tablets).",
+          "descriptions": [
+            {
+              "data": "Step 1: Verify that an ACL has been applied to the applicable VPN group policy via the vpn-filter attribute as shown in the example below.\n\ngroup-policy VPN_POLICY internal\ngroup-policy VPN_POLICY attributes\n …\n …\n …\n vpn-filter value RESTRICT_VPN\n\nStep 2: Verify that the filter restricts traffic according to organization-defined filtering rules as shown in the example below.\n\naccess-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255.0 host 192.168.1.12 eq http \naccess-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255.0  host 192.168.1.13 eq smtp \naccess-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255.0  host 192.168.1.14 eq ftp \naccess-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255.0 host 192.168.1.14 eq ftp-data \naccess-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255.0  host 192.168.1.15 eq domain\naccess-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255.0  host 192.168.1.16 eq sqlnet\naccess-list RESTRICT_VPN extended deny ip any any log\n\nNote: In the example above, assume that the client-assigned IP address pool is 10.10.10.0/24 and the local private network is 192.168.1.0/24.\n\nIf the ASA is not configured to restrict VPN traffic according to organization-defined filtering rules, this is a finding.",
+              "label": "check"
+            },
+            {
+              "data": "Step 1: Configure the ACL to restrict VPN traffic.\n\nASA(config)# access-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255. host 192.168.1.12 eq http\nASA(config)# access-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255. host 192.168.1.13 eq smtp\nASA(config)# access-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255. host 192.168.1.14 eq ftp\nASA(config)# access-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255. host 192.168.1.14 eq ftp-data\nASA(config)# access-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255.y host 192.168.1.15 eq domain\nASA(config)# access-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255. host 192.168.1.16 eq sqlnet\nASA(config)# access-list RESTRICT_VPN extended deny ip any any log\nASA(config)# exit \n\nStep 2: Apply the VPN filter to the applicable group policy as shown in the example below.\n\nASA(config)# group-policy VPN_POLICY attributes \nASA(config-group-policy)# vpn-filter value RESTRICT_VPN \nASA(config-group-policy)# end",
+              "label": "fix"
+            }
+          ],
+          "impact": 0.5,
+          "code": "{\n  \"status\": \"Not Reviewed\",\n  \"findingdetails\": \"\",\n  \"comments\": \"\",\n  \"severityoverride\": \"\",\n  \"severityjustification\": \"\",\n  \"vulnNum\": \"V-239854\",\n  \"severity\": \"medium\",\n  \"groupTitle\": \"SRG-NET-000061-FW-000001\",\n  \"ruleId\": \"SV-239854r665848_rule\",\n  \"ruleVer\": \"CASA-FW-000030\",\n  \"ruleTitle\": \"The Cisco ASA must be configured to restrict VPN traffic according to organization-defined filtering rules.\",\n  \"vulnDiscuss\": \"Remote access devices (such as those providing remote access to network devices and information systems) that lack automated capabilities increase risk and make remote user access management difficult at best.\\n\\nRemote access is access to DoD non-public information systems by an authorized user (or an information system) communicating through an external, non-organization-controlled network.\\n\\nAutomated monitoring of remote access sessions allows organizations to detect cyberattacks and also ensure ongoing compliance with remote access policies by auditing connection activities of remote access capabilities from a variety of information system components (e.g., servers, workstations, notebook computers, smart phones, and tablets).\",\n  \"iaControls\": \"\",\n  \"checkContent\": \"Step 1: Verify that an ACL has been applied to the applicable VPN group policy via the vpn-filter attribute as shown in the example below.\\n\\ngroup-policy VPN_POLICY internal\\ngroup-policy VPN_POLICY attributes\\n …\\n …\\n …\\n vpn-filter value RESTRICT_VPN\\n\\nStep 2: Verify that the filter restricts traffic according to organization-defined filtering rules as shown in the example below.\\n\\naccess-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255.0 host 192.168.1.12 eq http \\naccess-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255.0  host 192.168.1.13 eq smtp \\naccess-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255.0  host 192.168.1.14 eq ftp \\naccess-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255.0 host 192.168.1.14 eq ftp-data \\naccess-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255.0  host 192.168.1.15 eq domain\\naccess-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255.0  host 192.168.1.16 eq sqlnet\\naccess-list RESTRICT_VPN extended deny ip any any log\\n\\nNote: In the example above, assume that the client-assigned IP address pool is 10.10.10.0/24 and the local private network is 192.168.1.0/24.\\n\\nIf the ASA is not configured to restrict VPN traffic according to organization-defined filtering rules, this is a finding.\",\n  \"fixText\": \"Step 1: Configure the ACL to restrict VPN traffic.\\n\\nASA(config)# access-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255. host 192.168.1.12 eq http\\nASA(config)# access-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255. host 192.168.1.13 eq smtp\\nASA(config)# access-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255. host 192.168.1.14 eq ftp\\nASA(config)# access-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255. host 192.168.1.14 eq ftp-data\\nASA(config)# access-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255.y host 192.168.1.15 eq domain\\nASA(config)# access-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255. host 192.168.1.16 eq sqlnet\\nASA(config)# access-list RESTRICT_VPN extended deny ip any any log\\nASA(config)# exit \\n\\nStep 2: Apply the VPN filter to the applicable group policy as shown in the example below.\\n\\nASA(config)# group-policy VPN_POLICY attributes \\nASA(config-group-policy)# vpn-filter value RESTRICT_VPN \\nASA(config-group-policy)# end\",\n  \"falsePositives\": \"\",\n  \"falseNegatives\": \"\",\n  \"documentable\": \"false\",\n  \"mitigations\": \"\",\n  \"potentialImpact\": \"\",\n  \"thirdPartyTools\": \"\",\n  \"mitigationControl\": \"\",\n  \"responsibility\": \"\",\n  \"securityOverrideGuidance\": \"\",\n  \"checkContentRef\": \"M\",\n  \"weight\": \"10.0\",\n  \"class\": \"Unclass\",\n  \"stigRef\": \"Cisco ASA Firewall Security Technical Implementation Guide :: Version 1, Release: 4 Benchmark Date: 27 Apr 2023\",\n  \"targetKey\": \"5339\",\n  \"stigUuid\": \"54b4701f-19a1-4d5b-9497-5be85f995362\",\n  \"legacyId\": \"; \",\n  \"cciRef\": \"CCI-000067\"\n}",
+          "results": [
+            {
+              "status": "skipped",
+              "code_desc": "",
+              "start_time": ""
+            }
+          ]
+        }
+      ],
+      "sha256": "6c22e71efae78822d11742b8a72e8b8a1793076f3103e569319db612db7346ce"
+    }
+  ],
+  "passthrough": {
+    "checklist": {
+      "asset": {
+        "role": "Member Server",
+        "assettype": "Computing",
+        "hostname": "=",
+        "hostip": "",
+        "hostmac": "02:B9:78:82:FE:DE\nEE:EE:EE:EE:EE:EE\n6E:8D:55:AB:10:5F",
+        "hostfqdn": "",
+        "marking": "CUI",
+        "targetcomment": "",
+        "techarea": "Exchange Server",
+        "targetkey": "5339",
+        "webordatabase": false,
+        "webdbsite": "",
+        "webdbinstance": ""
+      },
+      "stigs": [
+        {
+          "header": {
+            "version": "1",
+            "classification": "UNCLASSIFIED",
+            "customname": "",
+            "stigid": "Cisco_ASA_FW_STIG",
+            "description": "This Security Technical Implementation Guide is published as a tool to improve the security of Department of Defense (DOD) information systems. The requirements are derived from the National Institute of Standards and Technology (NIST) 800-53 and related documents. Comments or proposed revisions to this document should be sent via email to the following address: disa.stig_spt@mail.mil.",
+            "filename": "U_Cisco_ASA_Firewall_STIG_V1R4_Manual-xccdf.xml",
+            "releaseinfo": "Release: 4 Benchmark Date: 27 Apr 2023",
+            "title": "Cisco ASA Firewall Security Technical Implementation Guide",
+            "uuid": "b6a7cb18-6ffe-4a6e-9f44-60d514c98db9",
+            "notice": "terms-of-use",
+            "source": "STIG.DOD.MIL"
+          },
+          "vulns": [
+            {
+              "status": "Not Reviewed",
+              "findingdetails": "",
+              "comments": "",
+              "severityoverride": "",
+              "severityjustification": "",
+              "vulnNum": "V-239852",
+              "severity": "high",
+              "groupTitle": "SRG-NET-000019-FW-000003",
+              "ruleId": "SV-239852r665842_rule",
+              "ruleVer": "CASA-FW-000010",
+              "ruleTitle": "The Cisco ASA must be configured to filter outbound traffic, allowing only authorized ports and services.",
+              "vulnDiscuss": "Information flow control regulates where information is allowed to travel within a network and between interconnected networks. Blocking or restricting detected harmful or suspicious communications between interconnected networks enforces approved authorizations for controlling the flow of traffic.\n\nThe firewall that filters traffic outbound to interconnected networks with different security policies must be configured to permit or block traffic based on organization-defined traffic authorizations.",
+              "iaControls": "",
+              "checkContent": "Review the ASA configuration to determine if it only permits outbound traffic using authorized ports and services.\n\nStep 1: Verify that an ingress ACL has been applied to all internal interfaces as shown in the example below.\n\n interface GigabitEthernet0/0\n nameif INSIDE\n security-level 100\n ip address 10.1.11.1 255.255.255.0\n…\n…\n…\naccess-group INSIDE _IN in interface INSIDE \n\nStep 2: Verify that the ingress ACL only allows outbound traffic using authorized ports and services as shown in the example below.\n\naccess-list INSIDE _IN extended permit tcp any any eq www \naccess-list INSIDE _IN extended permit tcp any any eq https \naccess-list INSIDE _IN extended permit tcp any any eq …\naccess-list INSIDE _IN extended deny ip any any log\n\nIf the ASA is not configured to only allow outbound traffic using authorized ports and services, this is a finding.",
+              "fixText": "Step 1: Configure the ingress ACL similar to the example below.\n\nASA(config)# access-list INSIDE_INextended permit tcp any any eq https\nASA(config)# access-list INSIDE_INextended permit tcp any any eq http\nASA(config)# access-list INSIDE_INextended permit tcp any any eq …\nASA(config)# access-list INSIDE_INextended deny ip any any log      \n\nStep 2: Apply the ACL inbound on all internal interfaces as shown in the example below.\n\nASA(config)# access-group INSIDE_IN in interface INSIDE\nASA(config)# end",
+              "falsePositives": "",
+              "falseNegatives": "",
+              "documentable": "false",
+              "mitigations": "",
+              "potentialImpact": "",
+              "thirdPartyTools": "",
+              "mitigationControl": "",
+              "responsibility": "",
+              "securityOverrideGuidance": "",
+              "checkContentRef": "M",
+              "weight": "10.0",
+              "class": "Unclass",
+              "stigRef": "Cisco ASA Firewall Security Technical Implementation Guide :: Version 1, Release: 4 Benchmark Date: 27 Apr 2023",
+              "targetKey": "5339",
+              "stigUuid": "54b4701f-19a1-4d5b-9497-5be85f995362",
+              "legacyId": "; ",
+              "cciRef": "CCI-001414"
+            },
+            {
+              "status": "Not Reviewed",
+              "findingdetails": "",
+              "comments": "",
+              "severityoverride": "",
+              "severityjustification": "",
+              "vulnNum": "V-239853",
+              "severity": "medium",
+              "groupTitle": "SRG-NET-000019-FW-000004",
+              "ruleId": "SV-239853r665845_rule",
+              "ruleVer": "CASA-FW-000020",
+              "ruleTitle": "The Cisco ASA must immediately use updates made to policy enforcement mechanisms such as firewall rules, security policies, and security zones.",
+              "vulnDiscuss": "Information flow policies regarding dynamic information flow control include, for example, allowing or disallowing information flows based on changes to the Ports, Protocols, Services Management (PPSM) Category Assurance Levels (CAL) list, vulnerability assessments, or mission conditions. Changing conditions include changes in the threat environment and detection of potentially harmful or adverse events.",
+              "iaControls": "",
+              "checkContent": "By default, when you change a rule-based policy such as access rules, the changes become effective immediately. With transactional model configured, the rules are not active until after compilation.\n\nReview the ASA configuration and verify that the following command is not configured.\n\nasp rule-engine transactional-commit access-group\n\nIf transactional-commit access-group has been configured, this is a finding.",
+              "fixText": "Remove the command asp rule-engine transactional-commit access-group\n\nASA(config)# no asp rule-engine transactional-commit access-group",
+              "falsePositives": "",
+              "falseNegatives": "",
+              "documentable": "false",
+              "mitigations": "",
+              "potentialImpact": "",
+              "thirdPartyTools": "",
+              "mitigationControl": "",
+              "responsibility": "",
+              "securityOverrideGuidance": "",
+              "checkContentRef": "M",
+              "weight": "10.0",
+              "class": "Unclass",
+              "stigRef": "Cisco ASA Firewall Security Technical Implementation Guide :: Version 1, Release: 4 Benchmark Date: 27 Apr 2023",
+              "targetKey": "5339",
+              "stigUuid": "54b4701f-19a1-4d5b-9497-5be85f995362",
+              "legacyId": "; ",
+              "cciRef": "CCI-001414"
+            },
+            {
+              "status": "Not Reviewed",
+              "findingdetails": "",
+              "comments": "",
+              "severityoverride": "",
+              "severityjustification": "",
+              "vulnNum": "V-239854",
+              "severity": "medium",
+              "groupTitle": "SRG-NET-000061-FW-000001",
+              "ruleId": "SV-239854r665848_rule",
+              "ruleVer": "CASA-FW-000030",
+              "ruleTitle": "The Cisco ASA must be configured to restrict VPN traffic according to organization-defined filtering rules.",
+              "vulnDiscuss": "Remote access devices (such as those providing remote access to network devices and information systems) that lack automated capabilities increase risk and make remote user access management difficult at best.\n\nRemote access is access to DoD non-public information systems by an authorized user (or an information system) communicating through an external, non-organization-controlled network.\n\nAutomated monitoring of remote access sessions allows organizations to detect cyberattacks and also ensure ongoing compliance with remote access policies by auditing connection activities of remote access capabilities from a variety of information system components (e.g., servers, workstations, notebook computers, smart phones, and tablets).",
+              "iaControls": "",
+              "checkContent": "Step 1: Verify that an ACL has been applied to the applicable VPN group policy via the vpn-filter attribute as shown in the example below.\n\ngroup-policy VPN_POLICY internal\ngroup-policy VPN_POLICY attributes\n …\n …\n …\n vpn-filter value RESTRICT_VPN\n\nStep 2: Verify that the filter restricts traffic according to organization-defined filtering rules as shown in the example below.\n\naccess-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255.0 host 192.168.1.12 eq http \naccess-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255.0  host 192.168.1.13 eq smtp \naccess-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255.0  host 192.168.1.14 eq ftp \naccess-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255.0 host 192.168.1.14 eq ftp-data \naccess-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255.0  host 192.168.1.15 eq domain\naccess-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255.0  host 192.168.1.16 eq sqlnet\naccess-list RESTRICT_VPN extended deny ip any any log\n\nNote: In the example above, assume that the client-assigned IP address pool is 10.10.10.0/24 and the local private network is 192.168.1.0/24.\n\nIf the ASA is not configured to restrict VPN traffic according to organization-defined filtering rules, this is a finding.",
+              "fixText": "Step 1: Configure the ACL to restrict VPN traffic.\n\nASA(config)# access-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255. host 192.168.1.12 eq http\nASA(config)# access-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255. host 192.168.1.13 eq smtp\nASA(config)# access-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255. host 192.168.1.14 eq ftp\nASA(config)# access-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255. host 192.168.1.14 eq ftp-data\nASA(config)# access-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255.y host 192.168.1.15 eq domain\nASA(config)# access-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255. host 192.168.1.16 eq sqlnet\nASA(config)# access-list RESTRICT_VPN extended deny ip any any log\nASA(config)# exit \n\nStep 2: Apply the VPN filter to the applicable group policy as shown in the example below.\n\nASA(config)# group-policy VPN_POLICY attributes \nASA(config-group-policy)# vpn-filter value RESTRICT_VPN \nASA(config-group-policy)# end",
+              "falsePositives": "",
+              "falseNegatives": "",
+              "documentable": "false",
+              "mitigations": "",
+              "potentialImpact": "",
+              "thirdPartyTools": "",
+              "mitigationControl": "",
+              "responsibility": "",
+              "securityOverrideGuidance": "",
+              "checkContentRef": "M",
+              "weight": "10.0",
+              "class": "Unclass",
+              "stigRef": "Cisco ASA Firewall Security Technical Implementation Guide :: Version 1, Release: 4 Benchmark Date: 27 Apr 2023",
+              "targetKey": "5339",
+              "stigUuid": "54b4701f-19a1-4d5b-9497-5be85f995362",
+              "legacyId": "; ",
+              "cciRef": "CCI-000067"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/libs/hdf-converters/sample_jsons/checklist_mapper/sample_input_report/multiple_mac_addresses_metadata.ckl
+++ b/libs/hdf-converters/sample_jsons/checklist_mapper/sample_input_report/multiple_mac_addresses_metadata.ckl
@@ -1,0 +1,507 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--DISA STIG Viewer :: 2.17-->
+<CHECKLIST>
+	<ASSET>
+		<ROLE>Member Server</ROLE>
+		<ASSET_TYPE>Computing</ASSET_TYPE>
+		<MARKING>CUI</MARKING>
+		<HOST_NAME>=</HOST_NAME>
+		<HOST_IP></HOST_IP>
+		<HOST_MAC>02:B9:78:82:FE:DE
+EE:EE:EE:EE:EE:EE
+6E:8D:55:AB:10:5F</HOST_MAC>
+		<HOST_FQDN></HOST_FQDN>
+		<TARGET_COMMENT></TARGET_COMMENT>
+		<TECH_AREA>Exchange Server</TECH_AREA>
+		<TARGET_KEY>5339</TARGET_KEY>
+		<WEB_OR_DATABASE>false</WEB_OR_DATABASE>
+		<WEB_DB_SITE></WEB_DB_SITE>
+		<WEB_DB_INSTANCE></WEB_DB_INSTANCE>
+	</ASSET>
+	<STIGS>
+		<iSTIG>
+			<STIG_INFO>
+				<SI_DATA>
+					<SID_NAME>version</SID_NAME>
+					<SID_DATA>1</SID_DATA>
+				</SI_DATA>
+				<SI_DATA>
+					<SID_NAME>classification</SID_NAME>
+					<SID_DATA>UNCLASSIFIED</SID_DATA>
+				</SI_DATA>
+				<SI_DATA>
+					<SID_NAME>customname</SID_NAME>
+				</SI_DATA>
+				<SI_DATA>
+					<SID_NAME>stigid</SID_NAME>
+					<SID_DATA>Cisco_ASA_FW_STIG</SID_DATA>
+				</SI_DATA>
+				<SI_DATA>
+					<SID_NAME>description</SID_NAME>
+					<SID_DATA>This Security Technical Implementation Guide is published as a tool to improve the security of Department of Defense (DOD) information systems. The requirements are derived from the National Institute of Standards and Technology (NIST) 800-53 and related documents. Comments or proposed revisions to this document should be sent via email to the following address: disa.stig_spt@mail.mil.</SID_DATA>
+				</SI_DATA>
+				<SI_DATA>
+					<SID_NAME>filename</SID_NAME>
+					<SID_DATA>U_Cisco_ASA_Firewall_STIG_V1R4_Manual-xccdf.xml</SID_DATA>
+				</SI_DATA>
+				<SI_DATA>
+					<SID_NAME>releaseinfo</SID_NAME>
+					<SID_DATA>Release: 4 Benchmark Date: 27 Apr 2023</SID_DATA>
+				</SI_DATA>
+				<SI_DATA>
+					<SID_NAME>title</SID_NAME>
+					<SID_DATA>Cisco ASA Firewall Security Technical Implementation Guide</SID_DATA>
+				</SI_DATA>
+				<SI_DATA>
+					<SID_NAME>uuid</SID_NAME>
+					<SID_DATA>b6a7cb18-6ffe-4a6e-9f44-60d514c98db9</SID_DATA>
+				</SI_DATA>
+				<SI_DATA>
+					<SID_NAME>notice</SID_NAME>
+					<SID_DATA>terms-of-use</SID_DATA>
+				</SI_DATA>
+				<SI_DATA>
+					<SID_NAME>source</SID_NAME>
+					<SID_DATA>STIG.DOD.MIL</SID_DATA>
+				</SI_DATA>
+			</STIG_INFO>
+			<VULN>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Vuln_Num</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>V-239852</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Severity</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>high</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Group_Title</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>SRG-NET-000019-FW-000003</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Rule_ID</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>SV-239852r665842_rule</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Rule_Ver</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>CASA-FW-000010</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Rule_Title</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>The Cisco ASA must be configured to filter outbound traffic, allowing only authorized ports and services.</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Vuln_Discuss</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>Information flow control regulates where information is allowed to travel within a network and between interconnected networks. Blocking or restricting detected harmful or suspicious communications between interconnected networks enforces approved authorizations for controlling the flow of traffic.
+
+The firewall that filters traffic outbound to interconnected networks with different security policies must be configured to permit or block traffic based on organization-defined traffic authorizations.</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>IA_Controls</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA></ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Check_Content</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>Review the ASA configuration to determine if it only permits outbound traffic using authorized ports and services.
+
+Step 1: Verify that an ingress ACL has been applied to all internal interfaces as shown in the example below.
+
+ interface GigabitEthernet0/0
+ nameif INSIDE
+ security-level 100
+ ip address 10.1.11.1 255.255.255.0
+…
+…
+…
+access-group INSIDE _IN in interface INSIDE 
+
+Step 2: Verify that the ingress ACL only allows outbound traffic using authorized ports and services as shown in the example below.
+
+access-list INSIDE _IN extended permit tcp any any eq www 
+access-list INSIDE _IN extended permit tcp any any eq https 
+access-list INSIDE _IN extended permit tcp any any eq …
+access-list INSIDE _IN extended deny ip any any log
+
+If the ASA is not configured to only allow outbound traffic using authorized ports and services, this is a finding.</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Fix_Text</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>Step 1: Configure the ingress ACL similar to the example below.
+
+ASA(config)# access-list INSIDE_INextended permit tcp any any eq https
+ASA(config)# access-list INSIDE_INextended permit tcp any any eq http
+ASA(config)# access-list INSIDE_INextended permit tcp any any eq …
+ASA(config)# access-list INSIDE_INextended deny ip any any log      
+
+Step 2: Apply the ACL inbound on all internal interfaces as shown in the example below.
+
+ASA(config)# access-group INSIDE_IN in interface INSIDE
+ASA(config)# end</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>False_Positives</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA></ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>False_Negatives</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA></ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Documentable</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>false</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Mitigations</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA></ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Potential_Impact</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA></ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Third_Party_Tools</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA></ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Mitigation_Control</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA></ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Responsibility</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA></ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Security_Override_Guidance</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA></ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Check_Content_Ref</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>M</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Weight</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>10.0</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Class</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>Unclass</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>STIGRef</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>Cisco ASA Firewall Security Technical Implementation Guide :: Version 1, Release: 4 Benchmark Date: 27 Apr 2023</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>TargetKey</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>5339</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>STIG_UUID</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>54b4701f-19a1-4d5b-9497-5be85f995362</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>LEGACY_ID</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA></ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>LEGACY_ID</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA></ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>CCI_REF</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>CCI-001414</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STATUS>Not_Reviewed</STATUS>
+				<FINDING_DETAILS></FINDING_DETAILS>
+				<COMMENTS></COMMENTS>
+				<SEVERITY_OVERRIDE></SEVERITY_OVERRIDE>
+				<SEVERITY_JUSTIFICATION></SEVERITY_JUSTIFICATION>
+			</VULN>
+			<VULN>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Vuln_Num</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>V-239853</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Severity</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>medium</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Group_Title</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>SRG-NET-000019-FW-000004</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Rule_ID</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>SV-239853r665845_rule</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Rule_Ver</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>CASA-FW-000020</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Rule_Title</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>The Cisco ASA must immediately use updates made to policy enforcement mechanisms such as firewall rules, security policies, and security zones.</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Vuln_Discuss</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>Information flow policies regarding dynamic information flow control include, for example, allowing or disallowing information flows based on changes to the Ports, Protocols, Services Management (PPSM) Category Assurance Levels (CAL) list, vulnerability assessments, or mission conditions. Changing conditions include changes in the threat environment and detection of potentially harmful or adverse events.</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>IA_Controls</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA></ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Check_Content</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>By default, when you change a rule-based policy such as access rules, the changes become effective immediately. With transactional model configured, the rules are not active until after compilation.
+
+Review the ASA configuration and verify that the following command is not configured.
+
+asp rule-engine transactional-commit access-group
+
+If transactional-commit access-group has been configured, this is a finding.</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Fix_Text</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>Remove the command asp rule-engine transactional-commit access-group
+
+ASA(config)# no asp rule-engine transactional-commit access-group</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>False_Positives</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA></ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>False_Negatives</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA></ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Documentable</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>false</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Mitigations</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA></ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Potential_Impact</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA></ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Third_Party_Tools</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA></ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Mitigation_Control</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA></ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Responsibility</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA></ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Security_Override_Guidance</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA></ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Check_Content_Ref</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>M</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Weight</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>10.0</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Class</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>Unclass</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>STIGRef</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>Cisco ASA Firewall Security Technical Implementation Guide :: Version 1, Release: 4 Benchmark Date: 27 Apr 2023</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>TargetKey</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>5339</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>STIG_UUID</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>54b4701f-19a1-4d5b-9497-5be85f995362</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>LEGACY_ID</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA></ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>LEGACY_ID</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA></ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>CCI_REF</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>CCI-001414</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STATUS>Not_Reviewed</STATUS>
+				<FINDING_DETAILS></FINDING_DETAILS>
+				<COMMENTS></COMMENTS>
+				<SEVERITY_OVERRIDE></SEVERITY_OVERRIDE>
+				<SEVERITY_JUSTIFICATION></SEVERITY_JUSTIFICATION>
+			</VULN>
+			<VULN>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Vuln_Num</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>V-239854</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Severity</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>medium</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Group_Title</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>SRG-NET-000061-FW-000001</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Rule_ID</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>SV-239854r665848_rule</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Rule_Ver</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>CASA-FW-000030</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Rule_Title</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>The Cisco ASA must be configured to restrict VPN traffic according to organization-defined filtering rules.</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Vuln_Discuss</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>Remote access devices (such as those providing remote access to network devices and information systems) that lack automated capabilities increase risk and make remote user access management difficult at best.
+
+Remote access is access to DoD non-public information systems by an authorized user (or an information system) communicating through an external, non-organization-controlled network.
+
+Automated monitoring of remote access sessions allows organizations to detect cyberattacks and also ensure ongoing compliance with remote access policies by auditing connection activities of remote access capabilities from a variety of information system components (e.g., servers, workstations, notebook computers, smart phones, and tablets).</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>IA_Controls</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA></ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Check_Content</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>Step 1: Verify that an ACL has been applied to the applicable VPN group policy via the vpn-filter attribute as shown in the example below.
+
+group-policy VPN_POLICY internal
+group-policy VPN_POLICY attributes
+ …
+ …
+ …
+ vpn-filter value RESTRICT_VPN
+
+Step 2: Verify that the filter restricts traffic according to organization-defined filtering rules as shown in the example below.
+
+access-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255.0 host 192.168.1.12 eq http 
+access-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255.0  host 192.168.1.13 eq smtp 
+access-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255.0  host 192.168.1.14 eq ftp 
+access-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255.0 host 192.168.1.14 eq ftp-data 
+access-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255.0  host 192.168.1.15 eq domain
+access-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255.0  host 192.168.1.16 eq sqlnet
+access-list RESTRICT_VPN extended deny ip any any log
+
+Note: In the example above, assume that the client-assigned IP address pool is 10.10.10.0/24 and the local private network is 192.168.1.0/24.
+
+If the ASA is not configured to restrict VPN traffic according to organization-defined filtering rules, this is a finding.</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Fix_Text</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>Step 1: Configure the ACL to restrict VPN traffic.
+
+ASA(config)# access-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255. host 192.168.1.12 eq http
+ASA(config)# access-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255. host 192.168.1.13 eq smtp
+ASA(config)# access-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255. host 192.168.1.14 eq ftp
+ASA(config)# access-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255. host 192.168.1.14 eq ftp-data
+ASA(config)# access-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255.y host 192.168.1.15 eq domain
+ASA(config)# access-list RESTRICT_VPN extended permit tcp 10.0.0.0 255.255.255. host 192.168.1.16 eq sqlnet
+ASA(config)# access-list RESTRICT_VPN extended deny ip any any log
+ASA(config)# exit 
+
+Step 2: Apply the VPN filter to the applicable group policy as shown in the example below.
+
+ASA(config)# group-policy VPN_POLICY attributes 
+ASA(config-group-policy)# vpn-filter value RESTRICT_VPN 
+ASA(config-group-policy)# end</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>False_Positives</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA></ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>False_Negatives</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA></ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Documentable</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>false</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Mitigations</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA></ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Potential_Impact</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA></ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Third_Party_Tools</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA></ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Mitigation_Control</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA></ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Responsibility</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA></ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Security_Override_Guidance</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA></ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Check_Content_Ref</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>M</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Weight</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>10.0</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>Class</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>Unclass</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>STIGRef</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>Cisco ASA Firewall Security Technical Implementation Guide :: Version 1, Release: 4 Benchmark Date: 27 Apr 2023</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>TargetKey</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>5339</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>STIG_UUID</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>54b4701f-19a1-4d5b-9497-5be85f995362</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>LEGACY_ID</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA></ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>LEGACY_ID</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA></ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STIG_DATA>
+					<VULN_ATTRIBUTE>CCI_REF</VULN_ATTRIBUTE>
+					<ATTRIBUTE_DATA>CCI-000067</ATTRIBUTE_DATA>
+				</STIG_DATA>
+				<STATUS>Not_Reviewed</STATUS>
+				<FINDING_DETAILS></FINDING_DETAILS>
+				<COMMENTS></COMMENTS>
+				<SEVERITY_OVERRIDE></SEVERITY_OVERRIDE>
+				<SEVERITY_JUSTIFICATION></SEVERITY_JUSTIFICATION>
+			</VULN>
+		</iSTIG>
+	</STIGS>
+</CHECKLIST>

--- a/libs/hdf-converters/src/ckl-mapper/checklist-metadata-utils.ts
+++ b/libs/hdf-converters/src/ckl-mapper/checklist-metadata-utils.ts
@@ -22,8 +22,14 @@ const assetMetadataSchema: Revalidator.JSONSchema<Asset> = {
     },
     hostmac: {
       type: 'string',
-      conform: (mac: string) => !mac || isMACAddress(mac),
-      message: 'Host MAC'
+      conform: (mac: string) => {
+        if (!mac) return true; // Allow empty input
+        // Split the input string by newline, space, or comma
+        const macAddresses = mac.split(/[\s,]+/);
+        // Check each MAC address using the isMACAddress function
+        return macAddresses.every((address) => isMACAddress(address));
+      },
+      message: 'Host MAC addresses must be valid and separated by newline, space, or comma.'
     },
     role: {
       type: 'string',

--- a/libs/hdf-converters/src/ckl-mapper/checklist-metadata-utils.ts
+++ b/libs/hdf-converters/src/ckl-mapper/checklist-metadata-utils.ts
@@ -29,7 +29,8 @@ const assetMetadataSchema: Revalidator.JSONSchema<Asset> = {
         // Check each MAC address using the isMACAddress function
         return macAddresses.every((address) => isMACAddress(address));
       },
-      message: 'Host MAC addresses must be valid and separated by newline, space, or comma.'
+      message:
+        'Host MAC addresses must be valid and separated by newline, space, or comma.'
     },
     role: {
       type: 'string',

--- a/libs/hdf-converters/test/mappers/forward/checklist_mapper.spec.ts
+++ b/libs/hdf-converters/test/mappers/forward/checklist_mapper.spec.ts
@@ -48,7 +48,8 @@ const testCases = [
     description: 'checklist_with_multiple_host_mac_addresses',
     inputFile:
       'sample_jsons/checklist_mapper/sample_input_report/multiple_mac_addresses_metadata.ckl',
-    expectedFile: 'sample_jsons/checklist_mapper/multiple_mac_addresses_metadata.json',
+    expectedFile:
+      'sample_jsons/checklist_mapper/multiple_mac_addresses_metadata.json',
     options: {includeRaw: false}
   }
 ];

--- a/libs/hdf-converters/test/mappers/forward/checklist_mapper.spec.ts
+++ b/libs/hdf-converters/test/mappers/forward/checklist_mapper.spec.ts
@@ -3,180 +3,100 @@ import {ChecklistResults} from '../../../src/ckl-mapper/checklist-mapper';
 import {omitVersions} from '../../utils';
 import {InvalidChecklistMetadataException} from '../../../src/ckl-mapper/checklist-metadata-utils';
 
-describe('checklist_mapper_single_stig', () => {
-  it('Successfully converts Checklists', () => {
-    const mapper = new ChecklistResults(
-      fs.readFileSync(
-        'sample_jsons/checklist_mapper/sample_input_report/RHEL8V1R3.ckl',
-        {encoding: 'utf-8'}
-      )
-    );
+// To write the output to a file for visual inspection, follow the example below:
+// fs.writeFileSync(
+//   'sample_jsons/checklist_mapper/FILENAME.json',
+//   JSON.stringify(mapper.toHdf(), null, 2)
+// );
 
-    // fs.writeFileSync(
-    //   'sample_jsons/checklist_mapper/checklist-RHEL8V1R3-hdf.json',
-    //   JSON.stringify(mapper.toHdf(), null, 2)
-    // );
+const readFile = (path: fs.PathOrFileDescriptor) =>
+  fs.readFileSync(path, {encoding: 'utf-8'});
+const parseJsonFile = (path: fs.PathOrFileDescriptor) =>
+  JSON.parse(readFile(path));
 
-    expect(omitVersions(mapper.toHdf())).toEqual(
-      omitVersions(
-        JSON.parse(
-          fs.readFileSync(
-            'sample_jsons/checklist_mapper/checklist-RHEL8V1R3-hdf.json',
-            {encoding: 'utf-8'}
-          )
-        )
-      )
-    );
+const testCases = [
+  {
+    description: 'checklist_mapper_single_stig',
+    inputFile:
+      'sample_jsons/checklist_mapper/sample_input_report/RHEL8V1R3.ckl',
+    expectedFile: 'sample_jsons/checklist_mapper/checklist-RHEL8V1R3-hdf.json',
+    options: {}
+  },
+  {
+    description: 'checklist_mapper_single_stig_with_raw',
+    inputFile:
+      'sample_jsons/checklist_mapper/sample_input_report/RHEL8V1R3.ckl',
+    expectedFile:
+      'sample_jsons/checklist_mapper/checklist-RHEL8V1R3-hdf-with-raw.json',
+    options: {includeRaw: true}
+  },
+  {
+    description: 'checklist_mapper_with_severity_overrides',
+    inputFile:
+      'sample_jsons/checklist_mapper/sample_input_report/small_ckl_overrides.ckl',
+    expectedFile: 'sample_jsons/checklist_mapper/small_overrides_hdf.json',
+    options: {includeRaw: true}
+  },
+  {
+    description: 'checklist_mapper_multi_stig_wrapper',
+    inputFile:
+      'sample_jsons/checklist_mapper/sample_input_report/three_stig_checklist.ckl',
+    expectedFile: 'sample_jsons/checklist_mapper/three_stig_checklist-hdf.json',
+    options: {}
+  },
+  {
+    description: 'checklist_with_multiple_host_mac_addresses',
+    inputFile:
+      'sample_jsons/checklist_mapper/sample_input_report/multiple_mac_addresses_metadata.ckl',
+    expectedFile: 'sample_jsons/checklist_mapper/multiple_mac_addresses_metadata.json',
+    options: {includeRaw: false}
+  }
+];
+
+describe('Checklist Mapper Tests', () => {
+  testCases.forEach(({description, inputFile, expectedFile, options}) => {
+    it(`Successfully converts Checklists for ${description}`, () => {
+      const mapper = new ChecklistResults(
+        readFile(inputFile),
+        options.includeRaw
+      );
+      const results = mapper.toHdf();
+      expect(omitVersions(results)).toEqual(
+        omitVersions(parseJsonFile(expectedFile))
+      );
+    });
   });
-});
 
-describe('checklist_mapper_single_stig_with_raw', () => {
-  it('Successfully converts Checklists with raw', () => {
-    const mapper = new ChecklistResults(
-      fs.readFileSync(
-        'sample_jsons/checklist_mapper/sample_input_report/RHEL8V1R3.ckl',
-        {encoding: 'utf-8'}
-      ),
-      true
-    );
-
-    // fs.writeFileSync(
-    //   'sample_jsons/checklist_mapper/checklist-RHEL8V1R3-hdf-with-raw.json',
-    //   JSON.stringify(mapper.toHdf(), null, 2)
-    // );
-
-    expect(omitVersions(mapper.toHdf())).toEqual(
-      omitVersions(
-        JSON.parse(
-          fs.readFileSync(
-            'sample_jsons/checklist_mapper/checklist-RHEL8V1R3-hdf-with-raw.json',
-            {encoding: 'utf-8'}
-          )
-        )
-      )
-    );
-  });
-});
-
-describe('checklist_mapper_with_severity_overrides', () => {
-  it('Successfully converts Checklists with severity overrides', () => {
-    const mapper = new ChecklistResults(
-      fs.readFileSync(
-        'sample_jsons/checklist_mapper/sample_input_report/small_ckl_overrides.ckl',
-        {encoding: 'utf-8'}
-      ),
-      true
-    );
-
-    // fs.writeFileSync(
-    //   'sample_jsons/checklist_mapper/small_overrides_hdf.json',
-    //   JSON.stringify(mapper.toHdf(), null, 2)
-    // );
-
-    expect(omitVersions(mapper.toHdf())).toEqual(
-      omitVersions(
-        JSON.parse(
-          fs.readFileSync(
-            'sample_jsons/checklist_mapper/small_overrides_hdf.json',
-            {encoding: 'utf-8'}
-          )
-        )
-      )
-    );
-  });
-});
-
-describe('checklist_mapper_multi_stig_wrapper', () => {
-  it('Successfully converts Checklists', () => {
-    const mapper = new ChecklistResults(
-      fs.readFileSync(
-        'sample_jsons/checklist_mapper/sample_input_report/three_stig_checklist.ckl',
-        {encoding: 'utf-8'}
-      )
-    );
-
-    const results = mapper.toHdf();
-
-    // fs.writeFileSync(
-    //   'sample_jsons/checklist_mapper/three_stig_checklist-hdf.json',
-    //   JSON.stringify(mapper.toHdf(), null, 2)
-    // );
-
-    expect(omitVersions(results)).toEqual(
-      omitVersions(
-        JSON.parse(
-          fs.readFileSync(
-            'sample_jsons/checklist_mapper/three_stig_checklist-hdf.json',
-            {encoding: 'utf-8'}
-          )
-        )
-      )
-    );
-  });
-});
-
-describe('checklist_jsonix', () => {
   it('Successfully creates jsonix object', () => {
     const mapper = new ChecklistResults(
-      fs.readFileSync(
-        'sample_jsons/checklist_mapper/sample_input_report/RHEL8V1R3.ckl',
-        {encoding: 'utf-8'}
+      readFile(
+        'sample_jsons/checklist_mapper/sample_input_report/RHEL8V1R3.ckl'
       )
     );
-
     const results = mapper.getJsonix();
-
-    // fs.writeFileSync(
-    //   'sample_jsons/checklist_mapper/checklist_jsonix_data.json',
-    //   JSON.stringify(mapper.getJsonix(), null, 2)
-    // );
-
     expect(results).toEqual(
-      JSON.parse(
-        fs.readFileSync(
-          'sample_jsons/checklist_mapper/checklist_jsonix_data.json',
-          {encoding: 'utf-8'}
-        )
-      )
+      parseJsonFile('sample_jsons/checklist_mapper/checklist_jsonix_data.json')
     );
   });
-});
 
-describe('checklist_intermediate_object', () => {
   it('Successfully creates intermediate checklist object', () => {
     const mapper = new ChecklistResults(
-      fs.readFileSync(
-        'sample_jsons/checklist_mapper/sample_input_report/RHEL8V1R3.ckl',
-        {encoding: 'utf-8'}
+      readFile(
+        'sample_jsons/checklist_mapper/sample_input_report/RHEL8V1R3.ckl'
       )
     );
-
     const jsonixData = mapper.getJsonix();
-
     const results = mapper.toIntermediateObject(jsonixData);
-
-    // fs.writeFileSync(
-    //   'sample_jsons/checklist_mapper/checklist_intermediate_object.json',
-    //   JSON.stringify(mapper.toIntermediateObject(jsonixData), null, 2)
-    // );
-
     expect(results).toEqual(
-      JSON.parse(
-        fs.readFileSync(
-          'sample_jsons/checklist_mapper/checklist_intermediate_object.json',
-          {encoding: 'utf-8'}
-        )
+      parseJsonFile(
+        'sample_jsons/checklist_mapper/checklist_intermediate_object.json'
       )
     );
   });
-});
 
-describe('checklist_with_invalid_metadata', () => {
-  // ensures that checklist metadata is being validated
   it('Throws InvalidChecklistFormatException when trying to convert checklist with invalid metadata', () => {
-    const fileContents = fs.readFileSync(
-      'sample_jsons/checklist_mapper/sample_input_report/invalid_metadata.ckl',
-      {encoding: 'utf-8'}
+    const fileContents = readFile(
+      'sample_jsons/checklist_mapper/sample_input_report/invalid_metadata.ckl'
     );
     expect(() => new ChecklistResults(fileContents)).toThrowError(
       InvalidChecklistMetadataException

--- a/libs/hdf-converters/test/mappers/reverse/checklist_reverse_mapper.spec.ts
+++ b/libs/hdf-converters/test/mappers/reverse/checklist_reverse_mapper.spec.ts
@@ -96,7 +96,8 @@ describe('hdf_profile_with_multiple_mac_host_addresses', () => {
     const mapper = new ChecklistResults(hdfData);
     const jsonixData = mapper.getJsonix();
     const hostmac = (jsonixData?.value as Stigdata).asset?.hostmac;
-    const expectedHostMac = "02:B9:78:82:FE:DE\nEE:EE:EE:EE:EE:EE\n6E:8D:55:AB:10:5F"
+    const expectedHostMac =
+      '02:B9:78:82:FE:DE\nEE:EE:EE:EE:EE:EE\n6E:8D:55:AB:10:5F';
     expect(hostmac).toEqual(expectedHostMac);
   });
 });

--- a/libs/hdf-converters/test/mappers/reverse/checklist_reverse_mapper.spec.ts
+++ b/libs/hdf-converters/test/mappers/reverse/checklist_reverse_mapper.spec.ts
@@ -88,6 +88,19 @@ describe('hdf_profile_with_invalid_metadata', () => {
   });
 });
 
+describe('hdf_profile_with_multiple_mac_host_addresses', () => {
+  it('can correctly provide multiple mac host addresses for the checklist file', () => {
+    const hdfData = loadJsonFile(
+      'sample_jsons/checklist_mapper/multiple_mac_addresses_metadata.json'
+    );
+    const mapper = new ChecklistResults(hdfData);
+    const jsonixData = mapper.getJsonix();
+    const hostmac = (jsonixData?.value as Stigdata).asset?.hostmac;
+    const expectedHostMac = "02:B9:78:82:FE:DE\nEE:EE:EE:EE:EE:EE\n6E:8D:55:AB:10:5F"
+    expect(hostmac).toEqual(expectedHostMac);
+  });
+});
+
 describe('checklist_mapper_severity_mapping', () => {
   it('Maps control V-61867 to correct severity category', () => {
     const hdfData = loadJsonFile(

--- a/libs/hdf-converters/test/mappers/reverse/checklist_reverse_mapper.spec.ts
+++ b/libs/hdf-converters/test/mappers/reverse/checklist_reverse_mapper.spec.ts
@@ -98,7 +98,10 @@ describe('hdf_profile_with_multiple_mac_host_addresses', () => {
     const hostmac = (jsonixData?.value as Stigdata).asset?.hostmac;
     const expectedHostMac =
       '02:B9:78:82:FE:DE\nEE:EE:EE:EE:EE:EE\n6E:8D:55:AB:10:5F';
-    expect(hostmac).toEqual(expectedHostMac);
+    // Replacing newlines to avoid issues with different newline characters on different systems
+    expect(hostmac?.replace(/\n/g, '')).toEqual(
+      expectedHostMac.replace(/\n/g, '')
+    );
   });
 });
 


### PR DESCRIPTION
Resolves the input part of #6512 
- refactor checklist mappper test
- add test for file with multiple mac addresses
- update checklist_metadata_utils to be able to validate a hostmac address string with multiple mac addresses
- allows export with more than one mac address