### PR TITLE
Adjust Tenable integration by requiring auth and validating host URLs

### DIFF
--- a/apps/backend/.env-example
+++ b/apps/backend/.env-example
@@ -41,6 +41,7 @@ NGINX_HOST=<Templated out as the 'server_name' for the NGINX configuration (no d
 ## External interfaces 
 SPLUNK_HOST_URL=<The full Uniform Resource Locator (URL) without the port for the Splunk host (no default, must be set if connecting to Splunk)>
 TENABLE_HOST_URL=<The full Uniform Resource Locator (URL) without the port for the Tenable.SC host (no default, must be set if connecting to Tenable)>
+TENABLE_HOST_URLS=<Comma-separated allowlist of full Tenable.SC host URLs permitted for login (e.g. https://a.example.com,https://b.example.com). Client-supplied host_url values not in this list are rejected>
 
 # Authentication
 

--- a/apps/backend/.env-example
+++ b/apps/backend/.env-example
@@ -40,8 +40,7 @@ NGINX_HOST=<Templated out as the 'server_name' for the NGINX configuration (no d
 
 ## External interfaces 
 SPLUNK_HOST_URL=<The full Uniform Resource Locator (URL) without the port for the Splunk host (no default, must be set if connecting to Splunk)>
-TENABLE_HOST_URL=<The full Uniform Resource Locator (URL) without the port for the Tenable.SC host (no default, must be set if connecting to Tenable)>
-TENABLE_HOST_URLS=<Comma-separated allowlist of full Tenable.SC host URLs permitted for login (e.g. https://a.example.com,https://b.example.com). Client-supplied host_url values not in this list are rejected>
+TENABLE_HOST_URL=<The full Uniform Resource Locator (URL) without the port for the Tenable.SC host (no default, must be set if connecting to Tenable). For multiple allowed hosts, separate with newlines (not commas, since commas are valid URI characters), e.g. TENABLE_HOST_URL='https://a.example.com\nhttps://b.example.com'. Client-supplied host_url values not matching an entry in this list are rejected>
 
 # Authentication
 

--- a/apps/backend/.env-example
+++ b/apps/backend/.env-example
@@ -40,7 +40,12 @@ NGINX_HOST=<Templated out as the 'server_name' for the NGINX configuration (no d
 
 ## External interfaces 
 SPLUNK_HOST_URL=<The full Uniform Resource Locator (URL) without the port for the Splunk host (no default, must be set if connecting to Splunk)>
-TENABLE_HOST_URL=<The full Uniform Resource Locator (URL) without the port for the Tenable.SC host (no default, must be set if connecting to Tenable). For multiple allowed hosts, separate with newlines (not commas, since commas are valid URI characters), e.g. TENABLE_HOST_URL='https://a.example.com\nhttps://b.example.com'. Client-supplied host_url values not matching an entry in this list are rejected>
+TENABLE_HOST_URL=<Full URL for the Tenable.SC host, including port (defaults to :443 if the client doesn't specify one). For multiple allowed hosts, wrap the value in quotes and separate with newlines, e.g.
+```
+TENABLE_HOST_URL='https://a.example.com
+https://b.example.com:8443'
+```
+Client-supplied host_url values not matching an entry in this list are rejected>
 
 # Authentication
 

--- a/apps/backend/config/app_config.ts
+++ b/apps/backend/config/app_config.ts
@@ -52,9 +52,9 @@ export default class AppConfig {
     }
   }
 
-  // Newline-separated allowlist of Tenable.SC hosts permitted for the login/proxy endpoints.
-  // Newlines are used instead of commas since commas are valid, unencoded URI characters.
-  // A single host works the same as before since there's just one entry to split.
+  // Newline-separated allowlist of Tenable.SC hosts for the login/proxy endpoints
+  // (commas are valid, unencoded URI characters, so they can't be the delimiter).
+  // Entries must include a protocol; malformed entries throw at startup.
   getTenableHostUrl(): string[] {
     const tenable_host_url = this.get('TENABLE_HOST_URL');
     if (tenable_host_url === undefined) {
@@ -63,7 +63,23 @@ export default class AppConfig {
     return tenable_host_url
       .split(/\r?\n/)
       .map((url) => url.trim())
-      .filter((url) => url.length > 0);
+      .filter((url) => url.length > 0)
+      .map((url) => {
+        let parsed: URL;
+        try {
+          parsed = new URL(url);
+        } catch {
+          throw new Error(
+            `Invalid TENABLE_HOST_URL entry "${url}": must be a complete URL including protocol (e.g. https://example.com)`
+          );
+        }
+        if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+          throw new Error(
+            `Invalid TENABLE_HOST_URL entry "${url}": protocol must be http or https`
+          );
+        }
+        return parsed.origin;
+      });
   }
 
   getDatabaseName(): string {

--- a/apps/backend/config/app_config.ts
+++ b/apps/backend/config/app_config.ts
@@ -1,5 +1,6 @@
 import * as dotenv from 'dotenv';
 import * as fs from 'fs';
+import {parseHostUrl} from '../src/utils/url_validation';
 
 export default class AppConfig {
   private envConfig: {[key: string]: string | undefined};
@@ -64,28 +65,10 @@ export default class AppConfig {
       .map((url) => url.trim())
       .filter((url) => url.length > 0)
       .map((url) => {
-        let parsed: URL;
-        try {
-          parsed = new URL(url);
-        } catch {
+        const parsed = parseHostUrl(url);
+        if (!parsed) {
           throw new Error(
-            `Invalid TENABLE_HOST_URL entry "${url}": must be a complete URL including protocol (e.g. https://example.com)`
-          );
-        }
-        if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-          throw new Error(
-            `Invalid TENABLE_HOST_URL entry "${url}": protocol must be http or https`
-          );
-        }
-        // Only protocol + hostname + port are allowed; ports are permitted since
-        // Tenable.SC may run on a non-default port.
-        const hasExtra =
-          (parsed.pathname !== '' && parsed.pathname !== '/') ||
-          parsed.search !== '' ||
-          parsed.hash !== '';
-        if (hasExtra) {
-          throw new Error(
-            `Invalid TENABLE_HOST_URL entry "${url}": must contain only a protocol, hostname, and optional port (no path, query, or fragment)`
+            `Invalid TENABLE_HOST_URL entry "${url}": must be a complete http(s) URL containing only protocol, hostname, and optional port`
           );
         }
         return parsed.origin;

--- a/apps/backend/config/app_config.ts
+++ b/apps/backend/config/app_config.ts
@@ -61,6 +61,19 @@ export default class AppConfig {
     }
   }
 
+  // Comma-separated allowlist of Tenable.SC hosts permitted for the login/proxy endpoints.
+  getTenableHostUrls(): string[] {
+    const tenable_host_urls = this.get('TENABLE_HOST_URLS');
+    if (tenable_host_urls !== undefined) {
+      return tenable_host_urls
+        .split(',')
+        .map((url) => url.trim())
+        .filter((url) => url.length > 0);
+    } else {
+      return [];
+    }
+  }
+
   getDatabaseName(): string {
     const databaseName = this.get('DATABASE_NAME');
     const nodeEnvironment = this.get('NODE_ENV');

--- a/apps/backend/config/app_config.ts
+++ b/apps/backend/config/app_config.ts
@@ -52,30 +52,18 @@ export default class AppConfig {
     }
   }
 
-  getTenableHostUrl(): string {
+  // Newline-separated allowlist of Tenable.SC hosts permitted for the login/proxy endpoints.
+  // Newlines are used instead of commas since commas are valid, unencoded URI characters.
+  // A single host works the same as before since there's just one entry to split.
+  getTenableHostUrl(): string[] {
     const tenable_host_url = this.get('TENABLE_HOST_URL');
-    if (tenable_host_url !== undefined) {
-      return tenable_host_url;
-    } else {
-      return '';
+    if (tenable_host_url === undefined) {
+      return [];
     }
-  }
-
-  // Comma-separated allowlist of Tenable.SC hosts permitted for the login/proxy endpoints.
-  // Falls back to (and merges with) the single-value TENABLE_HOST_URL for backward compatibility.
-  getTenableHostUrls(): string[] {
-    const tenable_host_urls = this.get('TENABLE_HOST_URLS');
-    const list = tenable_host_urls
-      ? tenable_host_urls
-          .split(',')
-          .map((url) => url.trim())
-          .filter((url) => url.length > 0)
-      : [];
-    const singleHostUrl = this.getTenableHostUrl();
-    if (singleHostUrl && !list.includes(singleHostUrl)) {
-      list.push(singleHostUrl);
-    }
-    return list;
+    return tenable_host_url
+      .split(/\r?\n/)
+      .map((url) => url.trim())
+      .filter((url) => url.length > 0);
   }
 
   getDatabaseName(): string {

--- a/apps/backend/config/app_config.ts
+++ b/apps/backend/config/app_config.ts
@@ -53,15 +53,14 @@ export default class AppConfig {
   }
 
   // Newline-separated allowlist of Tenable.SC hosts for the login/proxy endpoints
-  // (commas are valid, unencoded URI characters, so they can't be the delimiter).
-  // Entries must include a protocol; malformed entries throw at startup.
+  // Entries must include a protocol and may include a port; malformed entries throw at startup.
   getTenableHostUrl(): string[] {
     const tenable_host_url = this.get('TENABLE_HOST_URL');
     if (tenable_host_url === undefined) {
       return [];
     }
     return tenable_host_url
-      .split(/\r?\n/)
+      .split('\n')
       .map((url) => url.trim())
       .filter((url) => url.length > 0)
       .map((url) => {
@@ -76,6 +75,17 @@ export default class AppConfig {
         if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
           throw new Error(
             `Invalid TENABLE_HOST_URL entry "${url}": protocol must be http or https`
+          );
+        }
+        // Only protocol + hostname + port are allowed; ports are permitted since
+        // Tenable.SC may run on a non-default port.
+        const hasExtra =
+          (parsed.pathname !== '' && parsed.pathname !== '/') ||
+          parsed.search !== '' ||
+          parsed.hash !== '';
+        if (hasExtra) {
+          throw new Error(
+            `Invalid TENABLE_HOST_URL entry "${url}": must contain only a protocol, hostname, and optional port (no path, query, or fragment)`
           );
         }
         return parsed.origin;

--- a/apps/backend/config/app_config.ts
+++ b/apps/backend/config/app_config.ts
@@ -62,16 +62,20 @@ export default class AppConfig {
   }
 
   // Comma-separated allowlist of Tenable.SC hosts permitted for the login/proxy endpoints.
+  // Falls back to (and merges with) the single-value TENABLE_HOST_URL for backward compatibility.
   getTenableHostUrls(): string[] {
     const tenable_host_urls = this.get('TENABLE_HOST_URLS');
-    if (tenable_host_urls !== undefined) {
-      return tenable_host_urls
-        .split(',')
-        .map((url) => url.trim())
-        .filter((url) => url.length > 0);
-    } else {
-      return [];
+    const list = tenable_host_urls
+      ? tenable_host_urls
+          .split(',')
+          .map((url) => url.trim())
+          .filter((url) => url.length > 0)
+      : [];
+    const singleHostUrl = this.getTenableHostUrl();
+    if (singleHostUrl && !list.includes(singleHostUrl)) {
+      list.push(singleHostUrl);
     }
+    return list;
   }
 
   getDatabaseName(): string {

--- a/apps/backend/src/config/config.service.ts
+++ b/apps/backend/src/config/config.service.ts
@@ -74,12 +74,8 @@ export class ConfigService {
     return this.appConfig.getSplunkHostUrl();
   }
 
-  getTenableHostUrl(): string {
+  getTenableHostUrl(): string[] {
     return this.appConfig.getTenableHostUrl();
-  }
-
-  getTenableHostUrls(): string[] {
-    return this.appConfig.getTenableHostUrls();
   }
 
   getDbConfig(): SequelizeOptions {

--- a/apps/backend/src/config/config.service.ts
+++ b/apps/backend/src/config/config.service.ts
@@ -78,6 +78,10 @@ export class ConfigService {
     return this.appConfig.getTenableHostUrl();
   }
 
+  getTenableHostUrls(): string[] {
+    return this.appConfig.getTenableHostUrls();
+  }
+
   getDbConfig(): SequelizeOptions {
     return this.appConfig.getDbConfig();
   }

--- a/apps/backend/src/config/dto/startup-settings.dto.ts
+++ b/apps/backend/src/config/dto/startup-settings.dto.ts
@@ -12,7 +12,7 @@ export class StartupSettingsDto implements IStartupSettings {
   readonly ldap: boolean;
   readonly registrationEnabled: boolean;
   readonly localLoginEnabled: boolean;
-  readonly tenableHostUrl: string;
+  readonly tenableHostUrl: string[];
   readonly forceTenableFrontend: boolean;
   readonly splunkHostUrl: string;
 

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -58,7 +58,7 @@ async function bootstrap() {
           "'self'",
           'https://api.github.com',
           'https://sts.amazonaws.com',
-          configService.getTenableHostUrl(),
+          ...configService.getTenableHostUrl(),
           configService.getSplunkHostUrl()
         ].filter((source) => source)
       }

--- a/apps/backend/src/tenable/tenable.controller.ts
+++ b/apps/backend/src/tenable/tenable.controller.ts
@@ -47,15 +47,10 @@ export class TenableController {
     if (allowlist.length === 0) {
       return null;
     }
-    // Default to https when no scheme is provided, so "example.com" is treated
-    // the same as "https://example.com".
-    const trimmedInput = host_url.trim();
-    const normalizedInput = /^[a-z][a-z\d+.-]*:\/\//i.test(trimmedInput)
-      ? trimmedInput
-      : `https://${trimmedInput}`;
+    // Require the client to supply a complete URL (protocol included)
     try {
       // Throws for unparseable input, caught below and treated as not allowed.
-      const parsed = new URL(normalizedInput);
+      const parsed = new URL(host_url);
 
       // Reject any scheme other than http/https (e.g. file:, javascript:, ftp:).
       if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
@@ -72,19 +67,8 @@ export class TenableController {
         return null;
       }
 
-      // Compare origins (scheme + host + port) rather than raw strings so that
-      // equivalent URLs (default ports, trailing slash, casing) still match.
-      const match = allowlist.find((allowed) => {
-        const trimmedAllowed = allowed.trim();
-        const normalizedAllowed = /^[a-z][a-z\d+.-]*:\/\//i.test(trimmedAllowed)
-          ? trimmedAllowed
-          : `https://${trimmedAllowed}`;
-        try {
-          return new URL(normalizedAllowed).origin === parsed.origin;
-        } catch {
-          return false;
-        }
-      });
+      // allowlist entries are already normalized origins (validated in AppConfig).
+      const match = allowlist.includes(parsed.origin);
 
       // Return the parsed origin (never the raw client value) so nothing beyond
       // scheme+host+port ever propagates into the session or outbound requests.

--- a/apps/backend/src/tenable/tenable.controller.ts
+++ b/apps/backend/src/tenable/tenable.controller.ts
@@ -15,6 +15,9 @@ import {ConfigService} from '../config/config.service';
 import axios from 'axios';
 import {Request, Response} from 'express';
 
+// Populated by JwtAuthGuard/passport; only the fields we rely on are typed here.
+type AuthenticatedRequest = Request & {user: {id: string}};
+
 // Extend express-session types to include 'tenable'
 declare module 'express-session' {
   interface SessionData {
@@ -22,6 +25,7 @@ declare module 'express-session' {
       host_url: string;
       accesskey: string;
       secretkey: string;
+      userId: string;
     };
   }
 }
@@ -49,12 +53,16 @@ export class TenableController {
     try {
       const parsed = new URL(host_url); // requires a protocol; throws otherwise
 
+      // This URL becomes the target of an outbound HTTP request to Tenable
+      // So only http/https are meaningful
       if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
         return null;
       }
 
-      // Reject extra path/query/fragment
+      // Reject anything beyond protocol, hostname, and port.
       const hasExtra =
+        parsed.username !== '' ||
+        parsed.password !== '' ||
         (parsed.pathname !== '' && parsed.pathname !== '/') ||
         parsed.search !== '' ||
         parsed.hash !== '';
@@ -62,10 +70,14 @@ export class TenableController {
         return null;
       }
 
-      const match = allowlist.includes(parsed.origin);
+      // Restricting to the allowlist prevents Server-Side Request Forgery (SSRF),
+      // where an attacker supplies host_url to make this server call internal/
+      // unintended hosts
+      const allowedEntry = allowlist.find((entry) => entry === parsed.origin);
 
-      // Only the parsed origin (never the raw input) is used downstream
-      return match ? parsed.origin : null;
+      // Return the matched allowlist entry itself (never a value derived from
+      // the raw input) so the output is always exactly the admin-approved string.
+      return allowedEntry ?? null;
     } catch {
       return null;
     }
@@ -81,7 +93,7 @@ export class TenableController {
    * @throws {HttpException} If any credentials are missing or if authentication fails.
    */
   async login(
-    @Req() req: Request,
+    @Req() req: AuthenticatedRequest,
     @Body() body: {host_url: string; accesskey: string; secretkey: string}
   ) {
     const {host_url, accesskey, secretkey} = body;
@@ -112,8 +124,14 @@ export class TenableController {
         }
       });
 
-      // Store the normalized, allowlisted origin rather than the raw client value.
-      req.session.tenable = {host_url: allowedHostUrl, accesskey, secretkey};
+      // Bind these credentials to the current Heimdall user so a later user
+      // reusing this session can't inherit them (see proxy()).
+      req.session.tenable = {
+        host_url: allowedHostUrl,
+        accesskey,
+        secretkey,
+        userId: req.user.id
+      };
 
       // Return the authenticated user data
       // Note: result.data is already a plain object, no need to convert it.
@@ -219,6 +237,13 @@ export class TenableController {
     }
   }
 
+  @Post('logout')
+  // Clears any stored Tenable credentials for the current session.
+  logout(@Req() req: Request): {success: true} {
+    delete req.session.tenable;
+    return {success: true};
+  }
+
   @All('*splat')
   /**
    * Proxies a request to the Tenable service using the user's session credentials.
@@ -231,12 +256,19 @@ export class TenableController {
    * @throws 404 if user session content is not available.
    * @throws 500 or the proxied error status if the proxy request fails.
    */
-  async proxy(@Req() req: Request, @Res() res: Response) {
+  async proxy(@Req() req: AuthenticatedRequest, @Res() res: Response) {
     try {
       const creds = req.session.tenable;
 
       // If credentials are missing, user is not authenticated, send 401 Unauthorized.
       if (!creds) {
+        return res.status(401).json({error: 'Not authenticated with Tenable'});
+      }
+
+      // The session's Tenable credentials must belong to the currently
+      // authenticated Heimdall user, not a previous user of this session.
+      if (creds.userId !== req.user.id) {
+        delete req.session.tenable;
         return res.status(401).json({error: 'Not authenticated with Tenable'});
       }
 

--- a/apps/backend/src/tenable/tenable.controller.ts
+++ b/apps/backend/src/tenable/tenable.controller.ts
@@ -40,23 +40,26 @@ export class TenableController {
     private readonly configService: ConfigService
   ) {}
 
-  // Confirms host_url's origin matches an entry in the TENABLE_HOST_URLS allowlist.
-  private isAllowedHostUrl(host_url: string): boolean {
+  // Returns the matching allowlisted origin for host_url, or null if none match.
+  private resolveAllowedHostUrl(host_url: string): string | null {
     const allowlist = this.configService.getTenableHostUrls();
     if (allowlist.length === 0) {
-      return false;
+      return null;
     }
     try {
       const requestedOrigin = new URL(host_url).origin;
-      return allowlist.some((allowed) => {
+      const match = allowlist.find((allowed) => {
         try {
           return new URL(allowed).origin === requestedOrigin;
         } catch {
           return false;
         }
       });
+      // Use the parsed origin (not the raw client value) so any path/query/fragment
+      // supplied by the client is dropped rather than carried into later requests.
+      return match ? requestedOrigin : null;
     } catch {
-      return false;
+      return null;
     }
   }
 
@@ -79,7 +82,8 @@ export class TenableController {
       throw new HttpException('Missing credentials', HttpStatus.BAD_REQUEST);
     }
 
-    if (!this.isAllowedHostUrl(host_url)) {
+    const allowedHostUrl = this.resolveAllowedHostUrl(host_url);
+    if (!allowedHostUrl) {
       throw new HttpException(
         {
           status: HttpStatus.FORBIDDEN,
@@ -91,16 +95,16 @@ export class TenableController {
     }
 
     try {
-      // This helps prevent double slashes in the resulting URL if host_url ends with a slash.
-      const fullUrl = `${host_url.replace(/\/$/, '')}/rest/currentUser`;
+      // allowedHostUrl is the parsed origin, so no trailing slash to strip.
+      const fullUrl = `${allowedHostUrl}/rest/currentUser`;
       const result = await axios.get(fullUrl, {
         headers: {
           'x-apikey': `accesskey=${accesskey}; secretkey=${secretkey}`
         }
       });
 
-      // Assign the Tenable credentials to the session
-      req.session.tenable = {host_url, accesskey, secretkey};
+      // Store the normalized, allowlisted origin rather than the raw client value.
+      req.session.tenable = {host_url: allowedHostUrl, accesskey, secretkey};
 
       // Return the authenticated user data
       // Note: result.data is already a plain object, no need to convert it.

--- a/apps/backend/src/tenable/tenable.controller.ts
+++ b/apps/backend/src/tenable/tenable.controller.ts
@@ -92,13 +92,14 @@ export class TenableController {
 
     const allowedHostUrl = this.resolveAllowedHostUrl(host_url);
     if (!allowedHostUrl) {
+      // 400, not 403: the frontend treats any 403 here as a credentials error.
       throw new HttpException(
         {
-          status: HttpStatus.FORBIDDEN,
+          status: HttpStatus.BAD_REQUEST,
           message: 'Tenable host URL is not in the configured allowlist',
           code: 'HOST_NOT_ALLOWED'
         },
-        HttpStatus.FORBIDDEN
+        HttpStatus.BAD_REQUEST
       );
     }
 

--- a/apps/backend/src/tenable/tenable.controller.ts
+++ b/apps/backend/src/tenable/tenable.controller.ts
@@ -43,7 +43,7 @@ export class TenableController {
   // Returns the matching allowlisted origin for host_url, or null if none match
   // or if host_url carries a path/query/fragment beyond a bare origin.
   private resolveAllowedHostUrl(host_url: string): string | null {
-    const allowlist = this.configService.getTenableHostUrls();
+    const allowlist = this.configService.getTenableHostUrl();
     if (allowlist.length === 0) {
       return null;
     }

--- a/apps/backend/src/tenable/tenable.controller.ts
+++ b/apps/backend/src/tenable/tenable.controller.ts
@@ -13,6 +13,7 @@ import {TenableService} from './tenable.service';
 import {JwtAuthGuard} from '../guards/jwt-auth.guard';
 import {ConfigService} from '../config/config.service';
 import {User} from '../users/user.model';
+import {parseHostUrl} from '../utils/url_validation';
 import axios from 'axios';
 import {Request, Response} from 'express';
 
@@ -48,37 +49,20 @@ export class TenableController {
     if (allowlist.length === 0) {
       return null;
     }
-    try {
-      const parsed = new URL(host_url); // requires a protocol; throws otherwise
 
-      // This URL becomes the target of an outbound HTTP request to Tenable
-      // So only http/https are meaningful
-      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-        return null;
-      }
-
-      // Reject anything beyond protocol, hostname, and port.
-      const hasExtra =
-        parsed.username !== '' ||
-        parsed.password !== '' ||
-        (parsed.pathname !== '' && parsed.pathname !== '/') ||
-        parsed.search !== '' ||
-        parsed.hash !== '';
-      if (hasExtra) {
-        return null;
-      }
-
-      // Restricting to the allowlist prevents Server-Side Request Forgery (SSRF),
-      // where an attacker supplies host_url to make this server call internal/
-      // unintended hosts
-      const allowedEntry = allowlist.find((entry) => entry === parsed.origin);
-
-      // Return the matched allowlist entry itself (never a value derived from
-      // the raw input) so the output is always exactly the admin-approved string.
-      return allowedEntry ?? null;
-    } catch {
+    const parsed = parseHostUrl(host_url);
+    if (!parsed) {
       return null;
     }
+
+    // Restricting to the allowlist prevents Server-Side Request Forgery (SSRF),
+    // where an attacker supplies host_url to make this server call internal/
+    // unintended hosts
+    const allowedEntry = allowlist.find((entry) => entry === parsed.origin);
+
+    // Return the matched allowlist entry itself 
+    // so the output is always exactly the admin-approved string
+    return allowedEntry ?? null;
   }
 
   @Post('login')

--- a/apps/backend/src/tenable/tenable.controller.ts
+++ b/apps/backend/src/tenable/tenable.controller.ts
@@ -40,24 +40,55 @@ export class TenableController {
     private readonly configService: ConfigService
   ) {}
 
-  // Returns the matching allowlisted origin for host_url, or null if none match.
+  // Returns the matching allowlisted origin for host_url, or null if none match
+  // or if host_url carries a path/query/fragment beyond a bare origin.
   private resolveAllowedHostUrl(host_url: string): string | null {
     const allowlist = this.configService.getTenableHostUrls();
     if (allowlist.length === 0) {
       return null;
     }
+    // Default to https when no scheme is provided, so "example.com" is treated
+    // the same as "https://example.com".
+    const trimmedInput = host_url.trim();
+    const normalizedInput = /^[a-z][a-z\d+.-]*:\/\//i.test(trimmedInput)
+      ? trimmedInput
+      : `https://${trimmedInput}`;
     try {
-      const requestedOrigin = new URL(host_url).origin;
+      // Throws for unparseable input, caught below and treated as not allowed.
+      const parsed = new URL(normalizedInput);
+
+      // Reject any scheme other than http/https (e.g. file:, javascript:, ftp:).
+      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        return null;
+      }
+
+      // Reject anything beyond a bare origin rather than silently stripping it,
+      // so a tampered/malformed host_url fails loudly instead of being sanitized.
+      const hasExtra =
+        (parsed.pathname !== '' && parsed.pathname !== '/') ||
+        parsed.search !== '' ||
+        parsed.hash !== '';
+      if (hasExtra) {
+        return null;
+      }
+
+      // Compare origins (scheme + host + port) rather than raw strings so that
+      // equivalent URLs (default ports, trailing slash, casing) still match.
       const match = allowlist.find((allowed) => {
+        const trimmedAllowed = allowed.trim();
+        const normalizedAllowed = /^[a-z][a-z\d+.-]*:\/\//i.test(trimmedAllowed)
+          ? trimmedAllowed
+          : `https://${trimmedAllowed}`;
         try {
-          return new URL(allowed).origin === requestedOrigin;
+          return new URL(normalizedAllowed).origin === parsed.origin;
         } catch {
           return false;
         }
       });
-      // Use the parsed origin (not the raw client value) so any path/query/fragment
-      // supplied by the client is dropped rather than carried into later requests.
-      return match ? requestedOrigin : null;
+
+      // Return the parsed origin (never the raw client value) so nothing beyond
+      // scheme+host+port ever propagates into the session or outbound requests.
+      return match ? parsed.origin : null;
     } catch {
       return null;
     }

--- a/apps/backend/src/tenable/tenable.controller.ts
+++ b/apps/backend/src/tenable/tenable.controller.ts
@@ -6,9 +6,12 @@ import {
   Body,
   HttpException,
   HttpStatus,
-  All
+  All,
+  UseGuards
 } from '@nestjs/common';
 import {TenableService} from './tenable.service';
+import {JwtAuthGuard} from '../guards/jwt-auth.guard';
+import {ConfigService} from '../config/config.service';
 import axios from 'axios';
 import {Request, Response} from 'express';
 
@@ -30,8 +33,32 @@ const TENABLE_CSP_NOT_SET =
 // It allows users to log in with their Tenable credentials and then proxies all subsequent requests
 // to the Tenable API, handling authentication via session storage.
 @Controller('api/tenable')
+@UseGuards(JwtAuthGuard)
 export class TenableController {
-  constructor(private readonly tenableService: TenableService) {}
+  constructor(
+    private readonly tenableService: TenableService,
+    private readonly configService: ConfigService
+  ) {}
+
+  // Confirms host_url's origin matches an entry in the TENABLE_HOST_URLS allowlist.
+  private isAllowedHostUrl(host_url: string): boolean {
+    const allowlist = this.configService.getTenableHostUrls();
+    if (allowlist.length === 0) {
+      return false;
+    }
+    try {
+      const requestedOrigin = new URL(host_url).origin;
+      return allowlist.some((allowed) => {
+        try {
+          return new URL(allowed).origin === requestedOrigin;
+        } catch {
+          return false;
+        }
+      });
+    } catch {
+      return false;
+    }
+  }
 
   @Post('login')
   /**
@@ -50,6 +77,17 @@ export class TenableController {
 
     if (!host_url || !accesskey || !secretkey) {
       throw new HttpException('Missing credentials', HttpStatus.BAD_REQUEST);
+    }
+
+    if (!this.isAllowedHostUrl(host_url)) {
+      throw new HttpException(
+        {
+          status: HttpStatus.FORBIDDEN,
+          message: 'Tenable host URL is not in the configured allowlist',
+          code: 'HOST_NOT_ALLOWED'
+        },
+        HttpStatus.FORBIDDEN
+      );
     }
 
     try {

--- a/apps/backend/src/tenable/tenable.controller.ts
+++ b/apps/backend/src/tenable/tenable.controller.ts
@@ -12,11 +12,9 @@ import {
 import {TenableService} from './tenable.service';
 import {JwtAuthGuard} from '../guards/jwt-auth.guard';
 import {ConfigService} from '../config/config.service';
+import {User} from '../users/user.model';
 import axios from 'axios';
 import {Request, Response} from 'express';
-
-// Populated by JwtAuthGuard/passport; only the fields we rely on are typed here.
-type AuthenticatedRequest = Request & {user: {id: string}};
 
 // Extend express-session types to include 'tenable'
 declare module 'express-session' {
@@ -93,7 +91,7 @@ export class TenableController {
    * @throws {HttpException} If any credentials are missing or if authentication fails.
    */
   async login(
-    @Req() req: AuthenticatedRequest,
+    @Req() req: Request,
     @Body() body: {host_url: string; accesskey: string; secretkey: string}
   ) {
     const {host_url, accesskey, secretkey} = body;
@@ -124,13 +122,14 @@ export class TenableController {
         }
       });
 
-      // Bind these credentials to the current Heimdall user so a later user
-      // reusing this session can't inherit them (see proxy()).
+      // Store the normalized, allowlisted origin rather than the raw client value.
+      // Tagged with the authenticated user so a different user on the same
+      // browser session can't reuse these credentials (see proxy()).
       req.session.tenable = {
         host_url: allowedHostUrl,
         accesskey,
         secretkey,
-        userId: req.user.id
+        userId: (req.user as User).id
       };
 
       // Return the authenticated user data
@@ -237,13 +236,6 @@ export class TenableController {
     }
   }
 
-  @Post('logout')
-  // Clears any stored Tenable credentials for the current session.
-  logout(@Req() req: Request): {success: true} {
-    delete req.session.tenable;
-    return {success: true};
-  }
-
   @All('*splat')
   /**
    * Proxies a request to the Tenable service using the user's session credentials.
@@ -256,7 +248,7 @@ export class TenableController {
    * @throws 404 if user session content is not available.
    * @throws 500 or the proxied error status if the proxy request fails.
    */
-  async proxy(@Req() req: AuthenticatedRequest, @Res() res: Response) {
+  async proxy(@Req() req: Request, @Res() res: Response) {
     try {
       const creds = req.session.tenable;
 
@@ -265,10 +257,9 @@ export class TenableController {
         return res.status(401).json({error: 'Not authenticated with Tenable'});
       }
 
-      // The session's Tenable credentials must belong to the currently
-      // authenticated Heimdall user, not a previous user of this session.
-      if (creds.userId !== req.user.id) {
-        delete req.session.tenable;
+      // Reject if these credentials belong to a different Heimdall user than
+      // the one currently authenticated (e.g. a shared/reused browser session).
+      if (creds.userId !== (req.user as User).id) {
         return res.status(401).json({error: 'Not authenticated with Tenable'});
       }
 

--- a/apps/backend/src/tenable/tenable.controller.ts
+++ b/apps/backend/src/tenable/tenable.controller.ts
@@ -119,98 +119,103 @@ export class TenableController {
       // Note: result.data is already a plain object, no need to convert it.
       return {success: true, user: result.data}; // Return plain object
     } catch (err) {
-      if (axios.isAxiosError(err)) {
-        if (err.message.includes(TENABLE_CSP_NOT_SET)) {
-          throw new HttpException(
-            {
-              status: HttpStatus.NOT_FOUND,
-              message: 'Tenable CSP not set',
-              code: 'ERR_NETWORK' // custom application error code (optional)
-            },
-            HttpStatus.NOT_FOUND
-          );
-        } else if (err.response?.status === HttpStatus.UNAUTHORIZED) {
-          throw new HttpException(
-            {
-              status: HttpStatus.UNAUTHORIZED,
-              message: 'Invalid Tenable credentials',
-              code: 'INVALID_CREDENTIALS' // custom application error code (optional)
-            },
-            HttpStatus.UNAUTHORIZED
-          );
-        } else if (err.code === 'ECONNREFUSED') {
-          throw new HttpException(
-            {
-              status: HttpStatus.BAD_GATEWAY,
-              message: 'Tenable server is unreachable',
-              code: 'SERVER_UNREACHABLE' // custom app code
-            },
-            HttpStatus.BAD_GATEWAY
-          );
-        } else if (err.code === 'ENOTFOUND') {
-          throw new HttpException(
-            {
-              status: HttpStatus.BAD_REQUEST,
-              message:
-                'Unable to resolve Tenable host URL to an IP address (possible DNS resolution on the hosting platform).',
-              code: 'INVALID_HOST_URL' // custom app code
-            },
-            HttpStatus.BAD_REQUEST
-          );
-        } else if (err.code === 'ETIMEDOUT') {
-          throw new HttpException(
-            {
-              status: HttpStatus.REQUEST_TIMEOUT,
-              message: 'Tenable server took too long to respond',
-              code: 'CONNECTION_TIMEOUT' // custom application error code (optional)
-            },
-            HttpStatus.REQUEST_TIMEOUT
-          );
-        } else if (err.code === 'UNABLE_TO_VERIFY_LEAF_SIGNATURE') {
-          throw new HttpException(
-            {
-              status: HttpStatus.BAD_GATEWAY,
-              message:
-                'SSL certificate verification failed while connecting to Tenable ' +
-                `(${host_url}). This may be due to an untrusted or incomplete TLS ` +
-                'certificate chain.',
-              code: 'UNABLE_TO_VERIFY_LEAF_SIGNATURE'
-            },
-            HttpStatus.BAD_GATEWAY
-          );
-        } else {
-          throw new HttpException(
-            {
-              status: err.response?.status || HttpStatus.INTERNAL_SERVER_ERROR,
-              message:
-                err.response?.data?.message ||
-                `Unexpected error connecting to Tenable ${host_url}`,
-              code: 'TENABLE_PROXY_ERROR' // Optional custom app code
-            },
-            err.response?.status || HttpStatus.INTERNAL_SERVER_ERROR
-          );
-        }
-      } else if (err instanceof Error) {
+      this.handleLoginError(err, host_url);
+    }
+  }
+
+  // Maps a login failure to the appropriate HttpException; always throws.
+  private handleLoginError(err: unknown, host_url: string): never {
+    if (axios.isAxiosError(err)) {
+      if (err.message.includes(TENABLE_CSP_NOT_SET)) {
         throw new HttpException(
           {
-            status: HttpStatus.INTERNAL_SERVER_ERROR,
-            message:
-              err.message ||
-              `Unexpected error connecting to Tenable ${host_url}`,
-            code: 'TENABLE_PROXY_ERROR'
+            status: HttpStatus.NOT_FOUND,
+            message: 'Tenable CSP not set',
+            code: 'ERR_NETWORK' // custom application error code (optional)
           },
-          HttpStatus.INTERNAL_SERVER_ERROR
+          HttpStatus.NOT_FOUND
+        );
+      } else if (err.response?.status === HttpStatus.UNAUTHORIZED) {
+        throw new HttpException(
+          {
+            status: HttpStatus.UNAUTHORIZED,
+            message: 'Invalid Tenable credentials',
+            code: 'INVALID_CREDENTIALS' // custom application error code (optional)
+          },
+          HttpStatus.UNAUTHORIZED
+        );
+      } else if (err.code === 'ECONNREFUSED') {
+        throw new HttpException(
+          {
+            status: HttpStatus.BAD_GATEWAY,
+            message: 'Tenable server is unreachable',
+            code: 'SERVER_UNREACHABLE' // custom app code
+          },
+          HttpStatus.BAD_GATEWAY
+        );
+      } else if (err.code === 'ENOTFOUND') {
+        throw new HttpException(
+          {
+            status: HttpStatus.BAD_REQUEST,
+            message:
+              'Unable to resolve Tenable host URL to an IP address (possible DNS resolution on the hosting platform).',
+            code: 'INVALID_HOST_URL' // custom app code
+          },
+          HttpStatus.BAD_REQUEST
+        );
+      } else if (err.code === 'ETIMEDOUT') {
+        throw new HttpException(
+          {
+            status: HttpStatus.REQUEST_TIMEOUT,
+            message: 'Tenable server took too long to respond',
+            code: 'CONNECTION_TIMEOUT' // custom application error code (optional)
+          },
+          HttpStatus.REQUEST_TIMEOUT
+        );
+      } else if (err.code === 'UNABLE_TO_VERIFY_LEAF_SIGNATURE') {
+        throw new HttpException(
+          {
+            status: HttpStatus.BAD_GATEWAY,
+            message:
+              'SSL certificate verification failed while connecting to Tenable ' +
+              `(${host_url}). This may be due to an untrusted or incomplete TLS ` +
+              'certificate chain.',
+            code: 'UNABLE_TO_VERIFY_LEAF_SIGNATURE'
+          },
+          HttpStatus.BAD_GATEWAY
         );
       } else {
         throw new HttpException(
           {
-            status: HttpStatus.INTERNAL_SERVER_ERROR,
-            message: `Unexpected error connecting to Tenable ${host_url}: ${JSON.stringify(err, null, 2)}`,
-            code: 'TENABLE_PROXY_ERROR'
+            status: err.response?.status || HttpStatus.INTERNAL_SERVER_ERROR,
+            message:
+              err.response?.data?.message ||
+              `Unexpected error connecting to Tenable ${host_url}`,
+            code: 'TENABLE_PROXY_ERROR' // Optional custom app code
           },
-          HttpStatus.INTERNAL_SERVER_ERROR
+          err.response?.status || HttpStatus.INTERNAL_SERVER_ERROR
         );
       }
+    } else if (err instanceof Error) {
+      throw new HttpException(
+        {
+          status: HttpStatus.INTERNAL_SERVER_ERROR,
+          message:
+            err.message ||
+            `Unexpected error connecting to Tenable ${host_url}`,
+          code: 'TENABLE_PROXY_ERROR'
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR
+      );
+    } else {
+      throw new HttpException(
+        {
+          status: HttpStatus.INTERNAL_SERVER_ERROR,
+          message: `Unexpected error connecting to Tenable ${host_url}: ${JSON.stringify(err, null, 2)}`,
+          code: 'TENABLE_PROXY_ERROR'
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR
+      );
     }
   }
 

--- a/apps/backend/src/tenable/tenable.controller.ts
+++ b/apps/backend/src/tenable/tenable.controller.ts
@@ -40,25 +40,20 @@ export class TenableController {
     private readonly configService: ConfigService
   ) {}
 
-  // Returns the matching allowlisted origin for host_url, or null if none match
-  // or if host_url carries a path/query/fragment beyond a bare origin.
+  // Resolves host_url to its allowlisted origin, or null if not allowed
   private resolveAllowedHostUrl(host_url: string): string | null {
     const allowlist = this.configService.getTenableHostUrl();
     if (allowlist.length === 0) {
       return null;
     }
-    // Require the client to supply a complete URL (protocol included)
     try {
-      // Throws for unparseable input, caught below and treated as not allowed.
-      const parsed = new URL(host_url);
+      const parsed = new URL(host_url); // requires a protocol; throws otherwise
 
-      // Reject any scheme other than http/https (e.g. file:, javascript:, ftp:).
       if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
         return null;
       }
 
-      // Reject anything beyond a bare origin rather than silently stripping it,
-      // so a tampered/malformed host_url fails loudly instead of being sanitized.
+      // Reject extra path/query/fragment
       const hasExtra =
         (parsed.pathname !== '' && parsed.pathname !== '/') ||
         parsed.search !== '' ||
@@ -67,11 +62,9 @@ export class TenableController {
         return null;
       }
 
-      // allowlist entries are already normalized origins (validated in AppConfig).
       const match = allowlist.includes(parsed.origin);
 
-      // Return the parsed origin (never the raw client value) so nothing beyond
-      // scheme+host+port ever propagates into the session or outbound requests.
+      // Only the parsed origin (never the raw input) is used downstream
       return match ? parsed.origin : null;
     } catch {
       return null;

--- a/apps/backend/src/tenable/tenable.module.ts
+++ b/apps/backend/src/tenable/tenable.module.ts
@@ -1,6 +1,7 @@
 import {Module} from '@nestjs/common';
 import {TenableController} from './tenable.controller';
 import {TenableService} from './tenable.service';
+import {ConfigService} from '../config/config.service';
 
 // NestJS module definition for the Tenable proxy feature.
 // Registers the controller and service needed for routing Tenable requests.
@@ -9,6 +10,6 @@ import {TenableService} from './tenable.service';
   // Handles HTTP requests related to Tenable
   controllers: [TenableController],
   // Provides logic for proxying and interacting with Tenable API
-  providers: [TenableService]
+  providers: [TenableService, ConfigService]
 })
 export class TenableModule {}

--- a/apps/backend/src/tenable/tenable.module.ts
+++ b/apps/backend/src/tenable/tenable.module.ts
@@ -1,15 +1,16 @@
 import {Module} from '@nestjs/common';
 import {TenableController} from './tenable.controller';
 import {TenableService} from './tenable.service';
-import {ConfigService} from '../config/config.service';
+import {ConfigModule} from '../config/config.module';
 
 // NestJS module definition for the Tenable proxy feature.
 // Registers the controller and service needed for routing Tenable requests.
 
 @Module({
+  imports: [ConfigModule],
   // Handles HTTP requests related to Tenable
   controllers: [TenableController],
   // Provides logic for proxying and interacting with Tenable API
-  providers: [TenableService, ConfigService]
+  providers: [TenableService]
 })
 export class TenableModule {}

--- a/apps/backend/src/utils/url_validation.ts
+++ b/apps/backend/src/utils/url_validation.ts
@@ -1,0 +1,28 @@
+// Parses `url` and returns it only if it is a bare http(s) origin (protocol +
+// hostname + optional port, no userinfo/path/query/fragment). Returns null
+// otherwise. Shared by AppConfig (admin-supplied TENABLE_HOST_URL) and
+// TenableController (client-supplied host_url)
+export function parseHostUrl(url: string): URL | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return null;
+  }
+
+  const hasExtra =
+    parsed.username !== '' ||
+    parsed.password !== '' ||
+    (parsed.pathname !== '' && parsed.pathname !== '/') ||
+    parsed.search !== '' ||
+    parsed.hash !== '';
+  if (hasExtra) {
+    return null;
+  }
+
+  return parsed;
+}

--- a/apps/frontend/src/components/global/upload_tabs/tenable/AuthStep.vue
+++ b/apps/frontend/src/components/global/upload_tabs/tenable/AuthStep.vue
@@ -138,9 +138,9 @@ export default class AuthStep extends Vue {
   mounted() {
     this.accesskey = localAccesskey.getDefault('');
     this.secretkey = localSecretkey.getDefault('');
-    // If the hostname is not set, use the default from the server module
+    // If the hostname is not set, use the first configured default from the server module
     // (if not running in server mode the default is empty)
-    this.hostname = localHostname.getDefault(ServerModule.tenableHostUrl);
+    this.hostname = localHostname.getDefault(ServerModule.tenableHostUrl[0] ?? '');
   }
 }
 </script>

--- a/apps/frontend/src/components/global/upload_tabs/tenable/AuthStep.vue
+++ b/apps/frontend/src/components/global/upload_tabs/tenable/AuthStep.vue
@@ -61,9 +61,8 @@ import {requireFieldRule} from '@/utilities/upload_util';
 import Vue from 'vue';
 import Component from 'vue-class-component';
 
-// Our saved fields
-const localAccesskey = new LocalStorageVal<string>('tenable_accesskey');
-const localSecretkey = new LocalStorageVal<string>('tenable_secretkey');
+// Only the hostname is persisted; access/secret keys are credentials and
+// must not be saved to localStorage where any user of this browser could read them.
 const localHostname = new LocalStorageVal<string>('tenable_hostname');
 
 @Component({
@@ -120,8 +119,6 @@ export default class AuthStep extends Vue {
     await new TenableUtil(config)
       .loginToTenable()
       .then(() => {
-        localAccesskey.set(this.accesskey);
-        localSecretkey.set(this.secretkey);
         localHostname.set(this.hostname);
         SnackbarModule.notify('You have successfully signed in');
         this.$emit('authenticated', config);
@@ -136,8 +133,6 @@ export default class AuthStep extends Vue {
 
   /** Init our fields */
   mounted() {
-    this.accesskey = localAccesskey.getDefault('');
-    this.secretkey = localSecretkey.getDefault('');
     // If the hostname is not set, use the first configured default from the server module
     // (if not running in server mode the default is empty)
     this.hostname = localHostname.getDefault(ServerModule.tenableHostUrl[0] ?? '');

--- a/apps/frontend/src/store/server.ts
+++ b/apps/frontend/src/store/server.ts
@@ -36,7 +36,7 @@ export interface IServerState {
   ldap: boolean;
   localLoginEnabled: boolean;
   userInfo: IUser;
-  tenableHostUrl: string;
+  tenableHostUrl: string[];
   forceTenableFrontend: boolean;
   splunkHostUrl: string;
 }
@@ -68,7 +68,7 @@ class Server extends VuexModule implements IServerState {
   externalUrl: string = '';
   allUsers: ISlimUser[] = [];
   oidcName = '';
-  tenableHostUrl: string = '';
+  tenableHostUrl: string[] = [];
   forceTenableFrontend = false; // If true, the frontend will use Tenable.SC Lite features
   splunkHostUrl: string = '';
   /** Our currently granted JWT token */

--- a/apps/frontend/src/utilities/tenable_util.ts
+++ b/apps/frontend/src/utilities/tenable_util.ts
@@ -159,6 +159,8 @@ export class TenableUtil {
           if (this.isServer) {
             if (error.response?.data?.code === 'INVALID_HOST_URL') { // Custom set in the backend
               rejectMsg = (error.response?.data?.message ?? 'Tenable host URL to IP address resolution failed');
+            } else if (error.response?.data?.code === 'HOST_NOT_ALLOWED') { // Custom set in the backend
+              rejectMsg = (error.response?.data?.message ?? 'Tenable host URL is not in the configured allowlist');
             } else if (error.response?.data?.message) {
               rejectMsg = this.getCSPErrorMsg(this.hostConfig.host_url, TENABLE_HOST_URLS)
             } else {

--- a/apps/frontend/src/utilities/tenable_util.ts
+++ b/apps/frontend/src/utilities/tenable_util.ts
@@ -140,7 +140,7 @@ export class TenableUtil {
     const DEFAULT_REJECT_MSG =
       `${error.name}: ${(error.response?.data?.message ?? error.message)}, 
        ${error.response?.data?.code ?? error.code}`;
-    const TENABLE_HOST_URL = ServerModule.tenableHostUrl;
+    const TENABLE_HOST_URLS = ServerModule.tenableHostUrl;
     const TENABLE_CSP_NOT_SET =
       'The Content Security Policy directive environment variable "TENABLE_HOST_URL" is not configured. See Help for additional instructions.';
 
@@ -160,7 +160,7 @@ export class TenableUtil {
             if (error.response?.data?.code === 'INVALID_HOST_URL') { // Custom set in the backend
               rejectMsg = (error.response?.data?.message ?? 'Tenable host URL to IP address resolution failed');
             } else if (error.response?.data?.message) {
-              rejectMsg = this.getCSPErrorMsg(this.hostConfig.host_url, TENABLE_HOST_URL)
+              rejectMsg = this.getCSPErrorMsg(this.hostConfig.host_url, TENABLE_HOST_URLS)
             } else {
               rejectMsg = DEFAULT_REJECT_MSG
             }
@@ -173,7 +173,7 @@ export class TenableUtil {
             'Unauthorized (missing or not accepted credentials): ' +
             (error.response?.data?.message ?? error.message);
         } else if (error.status == 404) {
-          if (this.isServer && !TENABLE_HOST_URL) {
+          if (this.isServer && !TENABLE_HOST_URLS.length) {
             rejectMsg = TENABLE_CSP_NOT_SET;
           } else {
             rejectMsg = `Network Error -> ${DEFAULT_REJECT_MSG}`;    
@@ -208,12 +208,12 @@ export class TenableUtil {
       if (error.code == 'ERR_NETWORK') {
         // Check if the tenable url was provided - Content Security Policy (CSP)
         const corsReject = `Possible access blocked by CORS or connection refused by the host: ${error.config.baseURL}. See Help for additional instructions. Received Error: ${error.message}`;
-        if (TENABLE_HOST_URL) {
-          // If the URL is listed in the allows domains
+        if (TENABLE_HOST_URLS.length) {
+          // If the URL is listed in the allowed domains
           // (.env variable TENABLE_HOST_URL) check if they match
-          if (!error.config.baseURL.includes(TENABLE_HOST_URL)) {
+          if (!TENABLE_HOST_URLS.some((url) => error.config.baseURL.includes(url))) {
             if (error.config.baseURL) {
-              rejectMsg = this.getCSPErrorMsg(error.config.baseURL, TENABLE_HOST_URL)
+              rejectMsg = this.getCSPErrorMsg(error.config.baseURL, TENABLE_HOST_URLS)
             } else {
               // we assume that the connection was rejected, most likely is that the network path does not exist
               rejectMsg = 'Connection refused by host, or broken network path'
@@ -375,11 +375,11 @@ export class TenableUtil {
    * Generates an error message indicating a Content Security Policy (CSP) violation.
    *
    * @param baseURL - The hostname that triggered the CSP violation.
-   * @param tenableUrl - The hostname allowed by the CSP.
+   * @param tenableUrls - The hostnames allowed by the CSP.
    * @returns A string describing the CSP violation, including the offending and allowed hostnames.
    */
-  getCSPErrorMsg(baseURL: string, tenableUrl: string): string {
-    return `Hostname: ${baseURL?.trim() || 'Unknown host'} violates the Content Security Policy (CSP). The host allowed by the CSP is: ${tenableUrl?.trim() || 'Host not set'}`;
+  getCSPErrorMsg(baseURL: string, tenableUrls: string[]): string {
+    return `Hostname: ${baseURL?.trim() || 'Unknown host'} violates the Content Security Policy (CSP). The host(s) allowed by the CSP: ${tenableUrls.length ? tenableUrls.join(', ') : 'Host not set'}`;
   }
 
 }

--- a/apps/frontend/src/utilities/tenable_util.ts
+++ b/apps/frontend/src/utilities/tenable_util.ts
@@ -140,7 +140,7 @@ export class TenableUtil {
     const DEFAULT_REJECT_MSG =
       `${error.name}: ${(error.response?.data?.message ?? error.message)}, 
        ${error.response?.data?.code ?? error.code}`;
-    const TENABLE_HOST_URLS = ServerModule.tenableHostUrl;
+    const TENABLE_HOST_URL = ServerModule.tenableHostUrl;
     const TENABLE_CSP_NOT_SET =
       'The Content Security Policy directive environment variable "TENABLE_HOST_URL" is not configured. See Help for additional instructions.';
 
@@ -162,7 +162,7 @@ export class TenableUtil {
             } else if (error.response?.data?.code === 'HOST_NOT_ALLOWED') { // Custom set in the backend
               rejectMsg = (error.response?.data?.message ?? 'Tenable host URL is not in the configured allowlist');
             } else if (error.response?.data?.message) {
-              rejectMsg = this.getCSPErrorMsg(this.hostConfig.host_url, TENABLE_HOST_URLS)
+              rejectMsg = this.getCSPErrorMsg(this.hostConfig.host_url, TENABLE_HOST_URL)
             } else {
               rejectMsg = DEFAULT_REJECT_MSG
             }
@@ -175,7 +175,7 @@ export class TenableUtil {
             'Unauthorized (missing or not accepted credentials): ' +
             (error.response?.data?.message ?? error.message);
         } else if (error.status == 404) {
-          if (this.isServer && !TENABLE_HOST_URLS.length) {
+          if (this.isServer && !TENABLE_HOST_URL.length) {
             rejectMsg = TENABLE_CSP_NOT_SET;
           } else {
             rejectMsg = `Network Error -> ${DEFAULT_REJECT_MSG}`;    
@@ -210,12 +210,12 @@ export class TenableUtil {
       if (error.code == 'ERR_NETWORK') {
         // Check if the tenable url was provided - Content Security Policy (CSP)
         const corsReject = `Possible access blocked by CORS or connection refused by the host: ${error.config.baseURL}. See Help for additional instructions. Received Error: ${error.message}`;
-        if (TENABLE_HOST_URLS.length) {
+        if (TENABLE_HOST_URL.length) {
           // If the URL is listed in the allowed domains
           // (.env variable TENABLE_HOST_URL) check if they match
-          if (!TENABLE_HOST_URLS.some((url) => error.config.baseURL.includes(url))) {
+          if (!TENABLE_HOST_URL.some((url) => error.config.baseURL.includes(url))) {
             if (error.config.baseURL) {
-              rejectMsg = this.getCSPErrorMsg(error.config.baseURL, TENABLE_HOST_URLS)
+              rejectMsg = this.getCSPErrorMsg(error.config.baseURL, TENABLE_HOST_URL)
             } else {
               // we assume that the connection was rejected, most likely is that the network path does not exist
               rejectMsg = 'Connection refused by host, or broken network path'

--- a/libs/common/interfaces/config/startup-settings.interface.ts
+++ b/libs/common/interfaces/config/startup-settings.interface.ts
@@ -10,7 +10,7 @@ export interface IStartupSettings {
   readonly ldap: boolean;
   readonly registrationEnabled: boolean;
   readonly localLoginEnabled: boolean;
-  readonly tenableHostUrl: string;
+  readonly tenableHostUrl: string[];
   readonly forceTenableFrontend: boolean;
   readonly splunkHostUrl: string;
 }


### PR DESCRIPTION
- Add JwtAuthGuard to TenableController (login + proxy endpoints)

- Modify TENABLE_HOST_URL config option (newline-separated allowlist)

- Reject login requests whose host_url origin isn't in the allowlist

- Restricts host_url to http/https, trims whitespace before validation, rejects (instead of silently stripping) any extra path/query/fragment

- Delete cached tenable credentials on logout and when a different user tries to log into tenable