### PR TITLE
Revert vue prism component upgrade to v2 since it is not compatible

### DIFF
--- a/test/integration/database-results.cy.ts
+++ b/test/integration/database-results.cy.ts
@@ -1,0 +1,71 @@
+import {
+  CREATE_USER_DTO_TEST_OBJ,
+  LOGIN_AUTHENTICATION
+} from '../../apps/backend/test/constants/users-test.constant';
+import Sidebar from '../support/components/Sidebar';
+import UploadModal from '../support/components/UploadModal';
+import DatabasePage from '../support/pages/DatabasePage';
+import DataTableVerifier from '../support/verifiers/DataTableVerifier';
+import ResultsPageVerifier from '../support/verifiers/ResultsPageVerifier';
+import ToastVerifier from '../support/verifiers/ToastVerifier';
+
+context('Database results', () => {
+  const uploadModal = new UploadModal();
+  const sidebar = new Sidebar();
+  const toastVerifier = new ToastVerifier();
+  const dataTableVerifier = new DataTableVerifier();
+  const resultsPageVerifier = new ResultsPageVerifier();
+  const databasePage = new DatabasePage();
+  const sampleToLoad = 'Acme Overlay Example';
+
+  // Run before each test
+  beforeEach(() => {
+    cy.register(CREATE_USER_DTO_TEST_OBJ);
+    cy.visit('/login');
+    cy.login(LOGIN_AUTHENTICATION);
+    cy.get('#hide-snackbar').click();
+  });
+
+  describe('CRUD', () => {
+    it('allows a user to save a result', () => {
+      uploadModal.loadSample(sampleToLoad);
+      sidebar.save(sampleToLoad);
+      toastVerifier.toastTextContains('File saved successfully');
+      uploadModal.activate();
+      uploadModal.switchToTab('database');
+      dataTableVerifier.verifyTextPresent(sampleToLoad);
+    });
+
+    it('allows a user to load a result', () => {
+      uploadModal.loadSample(sampleToLoad);
+      sidebar.save(sampleToLoad);
+      sidebar.close(sampleToLoad);
+      uploadModal.activate();
+      uploadModal.loadFromDatabase(sampleToLoad);
+      resultsPageVerifier.resultsFilenameCorrect(sampleToLoad);
+    });
+
+    it('allows a user to update a result', () => {
+      const updatedName = 'Updated Filename';
+      uploadModal.loadSample(sampleToLoad);
+      sidebar.save(sampleToLoad);
+      sidebar.close(sampleToLoad);
+      uploadModal.activate();
+      uploadModal.switchToTab('database');
+      databasePage.updateResultName(sampleToLoad, updatedName);
+      dataTableVerifier.verifyTextPresent(updatedName);
+    });
+
+    it('allows a user to delete a result', () => {
+      uploadModal.loadSample(sampleToLoad);
+      sidebar.save(sampleToLoad);
+      sidebar.close(sampleToLoad);
+      uploadModal.activate();
+      uploadModal.switchToTab('database');
+      databasePage.deleteResult(sampleToLoad);
+      dataTableVerifier.verifyTextPresent(
+        'No data found - try changing the search filter(s)'
+      );
+    });
+  });
+});

--- a/test/integration/groups.cy.ts
+++ b/test/integration/groups.cy.ts
@@ -1,0 +1,59 @@
+import {
+  CREATE_USER_DTO_TEST_OBJ,
+  LOGIN_AUTHENTICATION
+} from '../../apps/backend/test/constants/users-test.constant';
+import Dropdown from '../support/components/Dropdown';
+import GroupPage from '../support/pages/GroupPage';
+import DataTableVerifier from '../support/verifiers/DataTableVerifier';
+import ToastVerifier from '../support/verifiers/ToastVerifier';
+
+context('Groups', () => {
+  const groupPage = new GroupPage();
+  const dropdown = new Dropdown();
+  const toastVerifier = new ToastVerifier();
+  const dataTableVerifier = new DataTableVerifier();
+  const groupName1 = 'Test Group 1';
+  const groupName2 = 'Test Group 2';
+  const groupName3 = 'Test Group 3';
+  const groupName4 = 'Test Group 4';
+
+  // Run before each test
+  beforeEach(() => {
+    cy.register(CREATE_USER_DTO_TEST_OBJ);
+    cy.visit('/login');
+    cy.login(LOGIN_AUTHENTICATION);
+  });
+
+  describe('CRUD', () => {
+    it('allows a user to create a group', () => {
+      dropdown.openGroupsPage();
+      groupPage.createGroup(groupName1);
+      dataTableVerifier.verifyTextPresent(groupName1);
+    });
+
+    it('allows a user to update a group', () => {
+      const updatedGroupName = 'Updated Test Group';
+      dropdown.openGroupsPage();
+      groupPage.createGroup(groupName2);
+      groupPage.updateGroup(groupName2, updatedGroupName);
+      dataTableVerifier.verifyTextPresent(updatedGroupName);
+    });
+
+    it('allows a user to delete a group', () => {
+      dropdown.openGroupsPage();
+      groupPage.createGroup(groupName3);
+      groupPage.deleteGroup(groupName3);
+      toastVerifier.toastTextContains(
+        `Successfully deleted group ${groupName3}`
+      );
+      dataTableVerifier.verifyTextPresent('No groups match current selection.');
+    });
+
+    it('fails to create a group with a duplicate name', () => {
+      dropdown.openGroupsPage();
+      groupPage.createGroup(groupName4);
+      groupPage.testGroupName(groupName4);
+      toastVerifier.toastTextContains('Group names must be unique.');
+    });
+  });
+});

--- a/test/integration/login.cy.ts
+++ b/test/integration/login.cy.ts
@@ -1,0 +1,94 @@
+import {
+  BAD_LDAP_AUTHENTICATION,
+  BAD_LOGIN_AUTHENTICATION,
+  CREATE_USER_DTO_TEST_OBJ,
+  LDAP_AUTHENTICATION,
+  LOGIN_AUTHENTICATION
+} from '../../apps/backend/test/constants/users-test.constant';
+import Dropdown from '../support/components/Dropdown';
+import LoginPage from '../support/pages/LoginPage';
+import LoginPageVerifier from '../support/verifiers/LoginPageVerifier';
+import ToastVerifier from '../support/verifiers/ToastVerifier';
+import UserModalVerifier from '../support/verifiers/UserModalVerifier';
+
+context('Login', () => {
+  // Pages, verifiers, and modules
+  const dropdown = new Dropdown();
+  const loginPage = new LoginPage();
+  const loginPageVerifier = new LoginPageVerifier();
+  const toastVerifier = new ToastVerifier();
+  const userModalVerifier = new UserModalVerifier();
+
+  // Run before each test
+  beforeEach(() => {
+    cy.register(CREATE_USER_DTO_TEST_OBJ);
+    cy.visit('/login');
+  });
+
+  // The test
+  describe('Login Form', () => {
+    it('authenticates a user with valid credentials', () => {
+      loginPageVerifier.loginFormPresent();
+      cy.login(LOGIN_AUTHENTICATION);
+      toastVerifier.toastTextContains('You have successfully signed in.');
+    });
+    it('authenticates a github oauth user', () => {
+      loginPageVerifier.loginFormPresent();
+      loginPage.loginOauth('github');
+      // Open the user modal
+      dropdown.openUserModal();
+      // Make sure all the fields exist
+      userModalVerifier.verifyFieldsExist();
+    });
+    it('authenticates an ldap user with valid credentials', () => {
+      loginPage.switchToLDAPAuth();
+      loginPageVerifier.ldapLoginFormPresent();
+      loginPage.ldapLogin(LDAP_AUTHENTICATION);
+      toastVerifier.toastTextContains('You have successfully signed in.');
+    });
+    it('authenticates an oidc user', () => {
+      loginPage.loginOauth('oidc');
+      // Open the user modal
+      dropdown.openUserModal();
+      // Make sure all the fields exist
+      userModalVerifier.verifyFieldsExist();
+    });
+
+    describe('Authentication Failures', () => {
+      // Ignore 401 errors on authentication failure tests
+      beforeEach(() => {
+        cy.on('uncaught:exception', (err) => {
+          expect(err.response.status).to.equal(401);
+
+          // return false to prevent the error from
+          // failing this test
+          return false;
+        });
+      });
+
+      it('fails to authenticate a user with invalid credentials', () => {
+        cy.login(BAD_LOGIN_AUTHENTICATION);
+        toastVerifier.toastTextContains('Incorrect Username or Password');
+      });
+      it('fails to authenticate an oidc user with unverified email', () => {
+        loginPage.loginOauth('oidc');
+        toastVerifier.toastTextContains(
+          'Please verify your name and email with your identity provider before logging into Heimdall.'
+        );
+      });
+      it('fails to authenticate an ldap user with invalid credentials', () => {
+        loginPage.switchToLDAPAuth();
+        loginPage.ldapLogin(BAD_LDAP_AUTHENTICATION);
+        toastVerifier.toastTextContains('Unauthorized');
+      });
+    });
+  });
+
+  describe('Logout Button', () => {
+    it('sucessfully logs a user out', () => {
+      cy.login(LOGIN_AUTHENTICATION);
+      dropdown.logout();
+      loginPageVerifier.loginFormPresent();
+    });
+  });
+});

--- a/test/integration/registration.cy.ts
+++ b/test/integration/registration.cy.ts
@@ -1,0 +1,59 @@
+import {
+  CREATE_USER_DTO_TEST_OBJ,
+  CREATE_USER_DTO_TEST_OBJ_WITH_INVALID_PASSWORD,
+  CREATE_USER_DTO_TEST_OBJ_WITH_UNMATCHING_PASSWORDS
+} from '../../apps/backend/test/constants/users-test.constant';
+import RegistrationPage from '../support/pages/RegistrationPage';
+import RegistrationVerifier from '../support/verifiers/RegistrationPageVerifier';
+import ToastVerifier from '../support/verifiers/ToastVerifier';
+
+context('Registration', () => {
+  // Pages, verifiers, and modules
+  const registrationPage = new RegistrationPage();
+  const registrationVerifier = new RegistrationVerifier();
+  const toastVerifier = new ToastVerifier();
+
+  // Run before each test
+  beforeEach(() => {
+    cy.visit('/signup');
+  });
+
+  // The test
+  describe('Registration Form', () => {
+    it('allows a user to create an account', () => {
+      registrationVerifier.registerFormPresent();
+      registrationPage.register(CREATE_USER_DTO_TEST_OBJ);
+      toastVerifier.toastTextContains(
+        'You have successfully registered, please sign in'
+      );
+    });
+
+    it('rejects emails that already exist', () => {
+      registrationPage.register(CREATE_USER_DTO_TEST_OBJ);
+      registrationPage.register(CREATE_USER_DTO_TEST_OBJ);
+      toastVerifier.toastTextContains('Email must be unique');
+    });
+
+    it('rejects a weak password', () => {
+      cy.on('uncaught:exception', (err) => {
+        expect(err.response.status).to.equal(400);
+
+        // return false to prevent the error from
+        // failing this test
+        return false;
+      });
+
+      registrationPage.registerNoSubmit(
+        CREATE_USER_DTO_TEST_OBJ_WITH_INVALID_PASSWORD
+      );
+      registrationVerifier.registerButtonDisabled();
+    });
+
+    it('rejects mismatching passwords', () => {
+      registrationPage.registerNoSubmit(
+        CREATE_USER_DTO_TEST_OBJ_WITH_UNMATCHING_PASSWORDS
+      );
+      registrationVerifier.registerButtonDisabled();
+    });
+  });
+});

--- a/test/integration/splunk.cy.ts
+++ b/test/integration/splunk.cy.ts
@@ -1,0 +1,46 @@
+import {
+  BAD_SPLUNK_AUTHENTICATION,
+  CREATE_USER_DTO_TEST_OBJ,
+  LOGIN_AUTHENTICATION,
+  SPLUNK_AUTHENTICATION
+} from '../../apps/backend/test/constants/users-test.constant';
+import UploadModal from '../support/components/UploadModal';
+import SplunkPage from '../support/pages/SplunkPage';
+import SplunkTabVerifier from '../support/verifiers/SplunkTabVerifier';
+import ToastVerifier from '../support/verifiers/ToastVerifier';
+
+context('Splunk', () => {
+  // Pages, verifiers, and modules
+  const uploadModal = new UploadModal();
+  const toastVerifier = new ToastVerifier();
+  const splunkTabVerifier = new SplunkTabVerifier();
+  const splunkPage = new SplunkPage();
+
+  // Run before each test
+  beforeEach(() => {
+    cy.register(CREATE_USER_DTO_TEST_OBJ);
+    cy.visit('/login');
+    cy.login(LOGIN_AUTHENTICATION);
+    toastVerifier.toastTextContains('You have successfully signed in.');
+    cy.get('#hide-snackbar').click();
+  });
+
+  // The test
+  describe('Splunk Form', () => {
+    it('authenticates a user with valid Splunk credentials', () => {
+      uploadModal.switchToTab('splunk');
+      splunkTabVerifier.splunkPresent();
+      splunkPage.splunkLogin(SPLUNK_AUTHENTICATION);
+      toastVerifier.toastTextContains('You have successfully signed in');
+    });
+
+    it('fails to authenticate a Splunk user with invalid credentials', () => {
+      uploadModal.switchToTab('splunk');
+      splunkTabVerifier.splunkPresent();
+      splunkPage.splunkLogin(BAD_SPLUNK_AUTHENTICATION);
+      toastVerifier.toastTextContains(
+        'Failed to login - Incorrect username or password'
+      );
+    });
+  });
+});


### PR DESCRIPTION
Resolves #7897 

Added a test to prevent this from getting auto-merged by dependabot in the future cause the code tab would then break thereby failing the test thereby preventing dependabot from merging.  It's good to have a test for that functionality anyways.