### PR TITLE
Fix fast-xml-parser to avoid eval() use

### DIFF
--- a/libs/hdf-converters/package.json
+++ b/libs/hdf-converters/package.json
@@ -42,7 +42,7 @@
     "axios": "^1.3.5",
     "compare-versions": "^6.0.0",
     "csv2json": "^2.0.2",
-    "fast-xml-parser": "^5.0.6",
+    "fast-xml-parser": "4.5.3",
     "html-entities": "^2.3.2",
     "htmlparser2": "^10.0.0",
     "inspecjs": "^2.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10943,12 +10943,12 @@ fast-xml-parser@4.4.1:
   dependencies:
     strnum "^1.0.5"
 
-fast-xml-parser@^5.0.6:
-  version "5.0.8"
-  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-5.0.8.tgz#cb84ca077c0c5c45906051c13c4075ed44d3f271"
-  integrity sha512-qY8NiI5L8ff00F2giyICiJxSSKHO52tC36LJqx2JtvGyAd5ZfehC/l4iUVVHpmpIa6sM9N5mneSLHQG2INGoHA==
+fast-xml-parser@4.5.4:
+  version "4.5.3"
+  resolved "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz#c54d6b35aa0f23dc1ea60b6c884340c006dc6efb"
+  integrity sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==
   dependencies:
-    strnum "^2.0.5"
+    strnum "^1.1.1"
 
 fastq@^1.6.0:
   version "1.17.1"
@@ -19476,10 +19476,10 @@ strnum@^1.0.5:
   resolved "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz#5c4e829fe15ad4ff0d20c3db5ac97b73c9b072db"
   integrity sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==
 
-strnum@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/strnum/-/strnum-2.0.5.tgz#40700b1b5bf956acdc755e98e90005d7657aaaea"
-  integrity sha512-YAT3K/sgpCUxhxNMrrdhtod3jckkpYwH6JAuwmUdXZsmzH1wUyzTMrrK2wYCEEqlKwrWDd35NeuUkbBy/1iK+Q==
+strnum@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz#57bca4fbaa6f271081715dbc9ed7cee5493e28e4"
+  integrity sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==
 
 strong-log-transformer@2.1.0:
   version "2.1.0"


### PR DESCRIPTION
fix fast-xml-parser to 4.5.4 because the 5.X versions cause issues with using eval() and break the docker build

The docker build had this issue using fast-xml-parser 5.0.6

Content-Security-Policy :The page's settings blocked a JavaScript eval (script-src) from being executed because it violates the following directive: "script-src 'self'" (Missing 'unsafe-eval')

Reference: https://github.com/NaturalIntelligence/fast-xml-parser/blob/af4f1d2d4da800202ad68e63f25a07a0ad9c201c/lib/fxp.cjs

https://github.com/NaturalIntelligence/fast-xml-parser/issues/733
Note commentator saying this is now esm native, which also causes issues
