### PR TITLE
fix(hdf-converters): map Twistlock's distro-vendor pass-through severities

### DIFF
--- a/libs/hdf-converters/sample_jsons/twistlock_mapper/sample_input_report/twistlock-twistcli-vendor-severities-sample.json
+++ b/libs/hdf-converters/sample_jsons/twistlock_mapper/sample_input_report/twistlock-twistcli-vendor-severities-sample.json
@@ -1,0 +1,211 @@
+{
+  "results": [
+    {
+      "id": "sha256:b1c0237ebd29860066656372da10d8d7da33b34715986f74b3d5a7e4ba060d1b",
+      "name": "registry.io/test:1a7a431a105aa04632f5f5fbe8f753bd245add0a",
+      "distro": "Red Hat Enterprise Linux release 8.6 (Ootpa)",
+      "distroRelease": "RHEL8",
+      "digest": "sha256:c0274cb1e0c6e92d2ccc1e23bd19b7dddedbaa2da26861c225d4ad6cec5047f4",
+      "collections": [
+        "All",
+        "TEST-COLLECTION"
+      ],
+      "packages": [
+        {
+          "type": "os",
+          "name": "expat",
+          "version": "2.2.5-8.el8",
+          "licenses": [
+            "MIT"
+          ]
+        },
+        {
+          "type": "os",
+          "name": "nss-util",
+          "version": "3.67.0-7.el8_5",
+          "licenses": [
+            "MPLv2.0"
+          ]
+        },
+        {
+          "type": "os",
+          "name": "dotnet-host",
+          "version": "6.0.5-1.el8_6",
+          "licenses": [
+            "MIT and ASL 2.0 and BSD and LGPLv2+ and CC-BY and CC0 and MS-PL and EPL-1.0 and GPL+ and GPLv2 and ISC and OFL and zlib"
+          ]
+        }
+      ],
+      "applications": [
+        {
+          "name": "asp.net-core",
+          "version": "5.0.17",
+          "path": "/usr/lib64/dotnet/dotnet"
+        },
+        {
+          "name": ".net-core",
+          "version": "5.0.17",
+          "path": "/usr/lib64/dotnet/dotnet"
+        }
+      ],
+      "complianceDistribution": {
+        "critical": 0,
+        "high": 0,
+        "medium": 0,
+        "low": 0,
+        "total": 0
+      },
+      "complianceScanPassed": true,
+      "vulnerabilities": [
+        {
+          "id": "CVE-2021-43529",
+          "status": "affected",
+          "cvss": 9.8,
+          "description": "DOCUMENTATION: A remote code execution flaw was found in the way NSS verifies certificates. This flaw allows an attacker posing as an SSL/TLS server to trigger this issue in a client application compiled with NSS when it tries to initiate an SSL/TLS connection.  Similarly, a server application compiled with NSS, which processes client certificates, can receive a malicious certificate via a client, triggering the flaw. The highest threat to this vulnerability is confidentiality, integrity, as well as system availability.              STATEMENT: The issue is not limited to TLS. Any applications that use NSS certificate verification are vulnerable; S/MIME is impacted as well.  Similarly, a server application compiled with NSS, which processes client certificates, can receive a malicious certificate via a client.  Firefox is not vulnerable to this flaw as it uses the mozilla::pkix for certificate verification. Thunderbird is affected when parsing email with the S/MIME signature.  Thunderbird on Red Hat Enterprise Linux 8.4 and later does not need to be updated since it uses the system NSS library, but earlier Red Hat Enterprise Linux 8 extended life streams will need to update Thunderbird as well as NSS.             MITIGATION: Red Hat has investigated whether a possible mitigation exists for this issue, and has not been able to identify a practical example. Please update the affec",
+          "severity": "critical",
+          "packageName": "nss-util",
+          "packageVersion": "3.67.0-7.el8_5",
+          "link": "https://access.redhat.com/security/cve/CVE-2021-43529",
+          "riskFactors": [
+            "Remote execution",
+            "Attack complexity: low",
+            "Attack vector: network",
+            "Critical severity",
+            "Recent vulnerability"
+          ],
+          "impactedVersions": [
+            "*"
+          ],
+          "publishedDate": "2021-12-01T00:00:00Z",
+          "discoveredDate": "2022-05-18T12:24:22Z",
+          "layerTime": "2022-05-16T23:12:25Z"
+        },
+        {
+          "id": "CVE-2022-1650",
+          "status": "under investigation",
+          "cvss": 8.1,
+          "description": "Exposure of Sensitive Information to an Unauthorized Actor in GitHub repository eventsource/eventsource prior to v2.0.2.",
+          "severity": "unassigned",
+          "packageName": "dotnet-host",
+          "packageVersion": "6.0.5-1.el8_6",
+          "link": "https://access.redhat.com/security/cve/CVE-2022-1650",
+          "riskFactors": [
+            "Attack complexity: low",
+            "Attack vector: network",
+            "High severity",
+            "Recent vulnerability"
+          ],
+          "impactedVersions": [
+            "*"
+          ],
+          "publishedDate": "2022-05-12T11:15:00Z",
+          "discoveredDate": "2022-05-18T12:24:22Z",
+          "layerTime": "2022-05-16T23:46:22Z"
+        },
+        {
+          "id": "CVE-2022-22824",
+          "status": "affected",
+          "cvss": 9.8,
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "description": "defineAttribute in xmlparse.c in Expat (aka libexpat) before 2.4.3 has an integer overflow.",
+          "severity": "unimportant",
+          "packageName": "expat",
+          "packageVersion": "2.2.5-8.el8",
+          "link": "https://access.redhat.com/security/cve/CVE-2022-22824",
+          "riskFactors": [
+            "Medium severity",
+            "Recent vulnerability",
+            "Attack complexity: low",
+            "Attack vector: network"
+          ],
+          "impactedVersions": [
+            "*"
+          ],
+          "publishedDate": "2022-01-10T14:12:00Z",
+          "discoveredDate": "2022-05-18T12:24:22Z",
+          "layerTime": "2022-05-03T08:38:31Z"
+        },
+        {
+          "id": "CVE-2022-22823",
+          "status": "affected",
+          "cvss": 9.8,
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "description": "build_model in xmlparse.c in Expat (aka libexpat) before 2.4.3 has an integer overflow.",
+          "severity": "negligible",
+          "packageName": "expat",
+          "packageVersion": "2.2.5-8.el8",
+          "link": "https://access.redhat.com/security/cve/CVE-2022-22823",
+          "riskFactors": [
+            "Attack vector: network",
+            "Medium severity",
+            "Recent vulnerability",
+            "Attack complexity: low"
+          ],
+          "impactedVersions": [
+            "*"
+          ],
+          "publishedDate": "2022-01-10T14:12:00Z",
+          "discoveredDate": "2022-05-18T12:24:22Z",
+          "layerTime": "2022-05-03T08:38:31Z"
+        },
+        {
+          "id": "CVE-2022-22822",
+          "status": "affected",
+          "cvss": 9.8,
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "description": "addBinding in xmlparse.c in Expat (aka libexpat) before 2.4.3 has an integer overflow.",
+          "severity": "untriaged",
+          "packageName": "expat",
+          "packageVersion": "2.2.5-8.el8",
+          "link": "https://access.redhat.com/security/cve/CVE-2022-22822",
+          "riskFactors": [
+            "Medium severity",
+            "Recent vulnerability",
+            "Attack complexity: low",
+            "Attack vector: network"
+          ],
+          "impactedVersions": [
+            "*"
+          ],
+          "publishedDate": "2022-01-10T14:12:00Z",
+          "discoveredDate": "2022-05-18T12:24:22Z",
+          "layerTime": "2022-05-03T08:38:31Z"
+        },
+        {
+          "id": "CVE-2022-22827",
+          "status": "affected",
+          "cvss": 8.8,
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+          "description": "storeAtts in xmlparse.c in Expat (aka libexpat) before 2.4.3 has an integer overflow.",
+          "severity": "not yet assigned",
+          "packageName": "expat",
+          "packageVersion": "2.2.5-8.el8",
+          "link": "https://access.redhat.com/security/cve/CVE-2022-22827",
+          "riskFactors": [
+            "Attack complexity: low",
+            "Attack vector: network",
+            "Medium severity",
+            "Recent vulnerability"
+          ],
+          "impactedVersions": [
+            "*"
+          ],
+          "publishedDate": "2022-01-10T14:12:00Z",
+          "discoveredDate": "2022-05-18T12:24:22Z",
+          "layerTime": "2022-05-03T08:38:31Z"
+        }
+      ],
+      "vulnerabilityDistribution": {
+        "critical": 1,
+        "high": 0,
+        "medium": 0,
+        "low": 0,
+        "total": 6
+      },
+      "vulnerabilityScanPassed": true,
+      "scanTime": "2022-05-18T12:24:32.855444532Z",
+      "scanID": "6284e580d9600f8d0db159e2"
+    }
+  ],
+  "consoleURL": "https://twistlock.test.net/#!/monitor/vulnerabilities/images/ci?search=sha256%3Ab1c0237ebd29860066656372da10d8d7da33b34715986f74b3d5a7e4ba060d1b"
+}

--- a/libs/hdf-converters/src/twistlock-mapper.ts
+++ b/libs/hdf-converters/src/twistlock-mapper.ts
@@ -12,13 +12,30 @@ import {
   getCCIsForNISTTags
 } from './utils/global';
 
+// For OS-vendor-maintained packages Prisma Cloud passes through the vendor's
+// severity string verbatim instead of NVD's, so distro vocabulary reaches the
+// report alongside Prisma's own tiers (mitre/heimdall2#8611; see the vendor
+// table in Prisma's CVSS-scoring doc). The no-rating values — 'unassigned',
+// 'not yet assigned', and Ubuntu's 'untriaged' — take the conservative
+// medium, matching dependency-track's 'unassigned' and grype's 'unknown'.
+// 'negligible' (Ubuntu: "technically a security problem" but theoretical/no
+// real damage) and 'unimportant' (Debian: the problem does not affect the
+// shipped binary package — Prisma ranks it even below negligible) are the
+// minimal ratings: 0.1 rather than 0.0 because the 0.0 tier is reserved for
+// informational non-findings across this codebase, and impact 0 exports as
+// Not_Applicable in checklists, hiding a finding the scanner reported.
 const IMPACT_MAPPING: Map<string, number> = new Map([
   ['critical', 0.9],
   ['important', 0.9],
   ['high', 0.7],
   ['medium', 0.5],
   ['moderate', 0.5],
-  ['low', 0.3]
+  ['unassigned', 0.5],
+  ['not yet assigned', 0.5],
+  ['untriaged', 0.5],
+  ['low', 0.3],
+  ['unimportant', 0.1],
+  ['negligible', 0.1]
 ]);
 
 export class TwistlockResults {

--- a/libs/hdf-converters/test/mappers/forward/twistlock_mapper.spec.ts
+++ b/libs/hdf-converters/test/mappers/forward/twistlock_mapper.spec.ts
@@ -1,7 +1,36 @@
 import fs from 'fs';
-import {describe, expect, it} from 'vitest';
+import {afterEach, describe, expect, it, vi} from 'vitest';
 import {TwistlockResults} from '../../../src/twistlock-mapper';
 import {omitVersions} from '../../utils';
+
+// Sequential: these tests spy on the shared console (vitest.config.ts runs
+// tests concurrently by default), see issue #8611 for the severity values.
+describe.sequential('twistlock_mapper_severity_mapping', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('maps the distro-vendor pass-through severities without warnings', () => {
+    const warn = vi.spyOn(console, 'warn').mockReturnValue();
+    const mapper = new TwistlockResults(
+      fs.readFileSync(
+        'sample_jsons/twistlock_mapper/sample_input_report/twistlock-twistcli-vendor-severities-sample.json',
+        {encoding: 'utf-8'}
+      )
+    );
+    const impacts = Object.fromEntries(
+      mapper.toHdf().profiles[0].controls.map((c) => [c.id, c.impact])
+    );
+    expect(impacts['CVE-2022-1650']).toBe(0.5); // unassigned
+    expect(impacts['CVE-2022-22824']).toBe(0.1); // unimportant
+    expect(impacts['CVE-2022-22823']).toBe(0.1); // negligible
+    expect(impacts['CVE-2022-22822']).toBe(0.5); // untriaged (Ubuntu)
+    expect(impacts['CVE-2022-22827']).toBe(0.5); // not yet assigned
+    expect(impacts['CVE-2021-43529']).toBe(0.9); // critical (control case)
+    // No warnings: proves 'unassigned' is mapped to 0.5, not defaulted to it
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
 
 describe('twistlock_mapper', () => {
   it('Successfully converts Twistlock docker image scan targeted at a local/cloned repository data', () => {


### PR DESCRIPTION
For OS-vendor-maintained packages Twistlock/Prisma Cloud reports the vendor's own severity string instead of NVD's, so distro vocabulary reaches the scan report. Closest doc available describing the possible severity levels one can see in the source format is the [vendor table in Prisma's CVSS-scoring doc](https://docs.prismacloud.io/admin-guide/vulnerability-management/cvss-scoring).

So for severity level mappings into OHDF, we're going to go with:
- unassigned / not yet assigned / untriaged -> 0.5 (on the theory that we usually bucket "unknown" severity levels as "average" to split the difference)
- unimportant / negligible -> 0.1 (the lowest ratings that aren't 0.0, which we usually take to mean "N/A")

Adds a (synthetic) fixture carrying all five severities plus a mapped control case, with targeted impact assertions. I am following up with the folks who brought #8611 to our attention to see if we can get a copy of the Twistlock scan that triggered the original error so that we can confirm it works with that one.



With #8610's warn-and-default fix this closes the Twistlock half of the severity data-loss report in #8611.