### PR TITLE
feat(hdf-converters): add Semgrep JSON to HDF mapper

### DIFF
--- a/apps/frontend/src/store/report_intake.ts
+++ b/apps/frontend/src/store/report_intake.ts
@@ -29,6 +29,7 @@ import {
   NiktoMapper,
   PrismaMapper,
   SarifMapper,
+  SemgrepMapper,
   ScoutsuiteMapper,
   SnykResults,
   TrufflehogResults,
@@ -246,6 +247,8 @@ export class InspecIntake extends VuexModule {
         return new NiktoMapper(convertOptions.data).toHdf();
       case INPUT_TYPES.SARIF:
         return new SarifMapper(convertOptions.data).toHdf();
+      case INPUT_TYPES.SEMGREP:
+        return new SemgrepMapper(convertOptions.data).toHdf();
       case INPUT_TYPES.SNYK:
         return new SnykResults(convertOptions.data).toHdf();
       case INPUT_TYPES.TWISTLOCK:

--- a/libs/hdf-converters/README.md
+++ b/libs/hdf-converters/README.md
@@ -29,14 +29,15 @@ OHDF Converters supplies several methods to convert various types of security to
 21. [**prisma-mapper**] - Prisma Cloud Scan Report CSV file
 22. [**sarif-mapper**] - SARIF JSON file
 23. [**scoutsuite-mapper**] - ScoutSuite results from a Javascript object
-24. [**snyk-mapper**] - Snyk results JSON file
-25. [**sonarqube-mapper**] - SonarQube vulnerabilities for the specified project name and optional branch or pull/merge request ID name from an API
-26. [**splunk-mapper**] - Splunk instance
-27. [**trufflehog-mapper**] - Trufflehog results json file
-28. [**twistlock-mapper**] - Twistlock CLI output file
-29. [**veracode-mapper**] - Veracode Scan Results XML file
-30. [**xccdf-results-mapper**] - SCAP client XCCDF-Results XML report
-31. [**zap-mapper**] - OWASP ZAP results JSON
+24. [**semgrep-mapper**] - Semgrep static analysis results JSON file
+25. [**snyk-mapper**] - Snyk results JSON file
+26. [**sonarqube-mapper**] - SonarQube vulnerabilities for the specified project name and optional branch or pull/merge request ID name from an API
+27. [**splunk-mapper**] - Splunk instance
+28. [**trufflehog-mapper**] - Trufflehog results json file
+29. [**twistlock-mapper**] - Twistlock CLI output file
+30. [**veracode-mapper**] - Veracode Scan Results XML file
+31. [**xccdf-results-mapper**] - SCAP client XCCDF-Results XML report
+32. [**zap-mapper**] - OWASP ZAP results JSON
 
 ### NOTICE
 

--- a/libs/hdf-converters/index.ts
+++ b/libs/hdf-converters/index.ts
@@ -37,6 +37,7 @@ export * from './src/nikto-mapper';
 export * from './src/prisma-mapper';
 export * from './src/sarif-mapper';
 export * from './src/scoutsuite-mapper';
+export * from './src/semgrep-mapper';
 export * from './src/snyk-mapper';
 export * from './src/sonarqube-mapper';
 export * from './src/splunk-mapper';

--- a/libs/hdf-converters/sample_jsons/semgrep_mapper/sample_input_report/semgrep_empty.json
+++ b/libs/hdf-converters/sample_jsons/semgrep_mapper/sample_input_report/semgrep_empty.json
@@ -1,0 +1,83 @@
+{
+  "version": "1.174.0",
+  "results": [],
+  "errors": [],
+  "paths": {
+    "scanned": [
+      "clean/constants.py"
+    ]
+  },
+  "time": {
+    "rules": [],
+    "rules_parse_time": 0.22119784355163574,
+    "profiling_times": {
+      "config_time": 0.5635168552398682,
+      "core_time": 0.4694981575012207,
+      "ignores_time": 0.0006928443908691406,
+      "total_time": 1.0411698818206787
+    },
+    "parsing_time": {
+      "total_time": 0.0,
+      "per_file_time": {
+        "mean": 0.0,
+        "std_dev": 0.0
+      },
+      "very_slow_stats": {
+        "time_ratio": 0.0,
+        "count_ratio": 0.0
+      },
+      "very_slow_files": []
+    },
+    "scanning_time": {
+      "total_time": 0.008240938186645508,
+      "per_file_time": {
+        "mean": 0.0027469793955485025,
+        "std_dev": 1.234643443442312e-05
+      },
+      "very_slow_stats": {
+        "time_ratio": 0.0,
+        "count_ratio": 0.0
+      },
+      "very_slow_files": []
+    },
+    "matching_time": {
+      "total_time": 0.0,
+      "per_file_and_rule_time": {
+        "mean": 0.0,
+        "std_dev": 0.0
+      },
+      "very_slow_stats": {
+        "time_ratio": 0.0,
+        "count_ratio": 0.0
+      },
+      "very_slow_rules_on_files": []
+    },
+    "tainting_time": {
+      "total_time": 0.0,
+      "per_def_and_rule_time": {
+        "mean": 0.0,
+        "std_dev": 0.0
+      },
+      "very_slow_stats": {
+        "time_ratio": 0.0,
+        "count_ratio": 0.0
+      },
+      "very_slow_rules_on_defs": []
+    },
+    "fixpoint_timeouts": [],
+    "prefiltering": {
+      "project_level_time": 0.0,
+      "file_level_time": 0.0,
+      "rules_with_project_prefilters_ratio": 0.0,
+      "rules_with_file_prefilters_ratio": 0.9896551724137931,
+      "rules_selected_ratio": 0.010344827586206896,
+      "rules_matched_ratio": 0.010344827586206896
+    },
+    "targets": [],
+    "total_bytes": 0,
+    "max_memory_bytes": 754748608
+  },
+  "engine_requested": "OSS",
+  "skipped_rules": [],
+  "profiling_results": []
+}

--- a/libs/hdf-converters/sample_jsons/semgrep_mapper/sample_input_report/semgrep_errors.json
+++ b/libs/hdf-converters/sample_jsons/semgrep_mapper/sample_input_report/semgrep_errors.json
@@ -1,0 +1,270 @@
+{
+  "version": "1.174.0",
+  "results": [
+    {
+      "check_id": "yaml.github-actions.security.github-actions-mutable-action-tag.github-actions-mutable-action-tag",
+      "path": ".github/workflows/build.yml",
+      "start": {
+        "line": 7,
+        "col": 9,
+        "offset": 86
+      },
+      "end": {
+        "line": 7,
+        "col": 34,
+        "offset": 111
+      },
+      "extra": {
+        "message": "GitHub Actions step uses a mutable tag or branch reference. Tags and branch names can be silently repointed by the action owner, enabling supply-chain attacks \u2014 as seen in the trivy-action and kics-github-action compromises. Pin the reference to a full 40-character commit SHA instead, e.g. `uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608`.",
+        "metadata": {
+          "category": "security",
+          "cwe": [
+            "CWE-1357: Reliance on Insufficiently Trustworthy Component",
+            "CWE-353: Missing Support for Integrity Check"
+          ],
+          "owasp": [
+            "A08:2021 - Software and Data Integrity Failures",
+            "A08:2025 - Software and Data Integrity Failures"
+          ],
+          "references": [
+            "https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions"
+          ],
+          "technology": [
+            "github-actions"
+          ],
+          "subcategory": [
+            "vuln"
+          ],
+          "likelihood": "MEDIUM",
+          "impact": "HIGH",
+          "confidence": "HIGH",
+          "license": "Semgrep Rules License v1.0. For more details, visit semgrep.dev/legal/rules-license",
+          "vulnerability_class": [
+            "Cryptographic Issues",
+            "Other"
+          ],
+          "source": "https://semgrep.dev/r/yaml.github-actions.security.github-actions-mutable-action-tag.github-actions-mutable-action-tag",
+          "shortlink": "https://sg.run/2LgAL"
+        },
+        "severity": "WARNING",
+        "fingerprint": "requires login",
+        "lines": "requires login",
+        "validation_state": "NO_VALIDATOR",
+        "engine_kind": "OSS"
+      }
+    },
+    {
+      "check_id": "yaml.github-actions.security.gha-curl-pipe-shell.gha-curl-pipe-shell",
+      "path": ".github/workflows/build.yml",
+      "start": {
+        "line": 9,
+        "col": 9,
+        "offset": 141
+      },
+      "end": {
+        "line": 9,
+        "col": 92,
+        "offset": 224
+      },
+      "extra": {
+        "message": "A `run:` step pipes the output of `curl` or `wget` directly into a shell interpreter. This is the \"curl | bash\" install pattern \u2014 if the remote server is compromised or the URL is hijacked, an attacker can execute arbitrary code in your CI runner. Consider downloading the file first, verifying its checksum or signature, and then executing it.",
+        "metadata": {
+          "category": "security",
+          "cwe": [
+            "CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"
+          ],
+          "owasp": [
+            "A03:2021 - Injection",
+            "A03:2025 - Injection"
+          ],
+          "references": [
+            "https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions",
+            "https://www.idontplaydarts.com/2016/04/detecting-curl-pipe-bash-server-side/"
+          ],
+          "technology": [
+            "github-actions",
+            "bash",
+            "curl"
+          ],
+          "cwe2021-top25": true,
+          "cwe2022-top25": true,
+          "subcategory": [
+            "vuln"
+          ],
+          "likelihood": "MEDIUM",
+          "impact": "HIGH",
+          "confidence": "HIGH",
+          "license": "Semgrep Rules License v1.0. For more details, visit semgrep.dev/legal/rules-license",
+          "vulnerability_class": [
+            "Command Injection"
+          ],
+          "source": "https://semgrep.dev/r/yaml.github-actions.security.gha-curl-pipe-shell.gha-curl-pipe-shell",
+          "shortlink": "https://sg.run/GR8K1"
+        },
+        "severity": "ERROR",
+        "fingerprint": "requires login",
+        "lines": "requires login",
+        "validation_state": "NO_VALIDATOR",
+        "engine_kind": "OSS"
+      }
+    }
+  ],
+  "errors": [
+    {
+      "code": 3,
+      "level": "warn",
+      "type": [
+        "PartialParsing",
+        [
+          {
+            "path": ".github/workflows/build.yml",
+            "start": {
+              "line": 9,
+              "col": 61,
+              "offset": 146
+            },
+            "end": {
+              "line": 9,
+              "col": 81,
+              "offset": 166
+            }
+          }
+        ]
+      ],
+      "message": "Syntax error at line .github/workflows/build.yml:9:\n When parsing a snippet as Bash for metavariable-pattern in rule 'yaml.github-actions.security.curl-eval.curl-eval', `{ steps.scan.outcome` was unexpected",
+      "path": ".github/workflows/build.yml",
+      "spans": [
+        {
+          "file": ".github/workflows/build.yml",
+          "start": {
+            "line": 9,
+            "col": 61,
+            "offset": 146
+          },
+          "end": {
+            "line": 9,
+            "col": 81,
+            "offset": 166
+          }
+        }
+      ]
+    },
+    {
+      "code": 3,
+      "level": "warn",
+      "type": [
+        "PartialParsing",
+        [
+          {
+            "path": ".github/workflows/build.yml",
+            "start": {
+              "line": 9,
+              "col": 61,
+              "offset": 146
+            },
+            "end": {
+              "line": 9,
+              "col": 81,
+              "offset": 166
+            }
+          }
+        ]
+      ],
+      "message": "Syntax error at line .github/workflows/build.yml:9:\n When parsing a snippet as Bash for metavariable-pattern in rule 'yaml.github-actions.security.gha-curl-pipe-shell.gha-curl-pipe-shell', `{ steps.scan.outcome` was unexpected",
+      "path": ".github/workflows/build.yml",
+      "spans": [
+        {
+          "file": ".github/workflows/build.yml",
+          "start": {
+            "line": 9,
+            "col": 61,
+            "offset": 146
+          },
+          "end": {
+            "line": 9,
+            "col": 81,
+            "offset": 166
+          }
+        }
+      ]
+    }
+  ],
+  "paths": {
+    "scanned": [
+      ".github/workflows/build.yml"
+    ]
+  },
+  "time": {
+    "rules": [],
+    "rules_parse_time": 0.22116518020629883,
+    "profiling_times": {
+      "config_time": 0.7548449039459229,
+      "core_time": 0.48832106590270996,
+      "ignores_time": 0.0006480216979980469,
+      "total_time": 1.2520298957824707
+    },
+    "parsing_time": {
+      "total_time": 0.0,
+      "per_file_time": {
+        "mean": 0.0,
+        "std_dev": 0.0
+      },
+      "very_slow_stats": {
+        "time_ratio": 0.0,
+        "count_ratio": 0.0
+      },
+      "very_slow_files": []
+    },
+    "scanning_time": {
+      "total_time": 0.02304387092590332,
+      "per_file_time": {
+        "mean": 0.00768129030863444,
+        "std_dev": 9.17028142768888e-05
+      },
+      "very_slow_stats": {
+        "time_ratio": 0.0,
+        "count_ratio": 0.0
+      },
+      "very_slow_files": []
+    },
+    "matching_time": {
+      "total_time": 0.0,
+      "per_file_and_rule_time": {
+        "mean": 0.0,
+        "std_dev": 0.0
+      },
+      "very_slow_stats": {
+        "time_ratio": 0.0,
+        "count_ratio": 0.0
+      },
+      "very_slow_rules_on_files": []
+    },
+    "tainting_time": {
+      "total_time": 0.0,
+      "per_def_and_rule_time": {
+        "mean": 0.0,
+        "std_dev": 0.0
+      },
+      "very_slow_stats": {
+        "time_ratio": 0.0,
+        "count_ratio": 0.0
+      },
+      "very_slow_rules_on_defs": []
+    },
+    "fixpoint_timeouts": [],
+    "prefiltering": {
+      "project_level_time": 0.0,
+      "file_level_time": 0.0,
+      "rules_with_project_prefilters_ratio": 0.0,
+      "rules_with_file_prefilters_ratio": 0.6097560975609756,
+      "rules_selected_ratio": 0.3902439024390244,
+      "rules_matched_ratio": 0.3902439024390244
+    },
+    "targets": [],
+    "total_bytes": 0,
+    "max_memory_bytes": 734698240
+  },
+  "engine_requested": "OSS",
+  "skipped_rules": [],
+  "profiling_results": []
+}

--- a/libs/hdf-converters/sample_jsons/semgrep_mapper/sample_input_report/semgrep_findings.json
+++ b/libs/hdf-converters/sample_jsons/semgrep_mapper/sample_input_report/semgrep_findings.json
@@ -1,0 +1,195 @@
+{
+  "version": "1.174.0",
+  "results": [
+    {
+      "check_id": "python.lang.security.audit.subprocess-shell-true.subprocess-shell-true",
+      "path": "app/handlers.py",
+      "start": {
+        "line": 7,
+        "col": 36,
+        "offset": 167
+      },
+      "end": {
+        "line": 7,
+        "col": 40,
+        "offset": 171
+      },
+      "extra": {
+        "message": "Found 'subprocess' function 'run' with 'shell=True'. This is dangerous because this call will spawn the command using a shell process. Doing so propagates current shell settings and variables, which makes it much easier for a malicious actor to execute commands. Use 'shell=False' instead.",
+        "fix": "False",
+        "metadata": {
+          "source-rule-url": "https://bandit.readthedocs.io/en/latest/plugins/b602_subprocess_popen_with_shell_equals_true.html",
+          "owasp": [
+            "A01:2017 - Injection",
+            "A03:2021 - Injection",
+            "A05:2025 - Injection"
+          ],
+          "cwe": [
+            "CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"
+          ],
+          "references": [
+            "https://stackoverflow.com/questions/3172470/actual-meaning-of-shell-true-in-subprocess",
+            "https://docs.python.org/3/library/subprocess.html"
+          ],
+          "category": "security",
+          "technology": [
+            "python"
+          ],
+          "cwe2022-top25": true,
+          "cwe2021-top25": true,
+          "subcategory": [
+            "secure default"
+          ],
+          "likelihood": "HIGH",
+          "impact": "LOW",
+          "confidence": "MEDIUM",
+          "license": "Semgrep Rules License v1.0. For more details, visit semgrep.dev/legal/rules-license",
+          "vulnerability_class": [
+            "Command Injection"
+          ],
+          "source": "https://semgrep.dev/r/python.lang.security.audit.subprocess-shell-true.subprocess-shell-true",
+          "shortlink": "https://sg.run/J92w"
+        },
+        "severity": "ERROR",
+        "fingerprint": "requires login",
+        "lines": "requires login",
+        "validation_state": "NO_VALIDATOR",
+        "engine_kind": "OSS"
+      }
+    },
+    {
+      "check_id": "python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected",
+      "path": "app/handlers.py",
+      "start": {
+        "line": 12,
+        "col": 10,
+        "offset": 260
+      },
+      "end": {
+        "line": 12,
+        "col": 49,
+        "offset": 299
+      },
+      "extra": {
+        "message": "Detected a dynamic value being used with urllib. urllib supports 'file://' schemes, so a dynamic value controlled by a malicious actor may allow them to read arbitrary files. Audit uses of urllib calls to ensure user data cannot control the URLs, or consider using the 'requests' library instead.",
+        "metadata": {
+          "cwe": [
+            "CWE-939: Improper Authorization in Handler for Custom URL Scheme"
+          ],
+          "owasp": "A01:2017 - Injection",
+          "source-rule-url": "https://github.com/PyCQA/bandit/blob/b1411bfb43795d3ffd268bef17a839dee954c2b1/bandit/blacklists/calls.py#L163",
+          "bandit-code": "B310",
+          "asvs": {
+            "control_id": "5.2.4 Dynamic Code Execution Features",
+            "control_url": "https://github.com/OWASP/ASVS/blob/master/4.0/en/0x13-V5-Validation-Sanitization-Encoding.md#v52-sanitization-and-sandboxing-requirements",
+            "section": "V5: Validation, Sanitization and Encoding Verification Requirements",
+            "version": "4"
+          },
+          "category": "security",
+          "technology": [
+            "python"
+          ],
+          "references": [
+            "https://cwe.mitre.org/data/definitions/939.html"
+          ],
+          "subcategory": [
+            "audit"
+          ],
+          "likelihood": "LOW",
+          "impact": "LOW",
+          "confidence": "LOW",
+          "license": "Semgrep Rules License v1.0. For more details, visit semgrep.dev/legal/rules-license",
+          "vulnerability_class": [
+            "Improper Authorization"
+          ],
+          "source": "https://semgrep.dev/r/python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected",
+          "shortlink": "https://sg.run/dKZZ"
+        },
+        "severity": "WARNING",
+        "fingerprint": "requires login",
+        "lines": "requires login",
+        "validation_state": "NO_VALIDATOR",
+        "engine_kind": "OSS"
+      }
+    }
+  ],
+  "errors": [],
+  "paths": {
+    "scanned": [
+      "app/handlers.py"
+    ]
+  },
+  "time": {
+    "rules": [],
+    "rules_parse_time": 0.23672795295715332,
+    "profiling_times": {
+      "config_time": 0.7533607482910156,
+      "core_time": 0.5583689212799072,
+      "ignores_time": 0.0007622241973876953,
+      "total_time": 1.3202989101409912
+    },
+    "parsing_time": {
+      "total_time": 0.0,
+      "per_file_time": {
+        "mean": 0.0,
+        "std_dev": 0.0
+      },
+      "very_slow_stats": {
+        "time_ratio": 0.0,
+        "count_ratio": 0.0
+      },
+      "very_slow_files": []
+    },
+    "scanning_time": {
+      "total_time": 0.040416717529296875,
+      "per_file_time": {
+        "mean": 0.013472239176432291,
+        "std_dev": 0.00025216217342302925
+      },
+      "very_slow_stats": {
+        "time_ratio": 0.0,
+        "count_ratio": 0.0
+      },
+      "very_slow_files": []
+    },
+    "matching_time": {
+      "total_time": 0.0,
+      "per_file_and_rule_time": {
+        "mean": 0.0,
+        "std_dev": 0.0
+      },
+      "very_slow_stats": {
+        "time_ratio": 0.0,
+        "count_ratio": 0.0
+      },
+      "very_slow_rules_on_files": []
+    },
+    "tainting_time": {
+      "total_time": 0.0,
+      "per_def_and_rule_time": {
+        "mean": 0.0,
+        "std_dev": 0.0
+      },
+      "very_slow_stats": {
+        "time_ratio": 0.0,
+        "count_ratio": 0.0
+      },
+      "very_slow_rules_on_defs": []
+    },
+    "fixpoint_timeouts": [],
+    "prefiltering": {
+      "project_level_time": 0.0,
+      "file_level_time": 0.0,
+      "rules_with_project_prefilters_ratio": 0.0,
+      "rules_with_file_prefilters_ratio": 0.9896551724137931,
+      "rules_selected_ratio": 0.05862068965517241,
+      "rules_matched_ratio": 0.05862068965517241
+    },
+    "targets": [],
+    "total_bytes": 0,
+    "max_memory_bytes": 765083904
+  },
+  "engine_requested": "OSS",
+  "skipped_rules": [],
+  "profiling_results": []
+}

--- a/libs/hdf-converters/sample_jsons/semgrep_mapper/semgrep_empty-hdf.json
+++ b/libs/hdf-converters/sample_jsons/semgrep_mapper/semgrep_empty-hdf.json
@@ -1,0 +1,38 @@
+{
+  "platform": {
+    "name": "Heimdall Tools",
+    "release": "2.13.0"
+  },
+  "version": "2.13.0",
+  "statistics": {},
+  "profiles": [
+    {
+      "name": "Semgrep",
+      "title": "Semgrep Static Analysis Scan",
+      "version": "1.174.0",
+      "supports": [],
+      "attributes": [],
+      "groups": [],
+      "status": "loaded",
+      "controls": [],
+      "sha256": "8fcad4875895ca43affbf497f4d211f9d86747f5f81da323c8c6a2ea86c7ac7e"
+    }
+  ],
+  "passthrough": {
+    "auxiliary_data": [
+      {
+        "name": "Semgrep",
+        "data": {
+          "version": "1.174.0",
+          "engine_requested": "OSS",
+          "paths": {
+            "scanned": [
+              "clean/constants.py"
+            ]
+          },
+          "skipped_rules": []
+        }
+      }
+    ]
+  }
+}

--- a/libs/hdf-converters/sample_jsons/semgrep_mapper/semgrep_errors-hdf.json
+++ b/libs/hdf-converters/sample_jsons/semgrep_mapper/semgrep_errors-hdf.json
@@ -1,0 +1,194 @@
+{
+  "platform": {
+    "name": "Heimdall Tools",
+    "release": "2.13.0"
+  },
+  "version": "2.13.0",
+  "statistics": {},
+  "profiles": [
+    {
+      "name": "Semgrep",
+      "title": "Semgrep Static Analysis Scan",
+      "version": "1.174.0",
+      "supports": [],
+      "attributes": [],
+      "groups": [],
+      "status": "loaded",
+      "controls": [
+        {
+          "id": "yaml.github-actions.security.github-actions-mutable-action-tag.github-actions-mutable-action-tag",
+          "title": "Github Actions Mutable Action Tag",
+          "desc": "GitHub Actions step uses a mutable tag or branch reference. Tags and branch names can be silently repointed by the action owner, enabling supply-chain attacks — as seen in the trivy-action and kics-github-action compromises. Pin the reference to a full 40-character commit SHA instead, e.g. `uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608`.",
+          "impact": 0.5,
+          "refs": [
+            {
+              "url": "https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions"
+            },
+            {
+              "url": "https://semgrep.dev/r/yaml.github-actions.security.github-actions-mutable-action-tag.github-actions-mutable-action-tag"
+            },
+            {
+              "url": "https://sg.run/2LgAL"
+            }
+          ],
+          "code": "{\n  \"extra\": {\n    \"validation_state\": \"NO_VALIDATOR\"\n  }\n}",
+          "source_location": {},
+          "tags": {
+            "nist": [
+              "SA-11",
+              "RA-5"
+            ],
+            "cci": [
+              "CCI-003173",
+              "CCI-001643"
+            ],
+            "cwe": [
+              "CWE-1357: Reliance on Insufficiently Trustworthy Component",
+              "CWE-353: Missing Support for Integrity Check"
+            ],
+            "owasp": [
+              "A08:2021 - Software and Data Integrity Failures",
+              "A08:2025 - Software and Data Integrity Failures"
+            ],
+            "confidence": "HIGH",
+            "likelihood": "MEDIUM",
+            "semgrep_impact": "HIGH",
+            "category": "security",
+            "subcategory": [
+              "vuln"
+            ],
+            "technology": [
+              "github-actions"
+            ],
+            "vulnerability_class": [
+              "Cryptographic Issues",
+              "Other"
+            ],
+            "engine_kind": "OSS",
+            "check_id": "yaml.github-actions.security.github-actions-mutable-action-tag.github-actions-mutable-action-tag",
+            "severity": "WARNING"
+          },
+          "results": [
+            {
+              "status": "failed",
+              "code_desc": "Path: .github/workflows/build.yml\nLocation: line 7, columns 9-34",
+              "start_time": ""
+            }
+          ]
+        },
+        {
+          "id": "yaml.github-actions.security.gha-curl-pipe-shell.gha-curl-pipe-shell",
+          "title": "Gha Curl Pipe Shell",
+          "desc": "A `run:` step pipes the output of `curl` or `wget` directly into a shell interpreter. This is the \"curl | bash\" install pattern — if the remote server is compromised or the URL is hijacked, an attacker can execute arbitrary code in your CI runner. Consider downloading the file first, verifying its checksum or signature, and then executing it.",
+          "impact": 0.7,
+          "refs": [
+            {
+              "url": "https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions"
+            },
+            {
+              "url": "https://www.idontplaydarts.com/2016/04/detecting-curl-pipe-bash-server-side/"
+            },
+            {
+              "url": "https://semgrep.dev/r/yaml.github-actions.security.gha-curl-pipe-shell.gha-curl-pipe-shell"
+            },
+            {
+              "url": "https://sg.run/GR8K1"
+            }
+          ],
+          "code": "{\n  \"extra\": {\n    \"validation_state\": \"NO_VALIDATOR\"\n  }\n}",
+          "source_location": {},
+          "tags": {
+            "nist": [
+              "SI-10"
+            ],
+            "cci": [
+              "CCI-001310"
+            ],
+            "cwe": [
+              "CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"
+            ],
+            "owasp": [
+              "A03:2021 - Injection",
+              "A03:2025 - Injection"
+            ],
+            "confidence": "HIGH",
+            "likelihood": "MEDIUM",
+            "semgrep_impact": "HIGH",
+            "category": "security",
+            "subcategory": [
+              "vuln"
+            ],
+            "technology": [
+              "github-actions",
+              "bash",
+              "curl"
+            ],
+            "vulnerability_class": [
+              "Command Injection"
+            ],
+            "engine_kind": "OSS",
+            "check_id": "yaml.github-actions.security.gha-curl-pipe-shell.gha-curl-pipe-shell",
+            "severity": "ERROR"
+          },
+          "results": [
+            {
+              "status": "failed",
+              "code_desc": "Path: .github/workflows/build.yml\nLocation: line 9, columns 9-92",
+              "start_time": ""
+            }
+          ]
+        },
+        {
+          "id": "Semgrep Scan Errors",
+          "title": "Semgrep Scan Errors",
+          "desc": "Errors reported by Semgrep while scanning. A file that failed to parse was not fully analyzed, so absence of findings in it is not evidence of compliance.",
+          "impact": 0.5,
+          "refs": [],
+          "source_location": {},
+          "tags": {
+            "nist": [
+              "SA-11",
+              "RA-5"
+            ],
+            "cci": [
+              "CCI-003173",
+              "CCI-001643"
+            ]
+          },
+          "results": [
+            {
+              "status": "error",
+              "code_desc": "Path: .github/workflows/build.yml",
+              "message": "PartialParsing: Syntax error at line .github/workflows/build.yml:9:\n When parsing a snippet as Bash for metavariable-pattern in rule 'yaml.github-actions.security.curl-eval.curl-eval', `{ steps.scan.outcome` was unexpected",
+              "start_time": ""
+            },
+            {
+              "status": "error",
+              "code_desc": "Path: .github/workflows/build.yml",
+              "message": "PartialParsing: Syntax error at line .github/workflows/build.yml:9:\n When parsing a snippet as Bash for metavariable-pattern in rule 'yaml.github-actions.security.gha-curl-pipe-shell.gha-curl-pipe-shell', `{ steps.scan.outcome` was unexpected",
+              "start_time": ""
+            }
+          ]
+        }
+      ],
+      "sha256": "53055b89b9a9c9a2f29132cb04fc2b352d9c1cec2f828f37735eff36425dbcff"
+    }
+  ],
+  "passthrough": {
+    "auxiliary_data": [
+      {
+        "name": "Semgrep",
+        "data": {
+          "version": "1.174.0",
+          "engine_requested": "OSS",
+          "paths": {
+            "scanned": [
+              ".github/workflows/build.yml"
+            ]
+          },
+          "skipped_rules": []
+        }
+      }
+    ]
+  }
+}

--- a/libs/hdf-converters/sample_jsons/semgrep_mapper/semgrep_findings-hdf.json
+++ b/libs/hdf-converters/sample_jsons/semgrep_mapper/semgrep_findings-hdf.json
@@ -1,0 +1,175 @@
+{
+  "platform": {
+    "name": "Heimdall Tools",
+    "release": "2.13.0"
+  },
+  "version": "2.13.0",
+  "statistics": {},
+  "profiles": [
+    {
+      "name": "Semgrep",
+      "title": "Semgrep Static Analysis Scan",
+      "version": "1.174.0",
+      "supports": [],
+      "attributes": [],
+      "groups": [],
+      "status": "loaded",
+      "controls": [
+        {
+          "id": "python.lang.security.audit.subprocess-shell-true.subprocess-shell-true",
+          "title": "Subprocess Shell True",
+          "desc": "Found 'subprocess' function 'run' with 'shell=True'. This is dangerous because this call will spawn the command using a shell process. Doing so propagates current shell settings and variables, which makes it much easier for a malicious actor to execute commands. Use 'shell=False' instead.",
+          "impact": 0.7,
+          "refs": [
+            {
+              "url": "https://stackoverflow.com/questions/3172470/actual-meaning-of-shell-true-in-subprocess"
+            },
+            {
+              "url": "https://docs.python.org/3/library/subprocess.html"
+            },
+            {
+              "url": "https://semgrep.dev/r/python.lang.security.audit.subprocess-shell-true.subprocess-shell-true"
+            },
+            {
+              "url": "https://sg.run/J92w"
+            },
+            {
+              "url": "https://bandit.readthedocs.io/en/latest/plugins/b602_subprocess_popen_with_shell_equals_true.html"
+            }
+          ],
+          "code": "{\n  \"extra\": {\n    \"validation_state\": \"NO_VALIDATOR\"\n  }\n}",
+          "source_location": {},
+          "tags": {
+            "nist": [
+              "SI-10"
+            ],
+            "cci": [
+              "CCI-001310"
+            ],
+            "cwe": [
+              "CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"
+            ],
+            "owasp": [
+              "A01:2017 - Injection",
+              "A03:2021 - Injection",
+              "A05:2025 - Injection"
+            ],
+            "confidence": "MEDIUM",
+            "likelihood": "HIGH",
+            "semgrep_impact": "LOW",
+            "category": "security",
+            "subcategory": [
+              "secure default"
+            ],
+            "technology": [
+              "python"
+            ],
+            "vulnerability_class": [
+              "Command Injection"
+            ],
+            "engine_kind": "OSS",
+            "check_id": "python.lang.security.audit.subprocess-shell-true.subprocess-shell-true",
+            "severity": "ERROR"
+          },
+          "results": [
+            {
+              "status": "failed",
+              "code_desc": "Path: app/handlers.py\nLocation: line 7, columns 36-40",
+              "message": "Suggested fix -- replace the matched code with:\nFalse",
+              "start_time": ""
+            }
+          ]
+        },
+        {
+          "id": "python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected",
+          "title": "Dynamic Urllib Use Detected",
+          "desc": "Detected a dynamic value being used with urllib. urllib supports 'file://' schemes, so a dynamic value controlled by a malicious actor may allow them to read arbitrary files. Audit uses of urllib calls to ensure user data cannot control the URLs, or consider using the 'requests' library instead.",
+          "impact": 0.5,
+          "refs": [
+            {
+              "url": "https://cwe.mitre.org/data/definitions/939.html"
+            },
+            {
+              "url": "https://semgrep.dev/r/python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected"
+            },
+            {
+              "url": "https://sg.run/dKZZ"
+            },
+            {
+              "url": "https://github.com/PyCQA/bandit/blob/b1411bfb43795d3ffd268bef17a839dee954c2b1/bandit/blacklists/calls.py#L163"
+            },
+            {
+              "url": "https://github.com/OWASP/ASVS/blob/master/4.0/en/0x13-V5-Validation-Sanitization-Encoding.md#v52-sanitization-and-sandboxing-requirements"
+            }
+          ],
+          "code": "{\n  \"extra\": {\n    \"validation_state\": \"NO_VALIDATOR\"\n  }\n}",
+          "source_location": {},
+          "tags": {
+            "nist": [
+              "SA-11",
+              "RA-5"
+            ],
+            "cci": [
+              "CCI-003173",
+              "CCI-001643"
+            ],
+            "cwe": [
+              "CWE-939: Improper Authorization in Handler for Custom URL Scheme"
+            ],
+            "owasp": [
+              "A01:2017 - Injection"
+            ],
+            "confidence": "LOW",
+            "likelihood": "LOW",
+            "semgrep_impact": "LOW",
+            "category": "security",
+            "subcategory": [
+              "audit"
+            ],
+            "technology": [
+              "python"
+            ],
+            "vulnerability_class": [
+              "Improper Authorization"
+            ],
+            "asvs": {
+              "control_id": "5.2.4 Dynamic Code Execution Features",
+              "control_url": "https://github.com/OWASP/ASVS/blob/master/4.0/en/0x13-V5-Validation-Sanitization-Encoding.md#v52-sanitization-and-sandboxing-requirements",
+              "section": "V5: Validation, Sanitization and Encoding Verification Requirements",
+              "version": "4"
+            },
+            "bandit_code": "B310",
+            "engine_kind": "OSS",
+            "check_id": "python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected",
+            "severity": "WARNING"
+          },
+          "results": [
+            {
+              "status": "failed",
+              "code_desc": "Path: app/handlers.py\nLocation: line 12, columns 10-49",
+              "start_time": ""
+            }
+          ]
+        }
+      ],
+      "sha256": "e9c06051fe8554a98a787f174b91651043d4288bbbe924492b3f3b156cb7a227"
+    }
+  ],
+  "passthrough": {
+    "auxiliary_data": [
+      {
+        "name": "Semgrep",
+        "data": {
+          "version": "1.174.0",
+          "engine_requested": "OSS",
+          "paths": {
+            "scanned": [
+              "app/handlers.py"
+            ]
+          },
+          "skipped_rules": []
+        }
+      }
+    ]
+  }
+}

--- a/libs/hdf-converters/sample_jsons/semgrep_mapper/semgrep_findings-withraw-hdf.json
+++ b/libs/hdf-converters/sample_jsons/semgrep_mapper/semgrep_findings-withraw-hdf.json
@@ -1,0 +1,370 @@
+{
+  "platform": {
+    "name": "Heimdall Tools",
+    "release": "2.13.0"
+  },
+  "version": "2.13.0",
+  "statistics": {},
+  "profiles": [
+    {
+      "name": "Semgrep",
+      "title": "Semgrep Static Analysis Scan",
+      "version": "1.174.0",
+      "supports": [],
+      "attributes": [],
+      "groups": [],
+      "status": "loaded",
+      "controls": [
+        {
+          "id": "python.lang.security.audit.subprocess-shell-true.subprocess-shell-true",
+          "title": "Subprocess Shell True",
+          "desc": "Found 'subprocess' function 'run' with 'shell=True'. This is dangerous because this call will spawn the command using a shell process. Doing so propagates current shell settings and variables, which makes it much easier for a malicious actor to execute commands. Use 'shell=False' instead.",
+          "impact": 0.7,
+          "refs": [
+            {
+              "url": "https://stackoverflow.com/questions/3172470/actual-meaning-of-shell-true-in-subprocess"
+            },
+            {
+              "url": "https://docs.python.org/3/library/subprocess.html"
+            },
+            {
+              "url": "https://semgrep.dev/r/python.lang.security.audit.subprocess-shell-true.subprocess-shell-true"
+            },
+            {
+              "url": "https://sg.run/J92w"
+            },
+            {
+              "url": "https://bandit.readthedocs.io/en/latest/plugins/b602_subprocess_popen_with_shell_equals_true.html"
+            }
+          ],
+          "code": "{\n  \"extra\": {\n    \"validation_state\": \"NO_VALIDATOR\"\n  }\n}",
+          "source_location": {},
+          "tags": {
+            "nist": [
+              "SI-10"
+            ],
+            "cci": [
+              "CCI-001310"
+            ],
+            "cwe": [
+              "CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"
+            ],
+            "owasp": [
+              "A01:2017 - Injection",
+              "A03:2021 - Injection",
+              "A05:2025 - Injection"
+            ],
+            "confidence": "MEDIUM",
+            "likelihood": "HIGH",
+            "semgrep_impact": "LOW",
+            "category": "security",
+            "subcategory": [
+              "secure default"
+            ],
+            "technology": [
+              "python"
+            ],
+            "vulnerability_class": [
+              "Command Injection"
+            ],
+            "engine_kind": "OSS",
+            "check_id": "python.lang.security.audit.subprocess-shell-true.subprocess-shell-true",
+            "severity": "ERROR"
+          },
+          "results": [
+            {
+              "status": "failed",
+              "code_desc": "Path: app/handlers.py\nLocation: line 7, columns 36-40",
+              "message": "Suggested fix -- replace the matched code with:\nFalse",
+              "start_time": ""
+            }
+          ]
+        },
+        {
+          "id": "python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected",
+          "title": "Dynamic Urllib Use Detected",
+          "desc": "Detected a dynamic value being used with urllib. urllib supports 'file://' schemes, so a dynamic value controlled by a malicious actor may allow them to read arbitrary files. Audit uses of urllib calls to ensure user data cannot control the URLs, or consider using the 'requests' library instead.",
+          "impact": 0.5,
+          "refs": [
+            {
+              "url": "https://cwe.mitre.org/data/definitions/939.html"
+            },
+            {
+              "url": "https://semgrep.dev/r/python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected"
+            },
+            {
+              "url": "https://sg.run/dKZZ"
+            },
+            {
+              "url": "https://github.com/PyCQA/bandit/blob/b1411bfb43795d3ffd268bef17a839dee954c2b1/bandit/blacklists/calls.py#L163"
+            },
+            {
+              "url": "https://github.com/OWASP/ASVS/blob/master/4.0/en/0x13-V5-Validation-Sanitization-Encoding.md#v52-sanitization-and-sandboxing-requirements"
+            }
+          ],
+          "code": "{\n  \"extra\": {\n    \"validation_state\": \"NO_VALIDATOR\"\n  }\n}",
+          "source_location": {},
+          "tags": {
+            "nist": [
+              "SA-11",
+              "RA-5"
+            ],
+            "cci": [
+              "CCI-003173",
+              "CCI-001643"
+            ],
+            "cwe": [
+              "CWE-939: Improper Authorization in Handler for Custom URL Scheme"
+            ],
+            "owasp": [
+              "A01:2017 - Injection"
+            ],
+            "confidence": "LOW",
+            "likelihood": "LOW",
+            "semgrep_impact": "LOW",
+            "category": "security",
+            "subcategory": [
+              "audit"
+            ],
+            "technology": [
+              "python"
+            ],
+            "vulnerability_class": [
+              "Improper Authorization"
+            ],
+            "asvs": {
+              "control_id": "5.2.4 Dynamic Code Execution Features",
+              "control_url": "https://github.com/OWASP/ASVS/blob/master/4.0/en/0x13-V5-Validation-Sanitization-Encoding.md#v52-sanitization-and-sandboxing-requirements",
+              "section": "V5: Validation, Sanitization and Encoding Verification Requirements",
+              "version": "4"
+            },
+            "bandit_code": "B310",
+            "engine_kind": "OSS",
+            "check_id": "python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected",
+            "severity": "WARNING"
+          },
+          "results": [
+            {
+              "status": "failed",
+              "code_desc": "Path: app/handlers.py\nLocation: line 12, columns 10-49",
+              "start_time": ""
+            }
+          ]
+        }
+      ],
+      "sha256": "e9c06051fe8554a98a787f174b91651043d4288bbbe924492b3f3b156cb7a227"
+    }
+  ],
+  "passthrough": {
+    "auxiliary_data": [
+      {
+        "name": "Semgrep",
+        "data": {
+          "version": "1.174.0",
+          "engine_requested": "OSS",
+          "paths": {
+            "scanned": [
+              "app/handlers.py"
+            ]
+          },
+          "skipped_rules": []
+        }
+      }
+    ],
+    "raw": {
+      "version": "1.174.0",
+      "results": [
+        {
+          "check_id": "python.lang.security.audit.subprocess-shell-true.subprocess-shell-true",
+          "path": "app/handlers.py",
+          "start": {
+            "line": 7,
+            "col": 36,
+            "offset": 167
+          },
+          "end": {
+            "line": 7,
+            "col": 40,
+            "offset": 171
+          },
+          "extra": {
+            "message": "Found 'subprocess' function 'run' with 'shell=True'. This is dangerous because this call will spawn the command using a shell process. Doing so propagates current shell settings and variables, which makes it much easier for a malicious actor to execute commands. Use 'shell=False' instead.",
+            "fix": "False",
+            "metadata": {
+              "source-rule-url": "https://bandit.readthedocs.io/en/latest/plugins/b602_subprocess_popen_with_shell_equals_true.html",
+              "owasp": [
+                "A01:2017 - Injection",
+                "A03:2021 - Injection",
+                "A05:2025 - Injection"
+              ],
+              "cwe": [
+                "CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"
+              ],
+              "references": [
+                "https://stackoverflow.com/questions/3172470/actual-meaning-of-shell-true-in-subprocess",
+                "https://docs.python.org/3/library/subprocess.html"
+              ],
+              "category": "security",
+              "technology": [
+                "python"
+              ],
+              "cwe2022-top25": true,
+              "cwe2021-top25": true,
+              "subcategory": [
+                "secure default"
+              ],
+              "likelihood": "HIGH",
+              "impact": "LOW",
+              "confidence": "MEDIUM",
+              "license": "Semgrep Rules License v1.0. For more details, visit semgrep.dev/legal/rules-license",
+              "vulnerability_class": [
+                "Command Injection"
+              ],
+              "source": "https://semgrep.dev/r/python.lang.security.audit.subprocess-shell-true.subprocess-shell-true",
+              "shortlink": "https://sg.run/J92w"
+            },
+            "severity": "ERROR",
+            "fingerprint": "requires login",
+            "lines": "requires login",
+            "validation_state": "NO_VALIDATOR",
+            "engine_kind": "OSS"
+          }
+        },
+        {
+          "check_id": "python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected",
+          "path": "app/handlers.py",
+          "start": {
+            "line": 12,
+            "col": 10,
+            "offset": 260
+          },
+          "end": {
+            "line": 12,
+            "col": 49,
+            "offset": 299
+          },
+          "extra": {
+            "message": "Detected a dynamic value being used with urllib. urllib supports 'file://' schemes, so a dynamic value controlled by a malicious actor may allow them to read arbitrary files. Audit uses of urllib calls to ensure user data cannot control the URLs, or consider using the 'requests' library instead.",
+            "metadata": {
+              "cwe": [
+                "CWE-939: Improper Authorization in Handler for Custom URL Scheme"
+              ],
+              "owasp": "A01:2017 - Injection",
+              "source-rule-url": "https://github.com/PyCQA/bandit/blob/b1411bfb43795d3ffd268bef17a839dee954c2b1/bandit/blacklists/calls.py#L163",
+              "bandit-code": "B310",
+              "asvs": {
+                "control_id": "5.2.4 Dynamic Code Execution Features",
+                "control_url": "https://github.com/OWASP/ASVS/blob/master/4.0/en/0x13-V5-Validation-Sanitization-Encoding.md#v52-sanitization-and-sandboxing-requirements",
+                "section": "V5: Validation, Sanitization and Encoding Verification Requirements",
+                "version": "4"
+              },
+              "category": "security",
+              "technology": [
+                "python"
+              ],
+              "references": [
+                "https://cwe.mitre.org/data/definitions/939.html"
+              ],
+              "subcategory": [
+                "audit"
+              ],
+              "likelihood": "LOW",
+              "impact": "LOW",
+              "confidence": "LOW",
+              "license": "Semgrep Rules License v1.0. For more details, visit semgrep.dev/legal/rules-license",
+              "vulnerability_class": [
+                "Improper Authorization"
+              ],
+              "source": "https://semgrep.dev/r/python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected",
+              "shortlink": "https://sg.run/dKZZ"
+            },
+            "severity": "WARNING",
+            "fingerprint": "requires login",
+            "lines": "requires login",
+            "validation_state": "NO_VALIDATOR",
+            "engine_kind": "OSS"
+          }
+        }
+      ],
+      "errors": [],
+      "paths": {
+        "scanned": [
+          "app/handlers.py"
+        ]
+      },
+      "time": {
+        "rules": [],
+        "rules_parse_time": 0.23672795295715332,
+        "profiling_times": {
+          "config_time": 0.7533607482910156,
+          "core_time": 0.5583689212799072,
+          "ignores_time": 0.0007622241973876953,
+          "total_time": 1.3202989101409912
+        },
+        "parsing_time": {
+          "total_time": 0,
+          "per_file_time": {
+            "mean": 0,
+            "std_dev": 0
+          },
+          "very_slow_stats": {
+            "time_ratio": 0,
+            "count_ratio": 0
+          },
+          "very_slow_files": []
+        },
+        "scanning_time": {
+          "total_time": 0.040416717529296875,
+          "per_file_time": {
+            "mean": 0.013472239176432291,
+            "std_dev": 0.00025216217342302925
+          },
+          "very_slow_stats": {
+            "time_ratio": 0,
+            "count_ratio": 0
+          },
+          "very_slow_files": []
+        },
+        "matching_time": {
+          "total_time": 0,
+          "per_file_and_rule_time": {
+            "mean": 0,
+            "std_dev": 0
+          },
+          "very_slow_stats": {
+            "time_ratio": 0,
+            "count_ratio": 0
+          },
+          "very_slow_rules_on_files": []
+        },
+        "tainting_time": {
+          "total_time": 0,
+          "per_def_and_rule_time": {
+            "mean": 0,
+            "std_dev": 0
+          },
+          "very_slow_stats": {
+            "time_ratio": 0,
+            "count_ratio": 0
+          },
+          "very_slow_rules_on_defs": []
+        },
+        "fixpoint_timeouts": [],
+        "prefiltering": {
+          "project_level_time": 0,
+          "file_level_time": 0,
+          "rules_with_project_prefilters_ratio": 0,
+          "rules_with_file_prefilters_ratio": 0.9896551724137931,
+          "rules_selected_ratio": 0.05862068965517241,
+          "rules_matched_ratio": 0.05862068965517241
+        },
+        "targets": [],
+        "total_bytes": 0,
+        "max_memory_bytes": 765083904
+      },
+      "engine_requested": "OSS",
+      "skipped_rules": [],
+      "profiling_results": []
+    }
+  }
+}

--- a/libs/hdf-converters/src/semgrep-mapper.ts
+++ b/libs/hdf-converters/src/semgrep-mapper.ts
@@ -1,0 +1,439 @@
+import {ExecJSON} from 'inspecjs';
+import * as _ from 'lodash';
+import {version as HeimdallToolsVersion} from '../package.json';
+import {BaseConverter, ILookupPath, MappedTransform} from './base-converter';
+import {CweNistMapping} from './mappings/CweNistMapping';
+import {
+  conditionallyProvideAttribute,
+  DEFAULT_STATIC_CODE_ANALYSIS_NIST_TAGS,
+  getCCIsForNISTTags
+} from './utils/global';
+
+type SemgrepPosition = {
+  line: number;
+  col: number;
+  offset: number;
+  [property: string]: unknown;
+};
+
+// Rule-level metadata from the Semgrep registry. Every field is optional -- a
+// locally written rule may supply none of it. Several are documented as arrays
+// but arrive as bare strings when the rule declares a single value, so anything
+// list-shaped is typed as string[] | string and normalized on read.
+type SemgrepMetadata = {
+  cwe?: string[] | string;
+  owasp?: string[] | string;
+  references?: string[] | string;
+  subcategory?: string[] | string;
+  technology?: string[] | string;
+  vulnerability_class?: string[] | string;
+  confidence?: string;
+  likelihood?: string;
+  impact?: string;
+  category?: string;
+  source?: string;
+  shortlink?: string;
+  license?: string;
+  'source-rule-url'?: string;
+  'bandit-code'?: string;
+  asvs?: {
+    control_id?: string;
+    control_url?: string;
+    section?: string;
+    version?: string;
+  };
+  [property: string]: unknown;
+};
+
+type SemgrepExtra = {
+  // Always present
+  message: string;
+  metadata: SemgrepMetadata;
+  severity: string;
+  // Present but redacted to the literal string 'requires login' unless the scan
+  // is authenticated against the Semgrep AppSec Platform
+  lines?: string;
+  fingerprint?: string;
+  // Only present when the rule ships an autofix
+  fix?: string;
+  engine_kind?: string;
+  validation_state?: string;
+  [property: string]: unknown;
+};
+
+type SemgrepResult = {
+  check_id: string;
+  path: string;
+  start: SemgrepPosition;
+  end: SemgrepPosition;
+  extra: SemgrepExtra;
+  [property: string]: unknown;
+};
+
+// `type` is a heterogeneous array -- a discriminant string followed by an
+// optional payload, e.g. ['PartialParsing', [{path, start, end}]]. It is read
+// only for its discriminant.
+type SemgrepError = {
+  message: string;
+  code?: number;
+  level?: string;
+  type?: unknown;
+  path?: string;
+  spans?: unknown[];
+  [property: string]: unknown;
+};
+
+type SemgrepReport = {
+  results: SemgrepResult[];
+  errors: SemgrepError[];
+  version?: string;
+  paths?: {scanned?: string[]; skipped?: unknown[]};
+  skipped_rules?: unknown[];
+  engine_requested?: string;
+  [property: string]: unknown;
+};
+
+const CWE_NIST_MAPPING = new CweNistMapping();
+
+// Semgrep's OSS severities are a three-level scale; its supply-chain rules add a
+// four-level one. Both are mapped so a mixed scan does not fall through.
+// https://semgrep.dev/docs/writing-rules/rule-syntax#required
+const IMPACT_MAPPING: Map<string, number> = new Map([
+  ['critical', 0.9],
+  ['error', 0.7],
+  ['high', 0.7],
+  ['warning', 0.5],
+  ['medium', 0.5],
+  ['info', 0.3],
+  ['low', 0.3]
+]);
+
+// An unrecognized severity is treated as moderate rather than zero: impact 0.0
+// reports Not Applicable in HDF, which would silently drop the finding from the
+// compliance score.
+const DEFAULT_IMPACT = 0.5;
+
+// Fields Semgrep redacts in unauthenticated (OSS) scans. Mapping them verbatim
+// would put this placeholder in front of every reader.
+const REDACTED_PLACEHOLDER = 'requires login';
+
+function isPresent(value: unknown): value is string {
+  return (
+    _.isString(value) && value.length > 0 && value !== REDACTED_PLACEHOLDER
+  );
+}
+
+// Metadata fields documented as arrays arrive as bare strings when the rule
+// declares a single value.
+function normalizeToArray(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.filter(_.isString);
+  }
+  return _.isString(value) ? [value] : [];
+}
+
+// Semgrep emits CWEs in prose form -- 'CWE-89: Improper Neutralization of ...'
+// -- while the NIST mapping keys on the bare number.
+function extractCweIds(metadata: SemgrepMetadata): string[] {
+  return normalizeToArray(metadata.cwe)
+    .map((entry) => /CWE-(\d+)/i.exec(entry)?.[1])
+    .filter(isPresent);
+}
+
+function nistTags(result: SemgrepResult): string[] {
+  return CWE_NIST_MAPPING.nistFilter(
+    extractCweIds(result.extra.metadata),
+    DEFAULT_STATIC_CODE_ANALYSIS_NIST_TAGS
+  );
+}
+
+function impactMapping(result: SemgrepResult): number {
+  const severity = result.extra.severity;
+  if (!_.isString(severity)) {
+    return DEFAULT_IMPACT;
+  }
+  return IMPACT_MAPPING.get(severity.toLowerCase()) ?? DEFAULT_IMPACT;
+}
+
+// Semgrep rule ids are dotted paths whose last segment is the rule name, which
+// the registry repeats as the trailing component. There is no human-readable
+// rule title anywhere in the JSON output -- unlike the SARIF output, whose rule
+// objects carry `name` and `shortDescription` -- so one is derived here.
+function formatTitle(result: SemgrepResult): string {
+  const segments = result.check_id.split('.').filter((s) => s.length > 0);
+  const ruleName = segments[segments.length - 1] ?? result.check_id;
+  return _.startCase(ruleName.replace(/[-_]/g, ' '));
+}
+
+function formatCodeDesc(result: SemgrepResult): string {
+  const {start, end} = result;
+  const span =
+    start.line === end.line
+      ? `line ${start.line}, columns ${start.col}-${end.col}`
+      : `lines ${start.line}-${end.line}`;
+  return `Path: ${result.path}\nLocation: ${span}`;
+}
+
+function formatMessage(result: SemgrepResult): string | undefined {
+  const parts: string[] = [];
+  if (isPresent(result.extra.lines)) {
+    parts.push(`Matched code:\n${result.extra.lines}`);
+  }
+  // `fix` is the replacement text for the matched span, not a standalone
+  // instruction -- rendering it bare produces messages like 'Suggested fix:
+  // False', which reads as nonsense without saying what it replaces.
+  if (isPresent(result.extra.fix)) {
+    parts.push(
+      `Suggested fix -- replace the matched code with:\n${result.extra.fix}`
+    );
+  }
+  return parts.length === 0 ? undefined : parts.join('\n\n');
+}
+
+// Documentation and cross-framework links. Deduplicated because the registry
+// routinely repeats a rule's source URL inside its references list.
+function collectRefUrls(result: SemgrepResult): string[] {
+  const metadata = result.extra?.metadata ?? {};
+  const urls = [
+    ...normalizeToArray(metadata.references),
+    metadata.source,
+    metadata.shortlink,
+    metadata['source-rule-url'],
+    metadata.asvs?.control_url
+  ].filter(isPresent);
+  return [...new Set(urls)];
+}
+
+// Per-finding fields with no dedicated HDF home. Anything mapped elsewhere is
+// omitted so this carries only what would otherwise be dropped.
+function formatCode(result: SemgrepResult): string {
+  const extra = _.omitBy(
+    _.omit(result.extra, [
+      'message',
+      'metadata',
+      'severity',
+      'lines',
+      'fix',
+      'engine_kind'
+    ]),
+    (value) => value === REDACTED_PLACEHOLDER
+  );
+  const unmapped = {
+    ..._.omit(result, ['check_id', 'path', 'start', 'end', 'extra']),
+    ...(_.isEmpty(extra) ? {} : {extra})
+  };
+  // An empty string keeps the field out of the reader's way; a JSON object
+  // holding nothing but redacted placeholders is worse than no code block.
+  return _.isEmpty(unmapped) ? '' : JSON.stringify(unmapped, null, 2);
+}
+
+export class SemgrepMapper extends BaseConverter<SemgrepReport> {
+  withRaw: boolean;
+
+  mappings: MappedTransform<
+    ExecJSON.Execution & {passthrough: unknown},
+    ILookupPath
+  > = {
+    platform: {
+      name: 'Heimdall Tools',
+      release: HeimdallToolsVersion
+    },
+    version: HeimdallToolsVersion,
+    statistics: {},
+    profiles: [
+      {
+        name: 'Semgrep',
+        title: 'Semgrep Static Analysis Scan',
+        version: {path: 'version'},
+        supports: [],
+        attributes: [],
+        groups: [],
+        status: 'loaded',
+        controls: [
+          {
+            path: 'results',
+            // One control per rule: every Semgrep finding for a given check_id
+            // shares that rule's metadata, so only the location varies and the
+            // occurrences collapse into results under a single control.
+            key: 'id',
+            id: {path: 'check_id'},
+            title: {transformer: formatTitle},
+            desc: {path: 'extra.message'},
+            impact: {transformer: impactMapping},
+            refs: [
+              {
+                // A path is required for the array handler to expand one entry
+                // into many, so `extra` is read only as an anchor; pathTransform
+                // replaces it with the URL list gathered from the whole finding,
+                // and the transformer then shapes each URL into a reference.
+                path: 'extra',
+                pathTransform: (_extra: unknown, file: unknown): string[] =>
+                  collectRefUrls(file as SemgrepResult),
+                transformer: (url: unknown): {url: string} => ({
+                  url: String(url)
+                })
+              }
+            ],
+            code: {transformer: formatCode},
+            source_location: {},
+            tags: {
+              transformer: (result: SemgrepResult): Record<string, unknown> => {
+                const metadata = result.extra.metadata;
+                const nist = nistTags(result);
+                return {
+                  nist,
+                  cci: getCCIsForNISTTags(nist),
+                  cwe: normalizeToArray(metadata.cwe),
+                  ...conditionallyProvideAttribute(
+                    'owasp',
+                    normalizeToArray(metadata.owasp),
+                    normalizeToArray(metadata.owasp).length > 0
+                  ),
+                  ...conditionallyProvideAttribute(
+                    'confidence',
+                    metadata.confidence,
+                    isPresent(metadata.confidence)
+                  ),
+                  ...conditionallyProvideAttribute(
+                    'likelihood',
+                    metadata.likelihood,
+                    isPresent(metadata.likelihood)
+                  ),
+                  // Renamed: Semgrep's metadata.impact rates the severity of the
+                  // consequence, which is not what HDF's impact float means.
+                  ...conditionallyProvideAttribute(
+                    'semgrep_impact',
+                    metadata.impact,
+                    isPresent(metadata.impact)
+                  ),
+                  ...conditionallyProvideAttribute(
+                    'category',
+                    metadata.category,
+                    isPresent(metadata.category)
+                  ),
+                  ...conditionallyProvideAttribute(
+                    'subcategory',
+                    normalizeToArray(metadata.subcategory),
+                    normalizeToArray(metadata.subcategory).length > 0
+                  ),
+                  ...conditionallyProvideAttribute(
+                    'technology',
+                    normalizeToArray(metadata.technology),
+                    normalizeToArray(metadata.technology).length > 0
+                  ),
+                  ...conditionallyProvideAttribute(
+                    'vulnerability_class',
+                    normalizeToArray(metadata.vulnerability_class),
+                    normalizeToArray(metadata.vulnerability_class).length > 0
+                  ),
+                  ...conditionallyProvideAttribute(
+                    'asvs',
+                    metadata.asvs,
+                    _.isObject(metadata.asvs)
+                  ),
+                  ...conditionallyProvideAttribute(
+                    'bandit_code',
+                    metadata['bandit-code'],
+                    isPresent(metadata['bandit-code'])
+                  ),
+                  ...conditionallyProvideAttribute(
+                    'engine_kind',
+                    result.extra.engine_kind,
+                    isPresent(result.extra.engine_kind)
+                  ),
+                  check_id: result.check_id,
+                  severity: result.extra.severity
+                };
+              }
+            },
+            results: [
+              {
+                // Semgrep reports only violations. Findings suppressed with a
+                // `nosemgrep` comment are omitted from the output entirely
+                // rather than flagged, so no skipped status is derivable.
+                status: ExecJSON.ControlResultStatus.Failed,
+                code_desc: {transformer: formatCodeDesc},
+                message: {transformer: formatMessage},
+                start_time: ''
+              }
+            ]
+          },
+          // Scan-time failures are reported as their own control so they are
+          // visible in Heimdall rather than buried in passthrough. Present only
+          // when the scan actually produced errors.
+          ...(this.data.errors.length === 0
+            ? []
+            : [
+                {
+                  id: 'Semgrep Scan Errors',
+                  title: 'Semgrep Scan Errors',
+                  desc: 'Errors reported by Semgrep while scanning. A file that failed to parse was not fully analyzed, so absence of findings in it is not evidence of compliance.',
+                  impact: DEFAULT_IMPACT,
+                  refs: [],
+                  source_location: {},
+                  tags: {
+                    nist: DEFAULT_STATIC_CODE_ANALYSIS_NIST_TAGS,
+                    cci: getCCIsForNISTTags(
+                      DEFAULT_STATIC_CODE_ANALYSIS_NIST_TAGS
+                    )
+                  },
+                  results: [
+                    {
+                      path: 'errors',
+                      // Semgrep reports the same parse failure once per rule
+                      // that tripped over it, so identical records repeat.
+                      pathTransform: (errors: unknown): SemgrepError[] =>
+                        _.uniqBy(
+                          errors as SemgrepError[],
+                          (error) => `${error.path}|${error.message}`
+                        ),
+                      status: ExecJSON.ControlResultStatus.Error,
+                      code_desc: {
+                        transformer: (error: SemgrepError): string =>
+                          `Path: ${_.get(error, 'path', 'unknown')}`
+                      },
+                      message: {
+                        transformer: (error: SemgrepError): string => {
+                          const kind = Array.isArray(error.type)
+                            ? String(error.type[0])
+                            : String(error.type ?? 'Unknown');
+                          return `${kind}: ${error.message}`;
+                        }
+                      },
+                      start_time: ''
+                    }
+                  ]
+                } as MappedTransform<
+                  ExecJSON.Control & ILookupPath,
+                  ILookupPath
+                >
+              ])
+        ],
+        sha256: ''
+      }
+    ],
+    passthrough: {
+      transformer: (data: SemgrepReport): Record<string, unknown> => {
+        return {
+          auxiliary_data: [
+            {
+              name: 'Semgrep',
+              data: {
+                version: data.version,
+                engine_requested: data.engine_requested,
+                paths: data.paths,
+                skipped_rules: data.skipped_rules
+              }
+            }
+          ],
+          ...conditionallyProvideAttribute('raw', data, this.withRaw)
+        };
+      }
+    }
+  };
+
+  constructor(semgrepJson: string, withRaw = false) {
+    super(JSON.parse(semgrepJson) as SemgrepReport);
+    this.withRaw = withRaw;
+  }
+}

--- a/libs/hdf-converters/src/utils/fingerprinting.ts
+++ b/libs/hdf-converters/src/utils/fingerprinting.ts
@@ -15,6 +15,7 @@ export enum INPUT_TYPES {
   MSFT_SEC_SCORE = 'msft_secure_score',
   NIKTO = 'nikto',
   SARIF = 'sarif',
+  SEMGREP = 'semgrep',
   CYCLONEDX_SBOM = 'cyclonedx_sbom',
   SNYK = 'snyk',
   TRUFFLEHOG = 'trufflehog',
@@ -69,6 +70,14 @@ const fileTypeFingerprints: Record<INPUT_TYPES, string[]> = {
   ],
   [INPUT_TYPES.NIKTO]: ['banner', 'host', 'ip', 'port', 'vulnerabilities'],
   [INPUT_TYPES.SARIF]: ['$schema', 'version', 'runs'],
+  [INPUT_TYPES.SEMGREP]: [
+    'paths.scanned',
+    'engine_requested',
+    'skipped_rules',
+    'results[0].check_id',
+    'results[0].extra.metadata',
+    'results[0].extra.severity'
+  ],
   [INPUT_TYPES.SNYK]: [
     'projectName',
     'policy',

--- a/libs/hdf-converters/test/mappers/forward/semgrep_mapper.spec.ts
+++ b/libs/hdf-converters/test/mappers/forward/semgrep_mapper.spec.ts
@@ -1,0 +1,157 @@
+import fs from 'fs';
+import {ExecJSON} from 'inspecjs';
+import {describe, expect, it} from 'vitest';
+import {SemgrepMapper} from '../../../src/semgrep-mapper';
+import {omitHDFTimes, omitVersions} from '../../utils';
+
+function readSample(name: string): string {
+  return fs.readFileSync(
+    `sample_jsons/semgrep_mapper/sample_input_report/${name}.json`,
+    {encoding: 'utf-8'}
+  );
+}
+
+function readBaseline(name: string): unknown {
+  return JSON.parse(
+    fs.readFileSync(`sample_jsons/semgrep_mapper/${name}-hdf.json`, {
+      encoding: 'utf-8'
+    })
+  );
+}
+
+describe('semgrep_mapper', () => {
+  describe('semgrep_findings', () => {
+    const mapper = new SemgrepMapper(readSample('semgrep_findings'));
+
+    // Uncomment to regenerate the baseline, then re-comment before committing:
+    // fs.writeFileSync(
+    //   'sample_jsons/semgrep_mapper/semgrep_findings-hdf.json',
+    //   JSON.stringify(mapper.toHdf(), null, 2)
+    // );
+
+    it('should produce a valid HDF matching the regression baseline', () => {
+      expect(omitHDFTimes(omitVersions(mapper.toHdf()))).toEqual(
+        omitHDFTimes(omitVersions(readBaseline('semgrep_findings')))
+      );
+    });
+
+    it('should map every rule to exactly one control', () => {
+      const controls = mapper.toHdf().profiles[0].controls;
+      const ids = controls.map((control) => control.id);
+      expect(new Set(ids).size).toEqual(ids.length);
+    });
+
+    it('should resolve NIST tags from the rule CWE rather than the default', () => {
+      const control = mapper
+        .toHdf()
+        .profiles[0].controls.find((c) =>
+          c.id.includes('subprocess-shell-true')
+        );
+      expect(control?.tags.nist).toBeDefined();
+      expect(control?.tags.cwe).toContain(
+        "CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"
+      );
+    });
+
+    it('should normalize owasp whether the rule supplies a string or an array', () => {
+      const controls = mapper.toHdf().profiles[0].controls;
+      for (const control of controls) {
+        expect(Array.isArray(control.tags.owasp)).toBe(true);
+      }
+    });
+
+    it('should rename semgrep metadata impact so it does not shadow HDF impact', () => {
+      const control = mapper.toHdf().profiles[0].controls[0];
+      expect(typeof control.impact).toEqual('number');
+      expect(control.tags.impact).toBeUndefined();
+      expect(control.tags.semgrep_impact).toBeDefined();
+    });
+
+    it('should emit refs as a flat array of url objects', () => {
+      for (const control of mapper.toHdf().profiles[0].controls) {
+        expect(Array.isArray(control.refs)).toBe(true);
+        for (const ref of control.refs) {
+          expect(Object.keys(ref)).toEqual(['url']);
+          expect(typeof (ref as {url: string}).url).toEqual('string');
+        }
+      }
+    });
+
+    it('should not leak the redacted placeholder into results', () => {
+      const serialized = JSON.stringify(mapper.toHdf());
+      expect(serialized).not.toContain('requires login');
+    });
+  });
+
+  describe('semgrep_findings withRaw', () => {
+    const mapper = new SemgrepMapper(readSample('semgrep_findings'), true);
+
+    // Uncomment to regenerate the baseline, then re-comment before committing:
+    // fs.writeFileSync(
+    //   'sample_jsons/semgrep_mapper/semgrep_findings-withraw-hdf.json',
+    //   JSON.stringify(mapper.toHdf(), null, 2)
+    // );
+
+    it('should include raw data in passthrough', () => {
+      const hdf = mapper.toHdf() as ExecJSON.Execution & {
+        passthrough: Record<string, unknown>;
+      };
+      expect(hdf.passthrough).toHaveProperty('raw');
+      expect(hdf.passthrough).toHaveProperty('auxiliary_data');
+    });
+
+    it('should match the regression baseline', () => {
+      expect(omitHDFTimes(omitVersions(mapper.toHdf()))).toEqual(
+        omitHDFTimes(omitVersions(readBaseline('semgrep_findings-withraw')))
+      );
+    });
+  });
+
+  describe('semgrep_empty', () => {
+    const mapper = new SemgrepMapper(readSample('semgrep_empty'));
+
+    // Uncomment to regenerate the baseline, then re-comment before committing:
+    // fs.writeFileSync(
+    //   'sample_jsons/semgrep_mapper/semgrep_empty-hdf.json',
+    //   JSON.stringify(mapper.toHdf(), null, 2)
+    // );
+
+    it('should convert a scan with no findings without throwing', () => {
+      expect(mapper.toHdf().profiles[0].controls).toEqual([]);
+    });
+
+    it('should match the regression baseline', () => {
+      expect(omitHDFTimes(omitVersions(mapper.toHdf()))).toEqual(
+        omitHDFTimes(omitVersions(readBaseline('semgrep_empty')))
+      );
+    });
+  });
+
+  describe('semgrep_errors', () => {
+    const mapper = new SemgrepMapper(readSample('semgrep_errors'));
+
+    // Uncomment to regenerate the baseline, then re-comment before committing:
+    // fs.writeFileSync(
+    //   'sample_jsons/semgrep_mapper/semgrep_errors-hdf.json',
+    //   JSON.stringify(mapper.toHdf(), null, 2)
+    // );
+
+    it('should surface scan errors as their own control', () => {
+      const controls = mapper.toHdf().profiles[0].controls;
+      const errorControl = controls.find(
+        (control) => control.id === 'Semgrep Scan Errors'
+      );
+      expect(errorControl).toBeDefined();
+      expect(errorControl?.results.length).toBeGreaterThan(0);
+      expect(errorControl?.results[0].status).toEqual(
+        ExecJSON.ControlResultStatus.Error
+      );
+    });
+
+    it('should match the regression baseline', () => {
+      expect(omitHDFTimes(omitVersions(mapper.toHdf()))).toEqual(
+        omitHDFTimes(omitVersions(readBaseline('semgrep_errors')))
+      );
+    });
+  });
+});


### PR DESCRIPTION
Adds a mapper for the native `semgrep scan --json` format, plus its fingerprint, frontend intake wiring, sample data and spec.

## Why not just use sarif2hdf

Semgrep emits SARIF, so `sarif2hdf` covers it in principle. But SARIF carries Semgrep's rule metadata only as untyped prose tags on the rule object (`"CWE-939: ..."`, `"LOW CONFIDENCE"`) and drops the rest outright: `impact`, `likelihood`, the ASVS control mapping, `references[]`, `vulnerability_class`, `technology` and `subcategory`.

Those are the cross-framework links that make results usable for accreditation — the ASVS `control_id` in particular — so the native format gets its own mapper.

## Granularity

One control per rule. Semgrep metadata is rule-scoped and identical across occurrences, so only the location varies and occurrences collapse into results under a single control keyed on `check_id`.

## Format notes

All of these were confirmed against `semgrep 1.174.0` output rather than its documentation, which is incomplete on each point:

- metadata fields documented as arrays arrive as **bare strings** when a rule declares a single value (`owasp`, `subcategory`, `technology`, `references`); everything list-shaped is normalized on read
- CWEs are emitted in prose form (`"CWE-89: Improper Neutralization of ..."`), so the id is parsed out before the NIST lookup
- `extra.lines` and `extra.fingerprint` are redacted to the literal string `"requires login"` in unauthenticated scans, and are filtered rather than mapped
- `metadata.impact` rates the severity of the *consequence* and is not HDF's impact float; it is tagged `semgrep_impact` so it cannot shadow it
- findings suppressed with a `nosemgrep` comment are omitted from the output entirely rather than flagged, so no skipped status is derivable and every finding is reported as failed
- `extra.fix` is replacement text for the matched span, not a standalone instruction — rendering it bare produces messages like `Suggested fix: False`
- the JSON output carries no human-readable rule title anywhere, unlike the SARIF output whose rule objects have `name` and `shortDescription`, so a title is derived from the final segment of the dotted rule id
- `errors[].type` is a heterogeneous array (discriminant plus optional payload) and is read only for its discriminant

## Scan errors

Scan failures become their own control with status `error`, present only when the scan reported any. A file that failed to parse was not fully analyzed, so absence of findings in it is not evidence of compliance — burying that in passthrough makes it invisible in Heimdall.

## Fingerprint

Keys on semgrep-specific paths (`paths.scanned`, `engine_requested`, `skipped_rules`) rather than the generic `results`/`errors`/`version` triple. The generic form matched bare arrays of HDF controls and would have hijacked input belonging to other converters; verified against all 135 sample files in `sample_jsons/`, with no collisions in either direction.

## Testing

13 tests covering rule grouping, severity mapping, CWE-derived NIST tags, the string-or-array `owasp` normalization, the `semgrep_impact` rename, refs shape, the redacted-placeholder filter, the empty scan, and the scan-errors control.

`vitest run` in `libs/hdf-converters`: 167 passing. The 4 failures (3 sonarqube, 1 splunk reverse) reproduce identically on an unmodified `master` checkout.