### PR TITLE
Make control comments editable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Heimdall
+# Heimdall 
 
 [![Run E2E Backend + Frontend Tests](https://github.com/mitre/heimdall2/workflows/Run%20E2E%20Backend%20+%20Frontend%20Tests/badge.svg)](https://github.com/mitre/heimdall2/actions/workflows/e2e-ui-tests.yml) 
 [![Run Frontend Tests](https://github.com/mitre/heimdall2/workflows/Run%20Frontend%20Tests/badge.svg)](https://github.com/mitre/heimdall2/actions/workflows/frontend-tests.yml) 

--- a/apps/frontend/src/App.vue
+++ b/apps/frontend/src/App.vue
@@ -21,6 +21,10 @@
 import Footer from '@/components/global/Footer.vue';
 import Snackbar from '@/components/global/Snackbar.vue';
 import Spinner from '@/components/global/Spinner.vue';
+import {
+  InspecDataModule,
+  UNSAVED_CHANGES_MESSAGE
+} from '@/store/data_store';
 import Vue from 'vue';
 import Component from 'vue-class-component';
 import {ServerModule} from './store/server';
@@ -33,6 +37,24 @@ import {ServerModule} from './store/server';
   }
 })
 export default class App extends Vue {
+  mounted() {
+    window.addEventListener('beforeunload', this.confirmBeforeUnload);
+  }
+
+  beforeDestroy() {
+    window.removeEventListener('beforeunload', this.confirmBeforeUnload);
+  }
+
+  confirmBeforeUnload(event: BeforeUnloadEvent) {
+    if (!InspecDataModule.hasUnsavedFiles) {
+      return;
+    }
+
+    event.preventDefault();
+    event.returnValue = UNSAVED_CHANGES_MESSAGE;
+    return UNSAVED_CHANGES_MESSAGE;
+  }
+
   get classificationStyle() {
     return {
       background: ServerModule.classificationBannerColor,

--- a/apps/frontend/src/components/cards/controltable/ControlRowDetails.vue
+++ b/apps/frontend/src/components/cards/controltable/ControlRowDetails.vue
@@ -15,7 +15,6 @@
                   caveat ||
                   justification ||
                   rationale ||
-                  localComments ||
                   errorMessage
                 "
               >
@@ -38,13 +37,20 @@
                   <br />
                 </span>
                 <span v-if="rationale">Rationale: {{ rationale }}<br /></span>
-                <span v-if="localComments">
-                  Comments: {{ localComments }}
-                  <br />
-                </span>
                 <v-divider />
                 <br />
               </div>
+              <h3>Comments:</h3>
+              <v-textarea
+                v-model="localComments"
+                auto-grow
+                class="mb-4"
+                dense
+                hide-details
+                outlined
+                rows="3"
+                @input="updateComments"
+              />
               <!-- eslint-disable-next-line vue/no-v-html -->
               <div v-html="sanitize_html(main_desc)" />
             </div>

--- a/apps/frontend/src/components/cards/controltable/ControlRowDetails.vue
+++ b/apps/frontend/src/components/cards/controltable/ControlRowDetails.vue
@@ -15,7 +15,7 @@
                   caveat ||
                   justification ||
                   rationale ||
-                  comments ||
+                  localComments ||
                   errorMessage
                 "
               >
@@ -38,7 +38,10 @@
                   <br />
                 </span>
                 <span v-if="rationale">Rationale: {{ rationale }}<br /></span>
-                <span v-if="comments">Comments: {{ comments }}<br /></span>
+                <span v-if="localComments">
+                  Comments: {{ localComments }}
+                  <br />
+                </span>
                 <v-divider />
                 <br />
               </div>
@@ -61,7 +64,17 @@
                 <v-row :key="'tab' + index" :class="zebra(index)">
                   <v-col cols="12" :class="detail.class">
                     <h3>{{ detail.name }}:</h3>
-                    <h4>
+                    <v-textarea
+                      v-if="detail.editable"
+                      v-model="localComments"
+                      auto-grow
+                      dense
+                      hide-details
+                      outlined
+                      rows="3"
+                      @input="updateComments"
+                    />
+                    <h4 v-else>
                       <!-- eslint-disable vue/no-v-html -->
                       <pre class="mono" v-html="sanitize_html(detail.value)" />
                       <!-- eslint-enable vue/no-v-html -->
@@ -91,6 +104,7 @@
 <script lang="ts">
 import ControlRowCol from '@/components/cards/controltable/ControlRowCol.vue';
 import HtmlSanitizeMixin from '@/mixins/HtmlSanitizeMixin';
+import {InspecDataModule} from '@/store/data_store';
 import {ContextualizedControl} from 'inspecjs';
 import * as _ from 'lodash';
 //TODO: add line numbers
@@ -108,7 +122,15 @@ interface Detail {
   name: string;
   value: string;
   class?: string;
+  editable?: boolean;
 }
+
+type EditableDetail = {
+  value: string;
+  editable: true;
+};
+
+type DetailValue = string | number | null | undefined | EditableDetail;
 
 @Component({
   components: {
@@ -122,6 +144,7 @@ export default class ControlRowDetails extends mixins(HtmlSanitizeMixin) {
   readonly control!: ContextualizedControl;
 
   localTab = this.tab;
+  localComments = this.comments;
 
   @Watch('tab')
   onTabChanged(newTab?: string, _oldVal?: string) {
@@ -195,8 +218,13 @@ export default class ControlRowDetails extends mixins(HtmlSanitizeMixin) {
     return this.control.hdf.descriptions.justification;
   }
 
-  get comments(): string | undefined {
-    return this.control.hdf.descriptions.comments;
+  get comments(): string {
+    return this.control.hdf.descriptions.comments ?? '';
+  }
+
+  updateComments(comments: string) {
+    this.localComments = comments;
+    InspecDataModule.updateControlComments({comments, control: this.control});
   }
 
   get errorMessage(): string {
@@ -206,13 +234,17 @@ export default class ControlRowDetails extends mixins(HtmlSanitizeMixin) {
   }
 
   get details(): Detail[] {
-    const detailsMap = new Map();
+    const detailsMap = new Map<string, DetailValue>();
 
     detailsMap.set('Control', this.control.data.id);
     detailsMap.set('Title', this.control.data.title);
     detailsMap.set('Caveat', this.control.hdf.descriptions.caveat);
     detailsMap.set('Desc', this.control.data.desc);
     detailsMap.set('Rationale', this.control.hdf.descriptions.rationale);
+    detailsMap.set('Comments', {
+      editable: true,
+      value: this.localComments
+    });
     // default to showing severity tag, otherwise show the computed severity (based on impact or severityoverride)
     detailsMap.set(
       'Severity',
@@ -270,7 +302,7 @@ export default class ControlRowDetails extends mixins(HtmlSanitizeMixin) {
     });
 
     for (const prop in this.control.hdf.descriptions) {
-      if (!detailsMap.has(_.capitalize(prop))) {
+      if (prop !== 'comments' && !detailsMap.has(_.capitalize(prop))) {
         detailsMap.set(_.startCase(prop), this.control.hdf.descriptions[prop]);
       }
     }
@@ -285,9 +317,15 @@ export default class ControlRowDetails extends mixins(HtmlSanitizeMixin) {
       );
     }
 
-    return Array.from(detailsMap, ([name, value]) => ({name, value})).filter(
-      (v) => v.value !== undefined
-    );
+    return Array.from(detailsMap, ([name, value]) => ({name, value}))
+      .filter((detail) => detail.value !== undefined)
+      .map((detail): Detail => {
+        const {name, value} = detail;
+        if (typeof value === 'object' && value !== null && 'value' in value) {
+          return {editable: value.editable, name, value: value.value};
+        }
+        return {name, value: value === null ? '' : String(value)};
+      });
   }
 
   //for zebra background

--- a/apps/frontend/src/components/global/ExportCKLModal.vue
+++ b/apps/frontend/src/components/global/ExportCKLModal.vue
@@ -738,8 +738,12 @@ export default class ExportCKLModal extends Vue {
         });
       }
     }
-    saveSingleOrMultipleFiles(fileData, 'ckl');
-    this.closeModal();
+    saveSingleOrMultipleFiles(fileData, 'ckl').then(() => {
+      InspecDataModule.markFilesSaved(
+        this.selected.map((file) => file.uniqueId)
+      );
+      this.closeModal();
+    });
   }
 
   validateInputMetadata(metadata: ChecklistMetadata): Result<true, string> {

--- a/apps/frontend/src/components/global/ExportJson.vue
+++ b/apps/frontend/src/components/global/ExportJson.vue
@@ -16,6 +16,7 @@
 <script lang="ts">
 import IconLinkItem from '@/components/global/sidebaritems/IconLinkItem.vue';
 import {FilteredDataModule} from '@/store/data_filters';
+import {InspecDataModule} from '@/store/data_store';
 import {saveSingleOrMultipleFiles} from '@/utilities/export_util';
 import Vue from 'vue';
 import Component from 'vue-class-component';
@@ -51,8 +52,11 @@ export default class ExportJSON extends Vue {
 
   //exports .zip of jsons if multiple are selected, if one is selected it will export that .json file
   export_json() {
+    const ids = FilteredDataModule.selected_file_ids;
     const files = this.populate_files();
-    saveSingleOrMultipleFiles(files, 'json');
+    saveSingleOrMultipleFiles(files, 'json').then(() => {
+      InspecDataModule.markFilesSaved(ids);
+    });
   }
 
   cleanup_filename(filename: string): string {

--- a/apps/frontend/src/components/global/Sidebar.vue
+++ b/apps/frontend/src/components/global/Sidebar.vue
@@ -43,7 +43,7 @@ import DropdownContent from '@/components/global/sidebaritems/DropdownContent.vu
 import {Trinary} from '@/enums/Trinary';
 import RouteMixin from '@/mixins/RouteMixin';
 import {FilteredDataModule} from '@/store/data_filters';
-import {InspecDataModule} from '@/store/data_store';
+import {InspecDataModule, UNSAVED_CHANGES_MESSAGE} from '@/store/data_store';
 import {EvaluationFile, ProfileFile} from '@/store/report_intake';
 import Component, {mixins} from 'vue-class-component';
 import {Prop} from 'vue-property-decorator';
@@ -141,7 +141,15 @@ export default class Sidebar extends mixins(RouteMixin) {
 
   removeSelectedEvaluations(): void {
     const selectedFiles = FilteredDataModule.selected_evaluation_ids;
-    selectedFiles.forEach((fileId) => {
+    const files = this.visible_evaluation_files.filter((file) =>
+      selectedFiles.includes(file.uniqueId)
+    );
+    if (!this.confirmRemoveUnsavedFiles(files)) {
+      return;
+    }
+
+    files.forEach((file) => {
+      const fileId = file.uniqueId;
       EvaluationModule.removeEvaluation(fileId);
       InspecDataModule.removeFile(fileId);
       // Remove any database files that may have been in the URL
@@ -153,7 +161,15 @@ export default class Sidebar extends mixins(RouteMixin) {
 
   removeSelectedProfiles(): void {
     const selectedFiles = FilteredDataModule.selected_profile_ids;
-    selectedFiles.forEach((fileId) => {
+    const files = this.visible_profile_files.filter((file) =>
+      selectedFiles.includes(file.uniqueId)
+    );
+    if (!this.confirmRemoveUnsavedFiles(files)) {
+      return;
+    }
+
+    files.forEach((file) => {
+      const fileId = file.uniqueId;
       EvaluationModule.removeEvaluation(fileId);
       InspecDataModule.removeFile(fileId);
       // Remove any database files that may have been in the URL
@@ -161,6 +177,16 @@ export default class Sidebar extends mixins(RouteMixin) {
       // route to the URL bar
       this.navigateWithNoErrors(`/${this.current_route}`);
     });
+  }
+
+  confirmRemoveUnsavedFiles(files: (EvaluationFile | ProfileFile)[]): boolean {
+    if (!files.some((file) => file.hasUnsavedChanges)) {
+      return true;
+    }
+
+    return globalThis.confirm(
+      `${UNSAVED_CHANGES_MESSAGE}\n\nRemove them anyway?`
+    );
   }
 }
 </script>

--- a/apps/frontend/src/components/global/sidebaritems/SidebarFileList.vue
+++ b/apps/frontend/src/components/global/sidebaritems/SidebarFileList.vue
@@ -13,7 +13,18 @@
     </v-list-item-avatar>
 
     <v-list-item-content>
-      <v-list-item-title>{{ file.filename }}</v-list-item-title>
+      <v-list-item-title>
+        {{ file.filename }}
+        <v-icon
+          v-if="file.hasUnsavedChanges"
+          class="ml-2"
+          color="warning"
+          small
+          title="Unsaved comments edits"
+        >
+          mdi-content-save-alert
+        </v-icon>
+      </v-list-item-title>
     </v-list-item-content>
 
     <v-list-item-action v-if="serverMode" @click.stop="save_file">
@@ -36,7 +47,7 @@
 import RouteMixin from '@/mixins/RouteMixin';
 import ServerMixin from '@/mixins/ServerMixin';
 import {FilteredDataModule} from '@/store/data_filters';
-import {InspecDataModule} from '@/store/data_store';
+import {InspecDataModule, UNSAVED_CHANGES_MESSAGE} from '@/store/data_store';
 import {EvaluationModule} from '@/store/evaluations';
 import {EvaluationFile, ProfileFile} from '@/store/report_intake';
 import {SnackbarModule} from '@/store/snackbar';
@@ -75,6 +86,13 @@ export default class SidebarFileList extends mixins(ServerMixin, RouteMixin) {
 
   //removes uploaded file from the currently observed files
   remove_file() {
+    if (
+      this.file.hasUnsavedChanges &&
+      !globalThis.confirm(`${UNSAVED_CHANGES_MESSAGE}\n\nRemove it anyway?`)
+    ) {
+      return;
+    }
+
     EvaluationModule.removeEvaluation(this.file.uniqueId);
     InspecDataModule.removeFile(this.file.uniqueId);
     // Remove any database files that may have been in the URL
@@ -86,7 +104,7 @@ export default class SidebarFileList extends mixins(ServerMixin, RouteMixin) {
   //saves file to database
   save_file() {
     if (this.file?.database_id) {
-      SnackbarModule.failure('This file is already in the database.');
+      this.update_database_file(this.file);
     } else if (this.file) {
       this.save_to_database(this.file);
     }
@@ -94,7 +112,43 @@ export default class SidebarFileList extends mixins(ServerMixin, RouteMixin) {
 
   //determines if the use can save the file
   get disable_saving() {
-    return typeof this.file?.database_id !== 'undefined' || this.saving;
+    return (
+      this.saving ||
+      (this.file?.database_id !== undefined && !this.file.hasUnsavedChanges)
+    );
+  }
+
+  file_data(file: EvaluationFile | ProfileFile) {
+    if (file.hasOwnProperty('evaluation')) {
+      return _.get(file, 'evaluation.data');
+    }
+    return _.get(file, 'profile.data');
+  }
+
+  update_database_file(file: EvaluationFile | ProfileFile) {
+    const evaluation = EvaluationModule.evaluationForFile(file) as
+      | IEvaluation
+      | undefined;
+    if (!evaluation) {
+      SnackbarModule.failure('Could not find the database entry for this file.');
+      return;
+    }
+
+    this.saving = true;
+    EvaluationModule.updateEvaluation({
+      ...evaluation,
+      data: this.file_data(file)
+    })
+      .then(() => {
+        SnackbarModule.notify('File saved successfully');
+        InspecDataModule.markFileSaved(file.uniqueId);
+      })
+      .catch((error) => {
+        SnackbarModule.HTTPFailure(error);
+      })
+      .finally(() => {
+        this.saving = false;
+      });
   }
 
   save_to_database(file: EvaluationFile | ProfileFile) {
@@ -116,26 +170,18 @@ export default class SidebarFileList extends mixins(ServerMixin, RouteMixin) {
       }
     }
     // Add evaluation data to the form
-    if (file.hasOwnProperty('evaluation')) {
-      formData.append(
-        'data',
-        new Blob([JSON.stringify(_.get(file, 'evaluation.data'))], {
-          type: 'text/plain'
-        })
-      );
-    } else {
-      formData.append(
-        'data',
-        new Blob([JSON.stringify(_.get(file, 'profile.data'))], {
-          type: 'text/plain'
-        })
-      );
-    }
+    formData.append(
+      'data',
+      new Blob([JSON.stringify(this.file_data(file))], {
+        type: 'text/plain'
+      })
+    );
     axios
       .post<IEvaluation>('/evaluations', formData)
       .then((response) => {
         SnackbarModule.notify('File saved successfully');
         file.database_id = parseInt(response.data.id);
+        InspecDataModule.markFileSaved(file.uniqueId);
         EvaluationModule.loadEvaluation(response.data.id);
         const loadedDatabaseIds = InspecDataModule.loadedDatabaseIds.join(',');
         this.navigateWithNoErrors(

--- a/apps/frontend/src/components/global/sidebaritems/SidebarFileList.vue
+++ b/apps/frontend/src/components/global/sidebaritems/SidebarFileList.vue
@@ -29,7 +29,7 @@
 
     <v-list-item-action v-if="serverMode" @click.stop="save_file">
       <v-btn data-cy="saveFile" icon small :disabled="disable_saving">
-        <v-icon title="Save entry to the database"> mdi-content-save </v-icon>
+        <v-icon :title="save_button_title"> mdi-content-save </v-icon>
       </v-btn>
     </v-list-item-action>
 
@@ -56,6 +56,17 @@ import axios from 'axios';
 import * as _ from 'lodash';
 import Component, {mixins} from 'vue-class-component';
 import {Prop} from 'vue-property-decorator';
+
+const REVIEW_TAG = 'heimdall:review';
+const REVIEW_ROOT_TAG_PREFIX = 'heimdall:review-root:';
+const REVIEW_PARENT_TAG_PREFIX = 'heimdall:review-parent:';
+const REVIEW_FILENAME_SUFFIX = /\s+- review \d{4}-\d{2}-\d{2} \d{2}-\d{2}$/u;
+
+type SaveToDatabaseOptions = {
+  filename?: string;
+  successMessage?: string;
+  tagValues?: string[];
+};
 
 @Component
 export default class SidebarFileList extends mixins(ServerMixin, RouteMixin) {
@@ -103,8 +114,16 @@ export default class SidebarFileList extends mixins(ServerMixin, RouteMixin) {
 
   //saves file to database
   save_file() {
+    if (this.saving) {
+      return;
+    }
+
     if (this.file?.database_id) {
-      this.update_database_file(this.file);
+      if (!this.file.hasUnsavedChanges) {
+        SnackbarModule.failure('This file is already in the database.');
+        return;
+      }
+      this.save_reviewed_copy(this.file);
     } else if (this.file) {
       this.save_to_database(this.file);
     }
@@ -118,6 +137,13 @@ export default class SidebarFileList extends mixins(ServerMixin, RouteMixin) {
     );
   }
 
+  get save_button_title(): string {
+    if (this.file?.database_id !== undefined) {
+      return 'Save reviewed copy to the database';
+    }
+    return 'Save entry to the database';
+  }
+
   file_data(file: EvaluationFile | ProfileFile) {
     if (file.hasOwnProperty('evaluation')) {
       return _.get(file, 'evaluation.data');
@@ -125,50 +151,106 @@ export default class SidebarFileList extends mixins(ServerMixin, RouteMixin) {
     return _.get(file, 'profile.data');
   }
 
-  update_database_file(file: EvaluationFile | ProfileFile) {
-    const evaluation = EvaluationModule.evaluationForFile(file) as
-      | IEvaluation
-      | undefined;
-    if (!evaluation) {
-      SnackbarModule.failure('Could not find the database entry for this file.');
+  review_timestamp(): string {
+    const now = new Date();
+    const pad = (value: number) => String(value).padStart(2, '0');
+    return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(
+      now.getDate()
+    )} ${pad(now.getHours())}-${pad(now.getMinutes())}`;
+  }
+
+  review_copy_filename(filename: string): string {
+    return `${filename.replace(
+      REVIEW_FILENAME_SUFFIX,
+      ''
+    )} - review ${this.review_timestamp()}`;
+  }
+
+  review_root_id(evaluation: IEvaluation | undefined): string | undefined {
+    const tagValues = evaluation?.evaluationTags?.map((tag) => tag.value) ?? [];
+    return tagValues
+      .find((tag) => tag.startsWith(REVIEW_ROOT_TAG_PREFIX))
+      ?.slice(REVIEW_ROOT_TAG_PREFIX.length);
+  }
+
+  reviewed_copy_tags(
+    sourceEvaluation: IEvaluation | undefined,
+    sourceDatabaseId: string
+  ): string[] {
+    const sourceTags =
+      sourceEvaluation?.evaluationTags?.map((tag) => tag.value) ?? [];
+    const rootId = this.review_root_id(sourceEvaluation) ?? sourceDatabaseId;
+    const reviewTags = [
+      REVIEW_TAG,
+      `${REVIEW_ROOT_TAG_PREFIX}${rootId}`,
+      `${REVIEW_PARENT_TAG_PREFIX}${sourceDatabaseId}`
+    ];
+    return [
+      ...new Set(
+        sourceTags
+          .filter(
+            (tag) =>
+              tag !== REVIEW_TAG &&
+              !tag.startsWith(REVIEW_ROOT_TAG_PREFIX) &&
+              !tag.startsWith(REVIEW_PARENT_TAG_PREFIX)
+          )
+          .concat(reviewTags)
+      )
+    ];
+  }
+
+  save_reviewed_copy(file: EvaluationFile | ProfileFile) {
+    const sourceDatabaseId = file.database_id?.toString();
+    if (!sourceDatabaseId) {
+      this.save_to_database(file);
       return;
     }
 
-    this.saving = true;
-    EvaluationModule.updateEvaluation({
-      ...evaluation,
-      data: this.file_data(file)
-    })
-      .then(() => {
-        SnackbarModule.notify('File saved successfully');
-        InspecDataModule.markFileSaved(file.uniqueId);
-      })
-      .catch((error) => {
-        SnackbarModule.HTTPFailure(error);
-      })
-      .finally(() => {
-        this.saving = false;
-      });
+    const sourceEvaluation = EvaluationModule.evaluationForFile(file) as
+      | IEvaluation
+      | undefined;
+    this.save_to_database(file, {
+      filename: this.review_copy_filename(file.filename),
+      successMessage: 'Reviewed copy saved successfully',
+      tagValues: this.reviewed_copy_tags(sourceEvaluation, sourceDatabaseId)
+    });
   }
 
-  save_to_database(file: EvaluationFile | ProfileFile) {
+  append_create_evaluation_form_data(
+    formData: FormData,
+    createEvaluationDto: ICreateEvaluation
+  ) {
+    formData.append('filename', createEvaluationDto.filename);
+    formData.append('public', String(createEvaluationDto.public));
+    formData.append(
+      'evaluationTags',
+      createEvaluationDto.evaluationTags
+        ?.map((evaluationTag) => evaluationTag.value)
+        .join(',') ?? ''
+    );
+    if (createEvaluationDto.groups !== undefined) {
+      formData.append('groups', createEvaluationDto.groups.join(','));
+    }
+  }
+
+  save_to_database(
+    file: EvaluationFile | ProfileFile,
+    options: SaveToDatabaseOptions = {}
+  ) {
     this.saving = true;
+    const filename = options.filename ?? file.filename;
 
     const createEvaluationDto: ICreateEvaluation = {
-      filename: file.filename,
+      filename,
       public: false,
-      evaluationTags: [],
+      evaluationTags:
+        options.tagValues?.map((tagValue) => ({value: tagValue})) ?? [],
       groups: undefined
     };
 
     // Create a multipart form to upload our data
     const formData = new FormData();
-    // Add the DTO objects to form data
-    for (const [key, value] of Object.entries(createEvaluationDto)) {
-      if (typeof value !== 'undefined') {
-        formData.append(key, value);
-      }
-    }
+    this.append_create_evaluation_form_data(formData, createEvaluationDto);
     // Add evaluation data to the form
     formData.append(
       'data',
@@ -179,8 +261,11 @@ export default class SidebarFileList extends mixins(ServerMixin, RouteMixin) {
     axios
       .post<IEvaluation>('/evaluations', formData)
       .then((response) => {
-        SnackbarModule.notify('File saved successfully');
-        file.database_id = parseInt(response.data.id);
+        SnackbarModule.notify(
+          options.successMessage ?? 'File saved successfully'
+        );
+        file.filename = filename;
+        file.database_id = Number.parseInt(response.data.id, 10);
         InspecDataModule.markFileSaved(file.uniqueId);
         EvaluationModule.loadEvaluation(response.data.id);
         const loadedDatabaseIds = InspecDataModule.loadedDatabaseIds.join(',');

--- a/apps/frontend/src/components/global/sidebaritems/SidebarFileList.vue
+++ b/apps/frontend/src/components/global/sidebaritems/SidebarFileList.vue
@@ -51,16 +51,15 @@ import {InspecDataModule, UNSAVED_CHANGES_MESSAGE} from '@/store/data_store';
 import {EvaluationModule} from '@/store/evaluations';
 import {EvaluationFile, ProfileFile} from '@/store/report_intake';
 import {SnackbarModule} from '@/store/snackbar';
+import {
+  reviewedCopyTags,
+  reviewCopyFilename
+} from '@/utilities/review_copy_util';
 import {ICreateEvaluation, IEvaluation} from '@heimdall/common/interfaces';
 import axios from 'axios';
 import * as _ from 'lodash';
 import Component, {mixins} from 'vue-class-component';
 import {Prop} from 'vue-property-decorator';
-
-const REVIEW_TAG = 'heimdall:review';
-const REVIEW_ROOT_TAG_PREFIX = 'heimdall:review-root:';
-const REVIEW_PARENT_TAG_PREFIX = 'heimdall:review-parent:';
-const REVIEW_FILENAME_SUFFIX = /\s+- review \d{4}-\d{2}-\d{2} \d{2}-\d{2}$/u;
 
 type SaveToDatabaseOptions = {
   filename?: string;
@@ -151,52 +150,13 @@ export default class SidebarFileList extends mixins(ServerMixin, RouteMixin) {
     return _.get(file, 'profile.data');
   }
 
-  review_timestamp(): string {
-    const now = new Date();
-    const pad = (value: number) => String(value).padStart(2, '0');
-    return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(
-      now.getDate()
-    )} ${pad(now.getHours())}-${pad(now.getMinutes())}`;
-  }
-
-  review_copy_filename(filename: string): string {
-    return `${filename.replace(
-      REVIEW_FILENAME_SUFFIX,
-      ''
-    )} - review ${this.review_timestamp()}`;
-  }
-
-  review_root_id(evaluation: IEvaluation | undefined): string | undefined {
-    const tagValues = evaluation?.evaluationTags?.map((tag) => tag.value) ?? [];
-    return tagValues
-      .find((tag) => tag.startsWith(REVIEW_ROOT_TAG_PREFIX))
-      ?.slice(REVIEW_ROOT_TAG_PREFIX.length);
-  }
-
   reviewed_copy_tags(
     sourceEvaluation: IEvaluation | undefined,
     sourceDatabaseId: string
   ): string[] {
     const sourceTags =
       sourceEvaluation?.evaluationTags?.map((tag) => tag.value) ?? [];
-    const rootId = this.review_root_id(sourceEvaluation) ?? sourceDatabaseId;
-    const reviewTags = [
-      REVIEW_TAG,
-      `${REVIEW_ROOT_TAG_PREFIX}${rootId}`,
-      `${REVIEW_PARENT_TAG_PREFIX}${sourceDatabaseId}`
-    ];
-    return [
-      ...new Set(
-        sourceTags
-          .filter(
-            (tag) =>
-              tag !== REVIEW_TAG &&
-              !tag.startsWith(REVIEW_ROOT_TAG_PREFIX) &&
-              !tag.startsWith(REVIEW_PARENT_TAG_PREFIX)
-          )
-          .concat(reviewTags)
-      )
-    ];
+    return reviewedCopyTags(sourceTags, sourceDatabaseId);
   }
 
   save_reviewed_copy(file: EvaluationFile | ProfileFile) {
@@ -210,7 +170,7 @@ export default class SidebarFileList extends mixins(ServerMixin, RouteMixin) {
       | IEvaluation
       | undefined;
     this.save_to_database(file, {
-      filename: this.review_copy_filename(file.filename),
+      filename: reviewCopyFilename(file.filename),
       successMessage: 'Reviewed copy saved successfully',
       tagValues: this.reviewed_copy_tags(sourceEvaluation, sourceDatabaseId)
     });

--- a/apps/frontend/src/components/global/upload_tabs/LoadFileList.vue
+++ b/apps/frontend/src/components/global/upload_tabs/LoadFileList.vue
@@ -268,7 +268,7 @@ import TagRow from '@/components/global/tags/TagRow.vue';
 import EditEvaluationModal from '@/components/global/upload_tabs/EditEvaluationModal.vue';
 import {EvaluationModule} from '@/store/evaluations';
 import {SnackbarModule} from '@/store/snackbar';
-import {InspecDataModule} from '@/store/data_store';
+import {InspecDataModule, UNSAVED_CHANGES_MESSAGE} from '@/store/data_store';
 import {
   IEvalPaginationParams,
   IEvaluation,
@@ -653,13 +653,22 @@ export default class LoadFileList extends mixins(ServerMixin, RouteMixin) {
   }
 
   async deleteItemConfirm(): Promise<void> {
-    EvaluationModule.deleteEvaluation(this.activeItem).then(async () => {
+    const fileId = await InspecDataModule.loadedFileIsForDatabaseIds(
+      Number(this.activeItem.id)
+    );
+
+    if (
+      fileId &&
+      InspecDataModule.fileHasUnsavedChanges(fileId) &&
+      !globalThis.confirm(`${UNSAVED_CHANGES_MESSAGE}\n\nDelete it anyway?`)
+    ) {
+      this.deleteItemDialog = false;
+      return;
+    }
+
+    EvaluationModule.deleteEvaluation(this.activeItem).then(() => {
       SnackbarModule.notify('Deleted evaluation successfully.');
       this.updateEvaluations();
-      // Remove the file from the visualization panel if it is loaded.
-      const fileId = await InspecDataModule.loadedFileIsForDatabaseIds(
-        Number(this.activeItem.id)
-      );
       if (FilteredDataModule.selected_file_ids.includes(fileId)) {
         //removes uploaded file from the currently observed files
         EvaluationModule.removeEvaluation(fileId);

--- a/apps/frontend/src/store/data_store.ts
+++ b/apps/frontend/src/store/data_store.ts
@@ -109,7 +109,7 @@ export function updateStructuredChecklistComments(
 
   let commentsSectionUpdated = false;
   const sections = existingComments
-    .split(/\n(?=[A-Z]+ ::)/gv)
+    .split(/\n(?=[A-Z_]+ ::)/gv)
     .map((section) => section.trimEnd())
     .filter((section) => section.length > 0)
     .flatMap((section) => {

--- a/apps/frontend/src/store/data_store.ts
+++ b/apps/frontend/src/store/data_store.ts
@@ -22,8 +22,9 @@ import {
 import {FilteredDataModule} from './data_filters';
 
 export const UNSAVED_CHANGES_MESSAGE =
-  'This file has unsaved comments edits. Export or save the file before ' +
-  'removing it from the loaded results.';
+  'This file has unsaved comments edits. Export the file or save a reviewed ' +
+  'copy where available before removing it from the loaded results or leaving ' +
+  'this page.';
 
 type UpdateControlCommentsPayload = {
   control: ContextualizedControl;

--- a/apps/frontend/src/store/data_store.ts
+++ b/apps/frontend/src/store/data_store.ts
@@ -64,7 +64,7 @@ function getFileForControl(
   return evaluation?.from_file ?? profile.from_file;
 }
 
-function updateDescriptionArray(
+export function updateDescriptionArray(
   control: ContextualizedControl,
   comments: string
 ) {
@@ -96,7 +96,7 @@ function updateDescriptionArray(
   }
 }
 
-function updateStructuredChecklistComments(
+export function updateStructuredChecklistComments(
   currentComments: unknown,
   comments: string
 ): string {
@@ -128,7 +128,7 @@ function updateStructuredChecklistComments(
   return sections.join('\n');
 }
 
-function updateChecklistPassthroughComments(
+export function updateChecklistPassthroughComments(
   file: EvaluationFile | ProfileFile,
   control: ContextualizedControl,
   comments: string

--- a/apps/frontend/src/store/data_store.ts
+++ b/apps/frontend/src/store/data_store.ts
@@ -10,6 +10,8 @@ import {
   SourcedContextualizedProfile
 } from '@/store/report_intake';
 import Store from '@/store/store';
+import {ContextualizedControl, ExecJSON} from 'inspecjs';
+import Vue from 'vue';
 import {
   Action,
   getModule,
@@ -19,9 +21,157 @@ import {
 } from 'vuex-module-decorators';
 import {FilteredDataModule} from './data_filters';
 
+export const UNSAVED_CHANGES_MESSAGE =
+  'This file has unsaved comments edits. Export or save the file before ' +
+  'removing it from the loaded results.';
+
+type UpdateControlCommentsPayload = {
+  control: ContextualizedControl;
+  comments: string;
+};
+
+type EditableControlData = {
+  descriptions?:
+    | ExecJSON.ControlDescription[]
+    | Record<string, string>
+    | null;
+  id: string;
+  tags?: Record<string, unknown>;
+};
+
+function nonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== 'string' && typeof value !== 'number') {
+    return undefined;
+  }
+
+  const text = String(value).trim();
+  return text.length > 0 ? text : undefined;
+}
+
 /** We make some new variant types of the Contextual types, to include their files*/
 export function isFromProfileFile(p: SourcedContextualizedProfile) {
   return p.sourcedFrom === null;
+}
+
+function getFileForControl(
+  control: ContextualizedControl
+): EvaluationFile | ProfileFile | undefined {
+  const profile = control.sourcedFrom as SourcedContextualizedProfile;
+  const evaluation = profile.sourcedFrom as
+    | SourcedContextualizedEvaluation
+    | null;
+  return evaluation?.from_file ?? profile.from_file;
+}
+
+function updateDescriptionArray(
+  control: ContextualizedControl,
+  comments: string
+) {
+  const controlData = control.data as EditableControlData;
+  if (control.hdf.isProfile) {
+    const descriptions: Record<string, string> =
+      controlData.descriptions && !Array.isArray(controlData.descriptions)
+        ? controlData.descriptions
+        : {};
+    descriptions.comments = comments;
+    controlData.descriptions = descriptions;
+    return;
+  }
+
+  const descriptions = Array.isArray(controlData.descriptions)
+    ? controlData.descriptions
+    : [];
+  controlData.descriptions = descriptions;
+
+  const commentDescription = descriptions.find(
+    (description: ExecJSON.ControlDescription) =>
+      description.label === 'comments'
+  );
+
+  if (commentDescription) {
+    commentDescription.data = comments;
+  } else {
+    descriptions.push({data: comments, label: 'comments'});
+  }
+}
+
+function updateStructuredChecklistComments(
+  currentComments: unknown,
+  comments: string
+): string {
+  const existingComments =
+    typeof currentComments === 'string' ? currentComments : '';
+
+  if (!existingComments.includes(' :: ')) {
+    return comments;
+  }
+
+  let commentsSectionUpdated = false;
+  const sections = existingComments
+    .split(/\n(?=[A-Z]+ ::)/gv)
+    .map((section) => section.trimEnd())
+    .filter((section) => section.length > 0)
+    .flatMap((section) => {
+      if (!section.startsWith('COMMENTS :: ')) {
+        return [section];
+      }
+
+      commentsSectionUpdated = true;
+      return comments ? [`COMMENTS :: ${comments}`] : [];
+    });
+
+  if (!commentsSectionUpdated && comments) {
+    sections.push(`COMMENTS :: ${comments}`);
+  }
+
+  return sections.join('\n');
+}
+
+function updateChecklistPassthroughComments(
+  file: EvaluationFile | ProfileFile,
+  control: ContextualizedControl,
+  comments: string
+) {
+  if (!('evaluation' in file)) {
+    return;
+  }
+
+  const evaluationData = file.evaluation
+    .data as unknown as Record<string, unknown>;
+  const passthrough = evaluationData.passthrough as
+    | {checklist?: {stigs?: {vulns?: Record<string, unknown>[]}[]}}
+    | undefined;
+  const checklist = passthrough?.checklist;
+  if (!checklist?.stigs) {
+    return;
+  }
+
+  const controlData = control.data as EditableControlData;
+  const controlTags = controlData.tags ?? {};
+  const targetIdentifiers = [
+    [controlData.id, 'vulnNum'],
+    [controlTags.rid, 'ruleId'],
+    [controlTags.stig_id, 'ruleVer'],
+    [controlTags.STIGRef, 'stigRef']
+  ] as const;
+  for (const stig of checklist.stigs) {
+    for (const vuln of stig.vulns ?? []) {
+      const matches = targetIdentifiers
+        .map(([targetValue, vulnKey]) => {
+          const target = nonEmptyString(targetValue);
+          const source = nonEmptyString(vuln[vulnKey]);
+          return target && source ? source === target : undefined;
+        })
+        .filter((match): match is boolean => match !== undefined);
+      if (matches.length >= 2 && matches.every(Boolean)) {
+        vuln.comments = updateStructuredChecklistComments(
+          vuln.comments,
+          comments
+        );
+        return;
+      }
+    }
+  }
 }
 
 @Module({
@@ -53,6 +203,18 @@ export class InspecData extends VuexModule {
   /* Return all profile files only */
   get allProfileFiles(): ProfileFile[] {
     return this.profileFiles;
+  }
+
+  get hasUnsavedFiles(): boolean {
+    return this.allFiles.some((file) => file.hasUnsavedChanges);
+  }
+
+  get fileHasUnsavedChanges(): (fileId: FileID) => boolean {
+    return (fileId: FileID) =>
+      Boolean(
+        this.allFiles.find((file) => file.uniqueId === fileId)
+          ?.hasUnsavedChanges
+      );
   }
 
   /**
@@ -111,6 +273,38 @@ export class InspecData extends VuexModule {
   @Mutation
   addExecution(newExecution: EvaluationFile) {
     this.executionFiles.push(newExecution);
+  }
+
+  @Mutation
+  updateControlComments({control, comments}: UpdateControlCommentsPayload) {
+    updateDescriptionArray(control, comments);
+    control.hdf.descriptions.comments = comments;
+
+    const file = getFileForControl(control);
+    if (file) {
+      updateChecklistPassthroughComments(file, control, comments);
+      Vue.set(file, 'hasUnsavedChanges', true);
+    }
+  }
+
+  @Mutation
+  MARK_FILE_SAVED(fileId: FileID) {
+    const file = this.allFiles.find(
+      (storedFile) => storedFile.uniqueId === fileId
+    );
+    if (file) {
+      Vue.set(file, 'hasUnsavedChanges', false);
+    }
+  }
+
+  @Action
+  markFileSaved(fileId: FileID) {
+    this.context.commit('MARK_FILE_SAVED', fileId);
+  }
+
+  @Action
+  markFilesSaved(fileIds: FileID[]) {
+    fileIds.forEach((fileId) => this.context.commit('MARK_FILE_SAVED', fileId));
   }
 
   /**

--- a/apps/frontend/src/store/report_intake.ts
+++ b/apps/frontend/src/store/report_intake.ts
@@ -69,6 +69,9 @@ export type InspecFile = {
   /** The filename that this file was uploaded under. */
   filename: string;
 
+  /** True when local edits have not been exported or saved back to the server. */
+  hasUnsavedChanges?: boolean;
+
   database_id?: number;
 
   tags?: Tag[];

--- a/apps/frontend/src/utilities/review_copy_util.ts
+++ b/apps/frontend/src/utilities/review_copy_util.ts
@@ -1,0 +1,50 @@
+export const REVIEW_TAG = 'heimdall:review';
+export const REVIEW_ROOT_TAG_PREFIX = 'heimdall:review-root:';
+export const REVIEW_PARENT_TAG_PREFIX = 'heimdall:review-parent:';
+
+const REVIEW_FILENAME_SUFFIX = /\s+- review \d{4}-\d{2}-\d{2} \d{2}-\d{2}$/u;
+
+export function reviewTimestamp(date = new Date()): string {
+  const pad = (value: number) => String(value).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(
+    date.getDate()
+  )} ${pad(date.getHours())}-${pad(date.getMinutes())}`;
+}
+
+export function reviewCopyFilename(filename: string, date = new Date()): string {
+  return `${filename.replace(
+    REVIEW_FILENAME_SUFFIX,
+    ''
+  )} - review ${reviewTimestamp(date)}`;
+}
+
+export function reviewRootId(tagValues: string[]): string | undefined {
+  return tagValues
+    .find((tag) => tag.startsWith(REVIEW_ROOT_TAG_PREFIX))
+    ?.slice(REVIEW_ROOT_TAG_PREFIX.length);
+}
+
+export function reviewedCopyTags(
+  sourceTagValues: string[],
+  sourceDatabaseId: string
+): string[] {
+  const rootId = reviewRootId(sourceTagValues) ?? sourceDatabaseId;
+  const reviewTags = [
+    REVIEW_TAG,
+    `${REVIEW_ROOT_TAG_PREFIX}${rootId}`,
+    `${REVIEW_PARENT_TAG_PREFIX}${sourceDatabaseId}`
+  ];
+
+  return [
+    ...new Set(
+      sourceTagValues
+        .filter(
+          (tag) =>
+            tag !== REVIEW_TAG &&
+            !tag.startsWith(REVIEW_ROOT_TAG_PREFIX) &&
+            !tag.startsWith(REVIEW_PARENT_TAG_PREFIX)
+        )
+        .concat(reviewTags)
+    )
+  ];
+}

--- a/apps/frontend/tests/unit/ControlRowDetails.spec.ts
+++ b/apps/frontend/tests/unit/ControlRowDetails.spec.ts
@@ -1,0 +1,83 @@
+import ControlRowDetails from '@/components/cards/controltable/ControlRowDetails.vue';
+import {mount, Wrapper} from '@vue/test-utils';
+import {ContextualizedControl} from 'inspecjs';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import Vue from 'vue';
+import Vuetify from 'vuetify';
+import {addElemWithDataAppToBody} from '../util/testingUtils';
+
+const mocks = vi.hoisted(() => ({
+  updateControlComments: vi.fn()
+}));
+
+vi.mock('@/store/data_store', () => ({
+  InspecDataModule: {
+    updateControlComments: mocks.updateControlComments
+  }
+}));
+
+addElemWithDataAppToBody();
+
+describe('ControlRowDetails', () => {
+  const vuetify = new Vuetify();
+  let control: ContextualizedControl;
+  let wrapper: Wrapper<Vue>;
+
+  beforeEach(() => {
+    mocks.updateControlComments.mockReset();
+    control = {
+      data: {
+        id: 'V-1',
+        title: 'Control title',
+        desc: 'Control description',
+        impact: 0.5,
+        tags: {},
+        refs: []
+      },
+      full_code: '',
+      hdf: {
+        descriptions: {},
+        isProfile: false,
+        rawNistTags: [],
+        wraps: {
+          tags: {}
+        }
+      },
+      root: {
+        data: {
+          tags: {}
+        },
+        hdf: {
+          finding_details: 'Finding details',
+          segments: [{status: 'passed'}],
+          severity: 'medium'
+        }
+      }
+    } as unknown as ContextualizedControl;
+
+    wrapper = mount(ControlRowDetails, {
+      vuetify,
+      propsData: {
+        control
+      },
+      stubs: {
+        ControlRowCol: true,
+        prism: true
+      }
+    });
+  });
+
+  it('always shows an editable comments field on the Test tab', () => {
+    expect(wrapper.text()).toContain('Comments:');
+    expect(wrapper.find('textarea').exists()).toBe(true);
+  });
+
+  it('updates control comments from the Test tab comments field', async () => {
+    await wrapper.find('textarea').setValue('review note');
+
+    expect(mocks.updateControlComments).toHaveBeenCalledWith({
+      comments: 'review note',
+      control
+    });
+  });
+});

--- a/apps/frontend/tests/unit/data_store_comments.spec.ts
+++ b/apps/frontend/tests/unit/data_store_comments.spec.ts
@@ -1,0 +1,119 @@
+import {
+  updateChecklistPassthroughComments,
+  updateDescriptionArray,
+  updateStructuredChecklistComments
+} from '@/store/data_store';
+import {EvaluationFile} from '@/store/report_intake';
+import {ContextualizedControl} from 'inspecjs';
+import {describe, expect, it} from 'vitest';
+
+function controlWithChecklistTags(): ContextualizedControl {
+  return {
+    data: {
+      id: 'V-1',
+      descriptions: [],
+      tags: {
+        rid: 'SV-1r1_rule',
+        stig_id: 'APP-1',
+        STIGRef: 'Application Security STIG'
+      }
+    },
+    hdf: {
+      descriptions: {},
+      isProfile: false
+    }
+  } as unknown as ContextualizedControl;
+}
+
+describe('data store comment mapping', () => {
+  it('updates OHDF control descriptions with comments', () => {
+    const control = controlWithChecklistTags();
+
+    updateDescriptionArray(control, 'review note');
+
+    expect(control.hdf.descriptions.comments).toBeUndefined();
+    expect(control.data.descriptions).toContainEqual({
+      data: 'review note',
+      label: 'comments'
+    });
+  });
+
+  it('updates the COMMENTS section while preserving other CKL structured comment sections', () => {
+    expect(
+      updateStructuredChecklistComments(
+        'FINDING_DETAILS :: existing finding\nCOMMENTS :: old comment\nSEVERITY_OVERRIDE :: Low',
+        'review note'
+      )
+    ).toBe(
+      'FINDING_DETAILS :: existing finding\nCOMMENTS :: review note\nSEVERITY_OVERRIDE :: Low'
+    );
+  });
+
+  it('updates matching CKL passthrough comments without changing nonmatching vulns', () => {
+    const control = controlWithChecklistTags();
+    const matchingVuln = {
+      vulnNum: 'V-1',
+      ruleId: 'SV-1r1_rule',
+      ruleVer: 'APP-1',
+      stigRef: 'Application Security STIG',
+      comments:
+        'FINDING_DETAILS :: existing finding\nCOMMENTS :: old comment'
+    };
+    const nonmatchingVuln = {
+      vulnNum: 'V-2',
+      ruleId: 'SV-2r1_rule',
+      comments: 'COMMENTS :: keep me'
+    };
+    const file = {
+      evaluation: {
+        data: {
+          passthrough: {
+            checklist: {
+              stigs: [
+                {
+                  vulns: [matchingVuln, nonmatchingVuln]
+                }
+              ]
+            }
+          }
+        }
+      }
+    } as unknown as EvaluationFile;
+
+    updateChecklistPassthroughComments(file, control, 'review note');
+
+    expect(matchingVuln.comments).toBe(
+      'FINDING_DETAILS :: existing finding\nCOMMENTS :: review note'
+    );
+    expect(nonmatchingVuln.comments).toBe('COMMENTS :: keep me');
+  });
+
+  it('does not update CKL passthrough comments when fewer than two identifiers match', () => {
+    const control = controlWithChecklistTags();
+    const vuln = {
+      vulnNum: 'V-1',
+      ruleId: 'different-rule',
+      ruleVer: 'different-stig',
+      comments: 'COMMENTS :: keep me'
+    };
+    const file = {
+      evaluation: {
+        data: {
+          passthrough: {
+            checklist: {
+              stigs: [
+                {
+                  vulns: [vuln]
+                }
+              ]
+            }
+          }
+        }
+      }
+    } as unknown as EvaluationFile;
+
+    updateChecklistPassthroughComments(file, control, 'review note');
+
+    expect(vuln.comments).toBe('COMMENTS :: keep me');
+  });
+});

--- a/apps/frontend/tests/unit/review_copy_util.spec.ts
+++ b/apps/frontend/tests/unit/review_copy_util.spec.ts
@@ -1,0 +1,71 @@
+import {
+  REVIEW_PARENT_TAG_PREFIX,
+  REVIEW_ROOT_TAG_PREFIX,
+  REVIEW_TAG,
+  reviewedCopyTags,
+  reviewCopyFilename,
+  reviewRootId,
+  reviewTimestamp
+} from '@/utilities/review_copy_util';
+import {describe, expect, it} from 'vitest';
+
+describe('review copy utilities', () => {
+  const reviewDate = new Date(2026, 5, 17, 9, 5);
+
+  it('formats reviewed copy timestamps for filenames', () => {
+    expect(reviewTimestamp(reviewDate)).toBe('2026-06-17 09-05');
+  });
+
+  it('appends a reviewed copy suffix to the source filename', () => {
+    expect(reviewCopyFilename('Acme Overlay Example', reviewDate)).toBe(
+      'Acme Overlay Example - review 2026-06-17 09-05'
+    );
+  });
+
+  it('replaces an existing reviewed copy suffix instead of stacking suffixes', () => {
+    expect(
+      reviewCopyFilename(
+        'Acme Overlay Example - review 2026-06-16 14-30',
+        reviewDate
+      )
+    ).toBe('Acme Overlay Example - review 2026-06-17 09-05');
+  });
+
+  it('finds the root evaluation id from existing review tags', () => {
+    expect(
+      reviewRootId([
+        REVIEW_TAG,
+        `${REVIEW_ROOT_TAG_PREFIX}123`,
+        `${REVIEW_PARENT_TAG_PREFIX}456`
+      ])
+    ).toBe('123');
+  });
+
+  it('creates review tags for a first-generation reviewed copy', () => {
+    expect(reviewedCopyTags(['team:red'], '123')).toEqual([
+      'team:red',
+      REVIEW_TAG,
+      `${REVIEW_ROOT_TAG_PREFIX}123`,
+      `${REVIEW_PARENT_TAG_PREFIX}123`
+    ]);
+  });
+
+  it('preserves the original root and updates the parent for later generations', () => {
+    expect(
+      reviewedCopyTags(
+        [
+          'team:red',
+          REVIEW_TAG,
+          `${REVIEW_ROOT_TAG_PREFIX}123`,
+          `${REVIEW_PARENT_TAG_PREFIX}123`
+        ],
+        '456'
+      )
+    ).toEqual([
+      'team:red',
+      REVIEW_TAG,
+      `${REVIEW_ROOT_TAG_PREFIX}123`,
+      `${REVIEW_PARENT_TAG_PREFIX}456`
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

This PR makes the control `Comments` field editable in the Heimdall frontend. The field is now always shown under the Details tab, even when empty, and user edits are reflected in exported/saved results.

## Features

- Adds an editable `Comments` textarea to control details.
- Keeps comments visible even when the source value is null/empty.
- Writes edited comments back into OHDF control descriptions.
- Preserves edited comments in JSON export.
- Updates CKL passthrough comments so DISA Checklist export includes edits.
- Tracks unsaved comment edits per loaded file.
- Shows an unsaved-edit indicator in the loaded file sidebar.
- Warns users before removing dirty loaded results or closing the browser.
- Enables saving DB-backed files after comment edits.
-- NOTE: changes adds a server-mode reviewed-copy workflow: DB-backed comment edits create a new evaluation with `filename <original filename> - review <YYYY-MM-DD HH-mm>` and tags `heimdall:review, heimdall:review-root:<id>, and heimdall:review-parent:<id>`, instead of overwriting the original evaluation.
- Clears dirty state after successful save/export.
- Adds warning coverage for deleting a DB-backed loaded file with unsaved edits.

## Approach

The implementation stores comment edits through the existing Vuex-backed loaded file state. Comment updates mutate the control’s OHDF description data, update the display wrapper, and, when the file came from CKL, update the CKL passthrough comment data used by CKL export.

Dirty-state tracking was added at the loaded-file level using `hasUnsavedChanges`, with supporting store getters/actions for save, export, remove, delete, and browser-unload flows.

## Reviews Performed

Three focused reviews were performed:

- Correctness/regression review
- DRY, maintainability, and frontend best-practices review
- Security, privacy, and data-integrity review

Findings addressed from review:

- Added a prompt before deleting a DB-loaded file with unsaved comment edits.
- Added error handling for failed saves of existing DB-backed files.
- Tightened CKL passthrough matching to reduce risk of updating the wrong vulnerability.
- Confirmed no obvious XSS path from the editable comments field; comments are rendered through Vue text rendering or existing sanitization paths.

## Notes

The remaining broader hardening item is CKL structured-comment semantics: user text containing reserved section markers such as `CAVEAT ::` can still be interpreted by existing CKL parsing logic on a future round trip. That is pre-existing format behavior and may be better handled as a converter-level follow-up.